### PR TITLE
feat: configure Chakra UI v3 provider and custom theme

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next'
 import { Geist, Geist_Mono } from 'next/font/google'
 import './globals.css'
 import { SessionProvider } from '@/components/providers/SessionProvider'
+import { ChakraProvider } from '@/components/providers/ChakraProvider'
 
 const geistSans = Geist({
   variable: '--font-geist-sans',
@@ -29,7 +30,9 @@ export default function RootLayout({
       className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}
     >
       <body className="min-h-full flex flex-col">
-        <SessionProvider>{children}</SessionProvider>
+        <SessionProvider>
+          <ChakraProvider>{children}</ChakraProvider>
+        </SessionProvider>
       </body>
     </html>
   )

--- a/components/providers/ChakraProvider.tsx
+++ b/components/providers/ChakraProvider.tsx
@@ -1,0 +1,9 @@
+'use client'
+
+import { ChakraProvider as ChakraUIProvider } from '@chakra-ui/react'
+import { system } from '@/theme'
+import { ReactNode } from 'react'
+
+export function ChakraProvider({ children }: { children: ReactNode }) {
+  return <ChakraUIProvider value={system}>{children}</ChakraUIProvider>
+}

--- a/theme/index.ts
+++ b/theme/index.ts
@@ -1,0 +1,43 @@
+import { createSystem, defaultConfig, defineConfig } from '@chakra-ui/react'
+
+const config = defineConfig({
+  theme: {
+    tokens: {
+      colors: {
+        brand: {
+          50: { value: '#E6F6FF' },
+          100: { value: '#BAE3FF' },
+          200: { value: '#7CC4FA' },
+          300: { value: '#47A3F3' },
+          400: { value: '#2186EB' },
+          500: { value: '#0967D2' },
+          600: { value: '#0552B5' },
+          700: { value: '#03449E' },
+          800: { value: '#01337D' },
+          900: { value: '#002159' },
+        },
+        income: {
+          50: { value: '#E6FAF5' },
+          500: { value: '#2ECC71' },
+          600: { value: '#27AE60' },
+        },
+        expense: {
+          50: { value: '#FFE6E6' },
+          500: { value: '#E74C3C' },
+          600: { value: '#C0392B' },
+        },
+      },
+      fonts: {
+        heading: { value: 'var(--font-geist-sans), sans-serif' },
+        body: { value: 'var(--font-geist-sans), sans-serif' },
+      },
+    },
+    semanticTokens: {
+      colors: {
+        'bg.canvas': { value: '{colors.gray.50}' },
+      },
+    },
+  },
+})
+
+export const system = createSystem(defaultConfig, config)


### PR DESCRIPTION
## Cambios
- Creado theme/index.ts con createSystem + defineConfig (Chakra v3)
- Colores brand, income, expense configurados
- Creado ChakraProvider wrapper para app/layout.tsx
- Actualizado app/layout.tsx para envolver con ChakraProvider

## Nota
Adaptado a Chakra UI v3 (el plan usaba API v2 con extendTheme).

## Testing
- ✅ Sin errores TypeScript

Closes #64
Related to #63