### PR TITLE
feat: create Zod validation schemas

### DIFF
--- a/lib/validations/budget.ts
+++ b/lib/validations/budget.ts
@@ -1,0 +1,11 @@
+import * as z from 'zod'
+
+export const createBudgetSchema = z.object({
+  category_id: z.string().uuid(),
+  amount: z.number().positive(),
+  currency: z.enum(['COP', 'USD', 'BOB']),
+  period: z.enum(['monthly', 'yearly']),
+  start_date: z.string(),
+})
+
+export type CreateBudgetInput = z.infer<typeof createBudgetSchema>

--- a/lib/validations/category.ts
+++ b/lib/validations/category.ts
@@ -1,0 +1,10 @@
+import * as z from 'zod'
+
+export const createCategorySchema = z.object({
+  name: z.string().min(1, 'Name is required'),
+  type: z.enum(['income', 'expense']),
+  icon: z.string().optional(),
+  color: z.string().optional(),
+})
+
+export type CreateCategoryInput = z.infer<typeof createCategorySchema>

--- a/lib/validations/transaction.ts
+++ b/lib/validations/transaction.ts
@@ -1,0 +1,16 @@
+import * as z from 'zod'
+
+export const createTransactionSchema = z.object({
+  amount: z.number().positive('Amount must be positive'),
+  currency: z.enum(['COP', 'USD', 'BOB']),
+  type: z.enum(['income', 'expense']),
+  category_id: z.string().uuid(),
+  description: z.string().min(1, 'Description is required'),
+  date: z.string(),
+  notes: z.string().optional(),
+})
+
+export const updateTransactionSchema = createTransactionSchema.partial()
+
+export type CreateTransactionInput = z.infer<typeof createTransactionSchema>
+export type UpdateTransactionInput = z.infer<typeof updateTransactionSchema>


### PR DESCRIPTION
## Cambios
- Creado schema de validación para transacciones con Zod v4
- Creado schema de validación para categorías
- Creado schema de validación para presupuestos
- Exportados tipos TypeScript inferidos

## Testing
- ✅ Sin errores TypeScript

Closes #48
Related to #47