### PR TITLE
fix: resolve hydration mismatch from Emotion SSR injection

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -29,7 +29,7 @@ export default function RootLayout({
       lang="es"
       className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}
     >
-      <body className="min-h-full flex flex-col">
+      <body className="min-h-full flex flex-col" suppressHydrationWarning>
         <SessionProvider>
           <ChakraProvider>{children}</ChakraProvider>
         </SessionProvider>

--- a/components/providers/ChakraProvider.tsx
+++ b/components/providers/ChakraProvider.tsx
@@ -4,23 +4,26 @@ import { ChakraProvider as ChakraUIProvider, Toaster, Toast } from '@chakra-ui/r
 import { system } from '@/theme'
 import { ReactNode } from 'react'
 import { toaster } from '@/lib/toaster'
+import { EmotionRegistry } from './EmotionRegistry'
 
 export function ChakraProvider({ children }: { children: ReactNode }) {
   return (
-    <ChakraUIProvider value={system}>
-      {children}
-      <Toaster toaster={toaster}>
-        {(toast) => (
-          <Toast.Root key={toast.id}>
-            <Toast.Indicator />
-            <Toast.Title>{toast.title as string}</Toast.Title>
-            {toast.description && (
-              <Toast.Description>{toast.description as string}</Toast.Description>
-            )}
-            <Toast.CloseTrigger />
-          </Toast.Root>
-        )}
-      </Toaster>
-    </ChakraUIProvider>
+    <EmotionRegistry>
+      <ChakraUIProvider value={system}>
+        {children}
+        <Toaster toaster={toaster}>
+          {(toast) => (
+            <Toast.Root key={toast.id}>
+              <Toast.Indicator />
+              <Toast.Title>{toast.title as string}</Toast.Title>
+              {toast.description && (
+                <Toast.Description>{toast.description as string}</Toast.Description>
+              )}
+              <Toast.CloseTrigger />
+            </Toast.Root>
+          )}
+        </Toaster>
+      </ChakraUIProvider>
+    </EmotionRegistry>
   )
 }

--- a/components/providers/EmotionRegistry.tsx
+++ b/components/providers/EmotionRegistry.tsx
@@ -1,0 +1,57 @@
+'use client'
+
+import createCache from '@emotion/cache'
+import { CacheProvider } from '@emotion/react'
+import { useServerInsertedHTML } from 'next/navigation'
+import { useState } from 'react'
+
+/**
+ * Collects emotion styles during SSR and injects them into <head>
+ * via useServerInsertedHTML, so server and client render the same structure.
+ * Required for Next.js App Router + emotion (Chakra UI v3) hydration consistency.
+ */
+export function EmotionRegistry({ children }: { children: React.ReactNode }) {
+  const [{ cache, flush }] = useState(() => {
+    const cache = createCache({ key: 'css' })
+    cache.compat = true
+
+    const prevInsert = cache.insert.bind(cache)
+    let inserted: string[] = []
+
+    cache.insert = (...args: Parameters<typeof prevInsert>) => {
+      const [, serialized] = args
+      if (cache.inserted[serialized.name] === undefined) {
+        inserted.push(serialized.name)
+      }
+      return prevInsert(...args)
+    }
+
+    const flush = () => {
+      const prev = inserted
+      inserted = []
+      return prev
+    }
+
+    return { cache, flush }
+  })
+
+  useServerInsertedHTML(() => {
+    const names = flush()
+    if (names.length === 0) return null
+
+    let styles = ''
+    for (const name of names) {
+      styles += cache.inserted[name] ?? ''
+    }
+
+    return (
+      <style
+        key={cache.key}
+        data-emotion={`${cache.key} ${names.join(' ')}`}
+        dangerouslySetInnerHTML={{ __html: styles }}
+      />
+    )
+  })
+
+  return <CacheProvider value={cache}>{children}</CacheProvider>
+}

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@chakra-ui/next-js": "^2.4.2",
     "@chakra-ui/react": "^3.34.0",
+    "@emotion/cache": "^11.14.0",
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",
     "@insforge/sdk": "^1.2.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@chakra-ui/react':
         specifier: ^3.34.0
         version: 3.34.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@emotion/cache':
+        specifier: ^11.14.0
+        version: 11.14.0
       '@emotion/react':
         specifier: ^11.14.0
         version: 11.14.0(@types/react@19.2.14)(react@19.2.4)


### PR DESCRIPTION
## Summary

- Add `EmotionRegistry` component that captures Emotion CSS-in-JS styles during SSR and injects them via `useServerInsertedHTML`, so server and client render the same HTML structure
- Wrap `ChakraUIProvider` with `EmotionRegistry` in `ChakraProvider.tsx`
- Add `suppressHydrationWarning` to `<body>` in `app/layout.tsx` to suppress false positives from browser extensions (e.g. Grammarly)
- Install `@emotion/cache` dependency required by `EmotionRegistry`

## Root cause

Chakra UI v3 uses Emotion under the hood. During SSR, Emotion renders a `<style>` tag inline. On the client, it renders a `<div>` container instead — causing a DOM structure mismatch and the hydration error. The `EmotionRegistry` fixes this by collecting styles during SSR and injecting them consistently via Next.js `useServerInsertedHTML`.

## Test plan

- [ ] Open the app and verify no hydration errors in the browser console
- [ ] Verify styles are applied correctly (no flash of unstyled content)
- [ ] Verify Toaster and all Chakra UI components still work as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)