### PR TITLE
feat: add month selector to dashboard

### DIFF
--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -1,11 +1,8 @@
-import { Box, Heading, VStack } from '@chakra-ui/react'
 import { getServerSession } from 'next-auth'
 import { authOptions } from '@/lib/auth'
 import { redirect } from 'next/navigation'
 import { insforge } from '@/lib/insforge'
-import { FinancialCards } from '@/components/dashboard/FinancialCards'
-import { MonthlyTrendChart } from '@/components/dashboard/MonthlyTrendChart'
-import { RecentTransactions } from '@/components/dashboard/RecentTransactions'
+import { DashboardContent } from '@/components/dashboard/DashboardContent'
 
 export default async function DashboardPage() {
   const session = await getServerSession(authOptions)
@@ -25,17 +22,5 @@ export default async function DashboardPage() {
     redirect('/login')
   }
 
-  return (
-    <Box>
-      <Heading mb={8}>Dashboard</Heading>
-
-      <VStack gap={8} align="stretch">
-        <FinancialCards userId={user.id} />
-
-        <MonthlyTrendChart userId={user.id} />
-
-        <RecentTransactions userId={user.id} limit={10} />
-      </VStack>
-    </Box>
-  )
+  return <DashboardContent userId={user.id} />
 }

--- a/components/dashboard/DashboardContent.tsx
+++ b/components/dashboard/DashboardContent.tsx
@@ -1,0 +1,34 @@
+'use client'
+
+import { useState } from 'react'
+import { Box, Heading, VStack, HStack } from '@chakra-ui/react'
+import { FinancialCards } from './FinancialCards'
+import { MonthlyTrendChart } from './MonthlyTrendChart'
+import { RecentTransactions } from './RecentTransactions'
+import { MonthSelector } from './MonthSelector'
+
+interface Props {
+  userId: string
+}
+
+export function DashboardContent({ userId }: Props) {
+  const currentMonth = new Date().toISOString().slice(0, 7) // YYYY-MM
+  const [selectedMonth, setSelectedMonth] = useState(currentMonth)
+
+  return (
+    <Box>
+      <HStack justify="space-between" align="center" mb={8}>
+        <Heading>Dashboard</Heading>
+        <MonthSelector value={selectedMonth} onChange={setSelectedMonth} />
+      </HStack>
+
+      <VStack gap={8} align="stretch">
+        <FinancialCards userId={userId} month={selectedMonth} />
+
+        <MonthlyTrendChart userId={userId} />
+
+        <RecentTransactions userId={userId} limit={10} />
+      </VStack>
+    </Box>
+  )
+}

--- a/components/dashboard/MonthSelector.tsx
+++ b/components/dashboard/MonthSelector.tsx
@@ -1,0 +1,39 @@
+'use client'
+
+import { NativeSelectField, NativeSelectRoot } from '@chakra-ui/react'
+
+interface Props {
+  value: string
+  onChange: (month: string) => void
+}
+
+export function MonthSelector({ value, onChange }: Props) {
+  const months: { value: string; label: string }[] = []
+  const now = new Date()
+
+  // Últimos 12 meses
+  for (let i = 0; i < 12; i++) {
+    const date = new Date(now.getFullYear(), now.getMonth() - i, 1)
+    const monthStr = date.toISOString().slice(0, 7)
+    const label = date.toLocaleDateString('es', {
+      year: 'numeric',
+      month: 'long',
+    })
+    months.push({ value: monthStr, label })
+  }
+
+  return (
+    <NativeSelectRoot maxW="250px">
+      <NativeSelectField
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+      >
+        {months.map((month) => (
+          <option key={month.value} value={month.value}>
+            {month.label}
+          </option>
+        ))}
+      </NativeSelectField>
+    </NativeSelectRoot>
+  )
+}


### PR DESCRIPTION
## Cambios
- Creado MonthSelector con últimos 12 meses usando NativeSelectRoot (Chakra v3)
- Creado DashboardContent como wrapper client-side para gestionar estado del mes
- Dashboard page simplificado: solo obtiene userId y renderiza DashboardContent
- FinancialCards se filtra por mes seleccionado

## Testing
- ✅ Sin errores de TypeScript

Closes #90
Related to #79