### PR TITLE
FASE 08: Sistema de Categorías

### DIFF
--- a/app/(dashboard)/categories/CategoriesPageClient.tsx
+++ b/app/(dashboard)/categories/CategoriesPageClient.tsx
@@ -1,0 +1,245 @@
+'use client'
+
+import {
+  Box,
+  Heading,
+  Button,
+  HStack,
+  VStack,
+  Text,
+  Badge,
+  IconButton,
+  SimpleGrid,
+  DialogRoot,
+  DialogBackdrop,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogBody,
+  DialogCloseTrigger,
+} from '@chakra-ui/react'
+import { useState, useCallback } from 'react'
+import { FiPlus, FiEdit2, FiTrash2 } from 'react-icons/fi'
+import { useDisclosure } from '@chakra-ui/react'
+import { getCategories, deleteCategory } from '@/lib/actions/categories.actions'
+import { toaster } from '@/lib/toaster'
+import { CategoryForm } from '@/components/categories/CategoryForm'
+import { CategoryEditForm } from '@/components/categories/CategoryEditForm'
+import type { Category } from '@/types/database.types'
+
+interface Props {
+  userId: string
+  initialCategories: Category[]
+}
+
+export function CategoriesPageClient({ userId, initialCategories }: Props) {
+  const [categories, setCategories] = useState<Category[]>(initialCategories)
+  const [selectedCategory, setSelectedCategory] = useState<Category | null>(null)
+  const [deletingId, setDeletingId] = useState<string | null>(null)
+  const [deleteLoading, setDeleteLoading] = useState(false)
+
+  const createDisclosure = useDisclosure()
+  const editDisclosure = useDisclosure()
+  const deleteDisclosure = useDisclosure()
+
+  const refresh = useCallback(async () => {
+    const result = await getCategories(userId)
+    if (result.success && result.data) {
+      setCategories(result.data as Category[])
+    }
+  }, [userId])
+
+  const handleEditOpen = (cat: Category) => {
+    setSelectedCategory(cat)
+    editDisclosure.onOpen()
+  }
+
+  const handleDeleteOpen = (cat: Category) => {
+    setSelectedCategory(cat)
+    setDeletingId(cat.id)
+    deleteDisclosure.onOpen()
+  }
+
+  const handleDelete = async () => {
+    if (!deletingId) return
+    setDeleteLoading(true)
+
+    const result = await deleteCategory(deletingId, userId)
+
+    if (result.success) {
+      toaster.create({ title: 'Categoría eliminada', type: 'success', duration: 3000 })
+      deleteDisclosure.onClose()
+      await refresh()
+    } else {
+      toaster.create({ title: 'No se pudo eliminar', description: result.error, type: 'error', duration: 5000 })
+    }
+    setDeleteLoading(false)
+  }
+
+  const predefined = categories.filter((c) => c.user_id === null)
+  const userCategories = categories.filter((c) => c.user_id !== null)
+
+  return (
+    <Box p={6}>
+      <HStack justify="space-between" mb={6}>
+        <Heading size="lg">Categorías</Heading>
+        <Button colorPalette="brand" onClick={createDisclosure.onOpen}>
+          <FiPlus />
+          Nueva Categoría
+        </Button>
+      </HStack>
+
+      <VStack gap={8} align="stretch">
+        {/* Categorías predefinidas */}
+        <Box>
+          <Text fontWeight="semibold" color="gray.500" mb={3} fontSize="sm" textTransform="uppercase">
+            Predefinidas
+          </Text>
+          <SimpleGrid columns={{ base: 1, sm: 2, md: 3, lg: 4 }} gap={3}>
+            {predefined.map((cat) => (
+              <CategoryCard key={cat.id} category={cat} readOnly />
+            ))}
+          </SimpleGrid>
+        </Box>
+
+        {/* Categorías del usuario */}
+        <Box>
+          <Text fontWeight="semibold" color="gray.500" mb={3} fontSize="sm" textTransform="uppercase">
+            Mis Categorías
+          </Text>
+          {userCategories.length === 0 ? (
+            <Text color="gray.400" fontSize="sm">
+              Aún no tienes categorías personalizadas. Crea una con el botón de arriba.
+            </Text>
+          ) : (
+            <SimpleGrid columns={{ base: 1, sm: 2, md: 3, lg: 4 }} gap={3}>
+              {userCategories.map((cat) => (
+                <CategoryCard
+                  key={cat.id}
+                  category={cat}
+                  onEdit={() => handleEditOpen(cat)}
+                  onDelete={() => handleDeleteOpen(cat)}
+                />
+              ))}
+            </SimpleGrid>
+          )}
+        </Box>
+      </VStack>
+
+      {/* Modales */}
+      <CategoryForm
+        isOpen={createDisclosure.open}
+        onClose={createDisclosure.onClose}
+        userId={userId}
+        onSuccess={refresh}
+      />
+
+      {selectedCategory && (
+        <CategoryEditForm
+          isOpen={editDisclosure.open}
+          onClose={editDisclosure.onClose}
+          userId={userId}
+          category={selectedCategory}
+          onSuccess={refresh}
+        />
+      )}
+
+      {/* Confirmación eliminar */}
+      <DialogRoot
+        open={deleteDisclosure.open}
+        onOpenChange={({ open }) => !open && deleteDisclosure.onClose()}
+        role="alertdialog"
+      >
+        <DialogBackdrop />
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Eliminar Categoría</DialogTitle>
+          </DialogHeader>
+          <DialogCloseTrigger />
+          <DialogBody pb={6}>
+            <Text mb={4}>
+              ¿Seguro que deseas eliminar{' '}
+              <Text as="span" fontWeight="bold">
+                {selectedCategory?.icon} {selectedCategory?.name}
+              </Text>
+              ? Esta acción no se puede deshacer.
+            </Text>
+            <HStack justify="flex-end">
+              <Button variant="outline" onClick={deleteDisclosure.onClose}>
+                Cancelar
+              </Button>
+              <Button colorPalette="red" loading={deleteLoading} onClick={handleDelete}>
+                Eliminar
+              </Button>
+            </HStack>
+          </DialogBody>
+        </DialogContent>
+      </DialogRoot>
+    </Box>
+  )
+}
+
+function CategoryCard({
+  category,
+  readOnly = false,
+  onEdit,
+  onDelete,
+}: {
+  category: Category
+  readOnly?: boolean
+  onEdit?: () => void
+  onDelete?: () => void
+}) {
+  return (
+    <Box
+      borderWidth="1px"
+      borderColor="gray.200"
+      borderRadius="lg"
+      p={4}
+      bg="white"
+      _hover={{ shadow: 'sm' }}
+      transition="box-shadow 0.15s"
+    >
+      <HStack justify="space-between" align="start">
+        <HStack gap={3}>
+          <Box
+            w="10"
+            h="10"
+            borderRadius="full"
+            bg={category.color ?? 'gray.100'}
+            display="flex"
+            alignItems="center"
+            justifyContent="center"
+            fontSize="xl"
+            flexShrink={0}
+          >
+            {category.icon ?? '🏷️'}
+          </Box>
+          <Box>
+            <Text fontWeight="medium" fontSize="sm">
+              {category.name}
+            </Text>
+            <Badge
+              colorPalette={category.type === 'income' ? 'green' : 'red'}
+              size="sm"
+              mt={1}
+            >
+              {category.type === 'income' ? 'Ingreso' : 'Gasto'}
+            </Badge>
+          </Box>
+        </HStack>
+
+        {!readOnly && (
+          <HStack gap={1}>
+            <IconButton size="xs" variant="ghost" colorPalette="gray" aria-label="Editar" onClick={onEdit}>
+              <FiEdit2 />
+            </IconButton>
+            <IconButton size="xs" variant="ghost" colorPalette="red" aria-label="Eliminar" onClick={onDelete}>
+              <FiTrash2 />
+            </IconButton>
+          </HStack>
+        )}
+      </HStack>
+    </Box>
+  )
+}

--- a/app/(dashboard)/categories/page.tsx
+++ b/app/(dashboard)/categories/page.tsx
@@ -1,0 +1,30 @@
+import { getServerSession } from 'next-auth'
+import { authOptions } from '@/lib/auth'
+import { redirect } from 'next/navigation'
+import { insforgeAdmin } from '@/lib/insforge-admin'
+import { getCategories } from '@/lib/actions/categories.actions'
+import { CategoriesPageClient } from './CategoriesPageClient'
+import type { Category } from '@/types/database.types'
+
+export default async function CategoriesPage() {
+  const session = await getServerSession(authOptions)
+
+  if (!session?.user?.email) {
+    redirect('/login')
+  }
+
+  const { data: user } = await insforgeAdmin.database
+    .from('users')
+    .select('id')
+    .eq('email', session.user.email)
+    .single()
+
+  if (!user) {
+    redirect('/login')
+  }
+
+  const categoriesResult = await getCategories(user.id)
+  const categories = (categoriesResult.success ? categoriesResult.data : []) as Category[]
+
+  return <CategoriesPageClient userId={user.id} initialCategories={categories} />
+}

--- a/components/categories/CategoryEditForm.tsx
+++ b/components/categories/CategoryEditForm.tsx
@@ -1,0 +1,118 @@
+'use client'
+
+import {
+  DialogRoot,
+  DialogBackdrop,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogBody,
+  DialogCloseTrigger,
+  VStack,
+  HStack,
+  FieldRoot,
+  FieldLabel,
+  Input,
+  Button,
+  Badge,
+} from '@chakra-ui/react'
+import { useState, useEffect } from 'react'
+import { updateCategory } from '@/lib/actions/categories.actions'
+import { toaster } from '@/lib/toaster'
+import type { Category } from '@/types/database.types'
+import { IconPicker } from './IconPicker'
+import { ColorPicker } from './ColorPicker'
+
+interface Props {
+  isOpen: boolean
+  onClose: () => void
+  userId: string
+  category: Category
+  onSuccess: () => void
+}
+
+export function CategoryEditForm({ isOpen, onClose, userId, category, onSuccess }: Props) {
+  const [loading, setLoading] = useState(false)
+  const [formData, setFormData] = useState({
+    name: category.name,
+    icon: category.icon ?? '',
+    color: category.color ?? '#6366f1',
+  })
+
+  useEffect(() => {
+    setFormData({
+      name: category.name,
+      icon: category.icon ?? '',
+      color: category.color ?? '#6366f1',
+    })
+  }, [category])
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setLoading(true)
+
+    const result = await updateCategory(category.id, userId, formData)
+
+    if (result.success) {
+      toaster.create({ title: 'Categoría actualizada', type: 'success', duration: 3000 })
+      onSuccess()
+      onClose()
+    } else {
+      toaster.create({ title: 'Error al actualizar', description: result.error, type: 'error', duration: 4000 })
+    }
+    setLoading(false)
+  }
+
+  return (
+    <DialogRoot open={isOpen} onOpenChange={({ open }) => !open && onClose()} size="md">
+      <DialogBackdrop />
+      <DialogContent>
+        <DialogHeader>
+          <HStack>
+            <DialogTitle>Editar Categoría</DialogTitle>
+            <Badge colorPalette={category.type === 'income' ? 'green' : 'red'} size="sm">
+              {category.type === 'income' ? 'Ingreso' : 'Gasto'}
+            </Badge>
+          </HStack>
+        </DialogHeader>
+        <DialogCloseTrigger />
+        <DialogBody pb={6}>
+          <form onSubmit={handleSubmit}>
+            <VStack gap={4}>
+              <FieldRoot required>
+                <FieldLabel>Nombre</FieldLabel>
+                <Input
+                  value={formData.name}
+                  onChange={(e) => setFormData({ ...formData, name: e.target.value })}
+                  placeholder="Ej: Transporte"
+                />
+              </FieldRoot>
+
+              <HStack gap={4} w="full">
+                <FieldRoot>
+                  <FieldLabel>Icono</FieldLabel>
+                  <IconPicker
+                    value={formData.icon}
+                    onChange={(icon) => setFormData({ ...formData, icon })}
+                  />
+                </FieldRoot>
+
+                <FieldRoot>
+                  <FieldLabel>Color</FieldLabel>
+                  <ColorPicker
+                    value={formData.color}
+                    onChange={(color) => setFormData({ ...formData, color })}
+                  />
+                </FieldRoot>
+              </HStack>
+
+              <Button type="submit" colorPalette="brand" width="full" loading={loading}>
+                Guardar Cambios
+              </Button>
+            </VStack>
+          </form>
+        </DialogBody>
+      </DialogContent>
+    </DialogRoot>
+  )
+}

--- a/components/categories/CategoryForm.tsx
+++ b/components/categories/CategoryForm.tsx
@@ -1,0 +1,131 @@
+'use client'
+
+import {
+  DialogRoot,
+  DialogBackdrop,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogBody,
+  DialogCloseTrigger,
+  VStack,
+  HStack,
+  FieldRoot,
+  FieldLabel,
+  Input,
+  RadioGroupRoot,
+  RadioGroupItem,
+  RadioGroupItemControl,
+  RadioGroupItemText,
+  Button,
+} from '@chakra-ui/react'
+import { useState } from 'react'
+import { createCategory } from '@/lib/actions/categories.actions'
+import { toaster } from '@/lib/toaster'
+import { IconPicker } from './IconPicker'
+import { ColorPicker } from './ColorPicker'
+
+interface Props {
+  isOpen: boolean
+  onClose: () => void
+  userId: string
+  onSuccess: () => void
+}
+
+const defaultForm = {
+  name: '',
+  type: 'expense' as 'income' | 'expense',
+  icon: '',
+  color: '#6366f1',
+}
+
+export function CategoryForm({ isOpen, onClose, userId, onSuccess }: Props) {
+  const [loading, setLoading] = useState(false)
+  const [formData, setFormData] = useState(defaultForm)
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setLoading(true)
+
+    const result = await createCategory(userId, formData)
+
+    if (result.success) {
+      toaster.create({ title: 'Categoría creada', type: 'success', duration: 3000 })
+      onSuccess()
+      onClose()
+      setFormData(defaultForm)
+    } else {
+      toaster.create({ title: 'Error al crear', description: result.error, type: 'error', duration: 4000 })
+    }
+    setLoading(false)
+  }
+
+  return (
+    <DialogRoot open={isOpen} onOpenChange={({ open }) => !open && onClose()} size="md">
+      <DialogBackdrop />
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Nueva Categoría</DialogTitle>
+        </DialogHeader>
+        <DialogCloseTrigger />
+        <DialogBody pb={6}>
+          <form onSubmit={handleSubmit}>
+            <VStack gap={4}>
+              <FieldRoot required>
+                <FieldLabel>Tipo</FieldLabel>
+                <RadioGroupRoot
+                  value={formData.type}
+                  onValueChange={({ value }) =>
+                    setFormData({ ...formData, type: value as 'income' | 'expense' })
+                  }
+                >
+                  <HStack gap={4}>
+                    <RadioGroupItem value="expense">
+                      <RadioGroupItemControl />
+                      <RadioGroupItemText>Gasto</RadioGroupItemText>
+                    </RadioGroupItem>
+                    <RadioGroupItem value="income">
+                      <RadioGroupItemControl />
+                      <RadioGroupItemText>Ingreso</RadioGroupItemText>
+                    </RadioGroupItem>
+                  </HStack>
+                </RadioGroupRoot>
+              </FieldRoot>
+
+              <FieldRoot required>
+                <FieldLabel>Nombre</FieldLabel>
+                <Input
+                  value={formData.name}
+                  onChange={(e) => setFormData({ ...formData, name: e.target.value })}
+                  placeholder="Ej: Transporte"
+                />
+              </FieldRoot>
+
+              <HStack gap={4} w="full">
+                <FieldRoot>
+                  <FieldLabel>Icono</FieldLabel>
+                  <IconPicker
+                    value={formData.icon}
+                    onChange={(icon) => setFormData({ ...formData, icon })}
+                  />
+                </FieldRoot>
+
+                <FieldRoot>
+                  <FieldLabel>Color</FieldLabel>
+                  <ColorPicker
+                    value={formData.color}
+                    onChange={(color) => setFormData({ ...formData, color })}
+                  />
+                </FieldRoot>
+              </HStack>
+
+              <Button type="submit" colorPalette="brand" width="full" loading={loading}>
+                Crear Categoría
+              </Button>
+            </VStack>
+          </form>
+        </DialogBody>
+      </DialogContent>
+    </DialogRoot>
+  )
+}

--- a/components/categories/ColorPicker.tsx
+++ b/components/categories/ColorPicker.tsx
@@ -1,0 +1,60 @@
+'use client'
+
+import { SimpleGrid, Popover, chakra } from '@chakra-ui/react'
+
+const StyledButton = chakra('button')
+
+const COLORS = [
+  '#ef4444', '#f97316', '#eab308', '#22c55e', '#14b8a6',
+  '#3b82f6', '#6366f1', '#8b5cf6', '#ec4899', '#f43f5e',
+  '#64748b', '#78716c', '#84cc16', '#06b6d4', '#a855f7',
+]
+
+interface Props {
+  value: string
+  onChange: (color: string) => void
+}
+
+export function ColorPicker({ value, onChange }: Props) {
+  return (
+    <Popover.Root>
+      <Popover.Trigger asChild>
+        <StyledButton
+          type="button"
+          w="9"
+          h="9"
+          borderRadius="md"
+          bg={value}
+          border="2px solid"
+          borderColor="gray.300"
+          cursor="pointer"
+          _hover={{ borderColor: 'gray.500' }}
+        />
+      </Popover.Trigger>
+      <Popover.Positioner>
+        <Popover.Content w="44">
+          <Popover.Body p={3}>
+            <SimpleGrid columns={5} gap={2}>
+              {COLORS.map((color) => (
+                <StyledButton
+                  key={color}
+                  type="button"
+                  onClick={() => onChange(color)}
+                  w="7"
+                  h="7"
+                  borderRadius="md"
+                  bg={color}
+                  border="2px solid"
+                  borderColor={value === color ? 'gray.800' : 'transparent'}
+                  cursor="pointer"
+                  _hover={{ transform: 'scale(1.15)' }}
+                  transition="transform 0.1s"
+                />
+              ))}
+            </SimpleGrid>
+          </Popover.Body>
+        </Popover.Content>
+      </Popover.Positioner>
+    </Popover.Root>
+  )
+}

--- a/components/categories/IconPicker.tsx
+++ b/components/categories/IconPicker.tsx
@@ -1,0 +1,66 @@
+'use client'
+
+import { SimpleGrid, Button, Text, Popover, Input, chakra } from '@chakra-ui/react'
+
+const StyledButton = chakra('button')
+import { useState } from 'react'
+
+const ICONS = [
+  '🍔', '🍕', '🍜', '🍣', '☕', '🛒', '🏠', '🚗', '✈️', '🚌',
+  '💊', '🏋️', '🎮', '🎬', '📚', '👗', '👟', '💄', '🐾', '🎁',
+  '💼', '💻', '📱', '🔧', '⚡', '💡', '🌊', '🌿', '🏖️', '🎵',
+  '💰', '💳', '🏦', '📈', '💸', '🎓', '🏥', '🏋', '🛍️', '🍷',
+  '🧾', '🔑', '🏡', '🚿', '🧹', '📦', '🧺', '🎨', '✂️', '🖥️',
+]
+
+interface Props {
+  value: string
+  onChange: (icon: string) => void
+}
+
+export function IconPicker({ value, onChange }: Props) {
+  const [search, setSearch] = useState('')
+
+  const filtered = ICONS.filter((i) => i.includes(search))
+
+  return (
+    <Popover.Root>
+      <Popover.Trigger asChild>
+        <Button variant="outline" size="sm" minW="10">
+          {value || '🏷️'}
+        </Button>
+      </Popover.Trigger>
+      <Popover.Positioner>
+        <Popover.Content w="72">
+          <Popover.Body p={3}>
+            <Input
+              size="sm"
+              placeholder="Buscar emoji..."
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              mb={2}
+            />
+            <SimpleGrid columns={8} gap={1}>
+              {filtered.map((icon) => (
+                <StyledButton
+                  key={icon}
+                  type="button"
+                  onClick={() => onChange(icon)}
+                  p={1}
+                  borderRadius="md"
+                  fontSize="xl"
+                  cursor="pointer"
+                  bg={value === icon ? 'brand.100' : 'transparent'}
+                  _hover={{ bg: 'gray.100' }}
+                  textAlign="center"
+                >
+                  <Text>{icon}</Text>
+                </StyledButton>
+              ))}
+            </SimpleGrid>
+          </Popover.Body>
+        </Popover.Content>
+      </Popover.Positioner>
+    </Popover.Root>
+  )
+}

--- a/lib/actions/categories.actions.ts
+++ b/lib/actions/categories.actions.ts
@@ -1,9 +1,11 @@
 'use server'
 
-import { insforge } from '@/lib/insforge'
+import { insforgeAdmin } from '@/lib/insforge-admin'
 import {
   createCategorySchema,
+  updateCategorySchema,
   type CreateCategoryInput,
+  type UpdateCategoryInput,
 } from '@/lib/validations/category'
 
 export async function getCategories(userId: string) {
@@ -11,8 +13,8 @@ export async function getCategories(userId: string) {
     // Obtener predefinidas (user_id null) + del usuario en dos queries
     const [{ data: predefined, error: e1 }, { data: userCats, error: e2 }] =
       await Promise.all([
-        insforge.database.from('categories').select('*').is('user_id', null).order('name'),
-        insforge.database.from('categories').select('*').eq('user_id', userId).order('name'),
+        insforgeAdmin.database.from('categories').select('*').is('user_id', null).order('name'),
+        insforgeAdmin.database.from('categories').select('*').eq('user_id', userId).order('name'),
       ])
 
     if (e1) throw e1
@@ -31,7 +33,7 @@ export async function createCategory(
   try {
     const validated = createCategorySchema.parse(data)
 
-    const { data: category, error } = await insforge.database
+    const { data: category, error } = await insforgeAdmin.database
       .from('categories')
       .insert([{ ...validated, user_id: userId }])
       .select()
@@ -45,9 +47,45 @@ export async function createCategory(
   }
 }
 
+export async function updateCategory(
+  id: string,
+  userId: string,
+  data: UpdateCategoryInput
+) {
+  try {
+    const validated = updateCategorySchema.parse(data)
+
+    const { data: category, error } = await insforgeAdmin.database
+      .from('categories')
+      .update(validated)
+      .eq('id', id)
+      .eq('user_id', userId)
+      .select()
+      .single()
+
+    if (error) throw error
+    return { success: true, data: category }
+  } catch (error) {
+    console.error('Update category error:', error)
+    return { success: false, error: 'Failed to update category' }
+  }
+}
+
 export async function deleteCategory(id: string, userId: string) {
   try {
-    const { error } = await insforge.database
+    // Verificar que no tenga transacciones asociadas
+    const { data: txCount } = await insforgeAdmin.database
+      .from('transactions')
+      .select('id')
+      .eq('category_id', id)
+      .eq('user_id', userId)
+      .limit(1)
+
+    if (txCount && txCount.length > 0) {
+      return { success: false, error: 'No se puede eliminar: la categoría tiene transacciones asociadas' }
+    }
+
+    const { error } = await insforgeAdmin.database
       .from('categories')
       .delete()
       .eq('id', id)

--- a/lib/validations/category.ts
+++ b/lib/validations/category.ts
@@ -7,4 +7,11 @@ export const createCategorySchema = z.object({
   color: z.string().optional(),
 })
 
+export const updateCategorySchema = z.object({
+  name: z.string().min(1, 'Name is required'),
+  icon: z.string().optional(),
+  color: z.string().optional(),
+})
+
 export type CreateCategoryInput = z.infer<typeof createCategorySchema>
+export type UpdateCategoryInput = z.infer<typeof updateCategorySchema>


### PR DESCRIPTION
Closes #104

## Resumen

CRUD completo de categorías personalizadas. Las predefinidas (`user_id = null`) son de solo lectura.

## Cambios

### Nuevas páginas y componentes
- **`app/(dashboard)/categories/page.tsx`** — server component, obtiene sesión y userId, pasa datos al cliente
- **`app/(dashboard)/categories/CategoriesPageClient.tsx`** — lista categorías en dos secciones (Predefinidas / Mis Categorías) con tarjetas visuales; maneja create/edit/delete
- **`components/categories/CategoryForm.tsx`** — modal para crear: tipo, nombre, icon picker, color picker
- **`components/categories/CategoryEditForm.tsx`** — modal para editar (solo nombre, icono y color — el tipo no se puede cambiar)
- **`components/categories/IconPicker.tsx`** — popover con búsqueda y grilla de emojis
- **`components/categories/ColorPicker.tsx`** — popover con paleta de 15 colores predefinidos

### Acciones
- **`updateCategory`** — nueva acción con validación `updateCategorySchema`
- **`deleteCategory`** — ahora valida que la categoría no tenga transacciones antes de eliminar
- Migrado `categories.actions.ts` a `insforgeAdmin` para bypasear RLS (mismo fix que páginas)

## Test plan
- [ ] Listar categorías: ver predefinidas y las del usuario
- [ ] Crear categoría: nombre, tipo, icono y color guardados correctamente
- [ ] Editar: cambios reflejados inmediatamente
- [ ] Eliminar sin transacciones: funciona
- [ ] Eliminar con transacciones: muestra error y no elimina
- [ ] No aparecen botones editar/eliminar en categorías predefinidas

🤖 Generated with [Claude Code](https://claude.com/claude-code)