### PR TITLE
feat: add database verification script

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@types/node": "^20.19.39",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "dotenv": "^17.4.2",
     "eslint": "^9",
     "eslint-config-next": "16.2.3",
     "eslint-config-prettier": "^10.1.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,6 +63,9 @@ importers:
       '@types/react-dom':
         specifier: ^19
         version: 19.2.3(@types/react@19.2.14)
+      dotenv:
+        specifier: ^17.4.2
+        version: 17.4.2
       eslint:
         specifier: ^9
         version: 9.39.4(jiti@2.6.1)
@@ -1397,6 +1400,10 @@ packages:
   doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
     engines: {node: '>=0.10.0'}
+
+  dotenv@17.4.2:
+    resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
+    engines: {node: '>=12'}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -4383,6 +4390,8 @@ snapshots:
   doctrine@2.1.0:
     dependencies:
       esutils: 2.0.3
+
+  dotenv@17.4.2: {}
 
   dunder-proto@1.0.1:
     dependencies:

--- a/scripts/test-database.ts
+++ b/scripts/test-database.ts
@@ -1,0 +1,73 @@
+import { createClient } from '@supabase/supabase-js'
+import * as dotenv from 'dotenv'
+import * as path from 'path'
+
+dotenv.config({ path: path.resolve(process.cwd(), '.env.local') })
+
+const url = process.env.NEXT_PUBLIC_INSFORGE_URL
+const key = process.env.INSFORGE_API_KEY
+
+if (!url || !key) {
+  console.error('Missing NEXT_PUBLIC_INSFORGE_URL or INSFORGE_API_KEY')
+  process.exit(1)
+}
+
+const insforge = createClient(url, key, { auth: { persistSession: false } })
+
+async function testTable(name: string) {
+  const { error, count } = await insforge
+    .from(name)
+    .select('*', { count: 'exact', head: true })
+
+  if (error) {
+    console.error(`  ❌ ${name}: ${error.message}`)
+    return false
+  }
+
+  console.log(`  ✅ ${name}: accessible (${count ?? 0} rows)`)
+  return true
+}
+
+async function main() {
+  console.log('🔍 Testing database tables...\n')
+
+  const tables = [
+    'whitelist',
+    'users',
+    'categories',
+    'transactions',
+    'budgets',
+    'exchange_rates',
+  ]
+
+  let allPassed = true
+  for (const table of tables) {
+    const ok = await testTable(table)
+    if (!ok) allPassed = false
+  }
+
+  console.log('\n📊 Checking seed data...')
+
+  const { data: whitelist } = await insforge.from('whitelist').select('email')
+  console.log(
+    `  whitelist emails: ${whitelist?.map((w) => w.email).join(', ') || 'none'}`
+  )
+
+  const { data: categories, count: catCount } = await insforge
+    .from('categories')
+    .select('*', { count: 'exact' })
+  console.log(`  predefined categories: ${catCount ?? 0}`)
+  if (categories?.length) {
+    const incomeCount = categories.filter((c) => c.type === 'income').length
+    const expenseCount = categories.filter((c) => c.type === 'expense').length
+    console.log(`    - income: ${incomeCount}, expense: ${expenseCount}`)
+  }
+
+  console.log(`\n${allPassed ? '✅ All tables accessible' : '❌ Some tables failed'}`)
+  process.exit(allPassed ? 0 : 1)
+}
+
+main().catch((err) => {
+  console.error('Unexpected error:', err)
+  process.exit(1)
+})


### PR DESCRIPTION
Closes #44

## Changes
- Add `scripts/test-database.ts` to verify all 6 database tables are accessible
- Add `dotenv` as dev dependency for loading `.env.local` in scripts
- All tables verified: whitelist, users, categories, transactions, budgets, exchange_rates