### PR TITLE
FASE 10: Chat IA para Registro de Gastos

### DIFF
--- a/app/(dashboard)/chat/page.tsx
+++ b/app/(dashboard)/chat/page.tsx
@@ -1,0 +1,51 @@
+import { getServerSession } from 'next-auth'
+import { authOptions } from '@/lib/auth'
+import { redirect } from 'next/navigation'
+import { insforgeAdmin } from '@/lib/insforge-admin'
+import { getCategories } from '@/lib/actions/categories.actions'
+import { ChatInterface } from '@/components/chat/ChatInterface'
+import { Box, Heading, Text, VStack } from '@chakra-ui/react'
+
+export default async function ChatPage() {
+  const session = await getServerSession(authOptions)
+
+  if (!session?.user?.email) {
+    redirect('/login')
+  }
+
+  const { data: user } = await insforgeAdmin.database
+    .from('users')
+    .select('id')
+    .eq('email', session.user.email)
+    .single()
+
+  if (!user) {
+    redirect('/login')
+  }
+
+  const categoriesResult = await getCategories(user.id)
+  const categories = categoriesResult.success ? (categoriesResult.data ?? []) : []
+
+  return (
+    <VStack gap={0} h="full" align="stretch">
+      <Box pb={4}>
+        <Heading size="lg" color="gray.800">Chat IA</Heading>
+        <Text color="gray.500" fontSize="sm" mt={1}>
+          Registra gastos e ingresos escribiendo en lenguaje natural
+        </Text>
+      </Box>
+
+      <Box
+        flex="1"
+        borderWidth="1px"
+        borderColor="gray.200"
+        borderRadius="xl"
+        overflow="hidden"
+        bg="white"
+        shadow="sm"
+      >
+        <ChatInterface userId={user.id} categories={categories} />
+      </Box>
+    </VStack>
+  )
+}

--- a/app/(dashboard)/layout.tsx
+++ b/app/(dashboard)/layout.tsx
@@ -1,12 +1,36 @@
 import { Flex, Box } from '@chakra-ui/react'
+import { getServerSession } from 'next-auth'
+import { authOptions } from '@/lib/auth'
+import { insforgeAdmin } from '@/lib/insforge-admin'
+import { getCategories } from '@/lib/actions/categories.actions'
 import { Header } from '@/components/dashboard/Header'
 import { Sidebar } from '@/components/dashboard/Sidebar'
+import { FloatingChat } from '@/components/chat/FloatingChat'
 
-export default function DashboardLayout({
+export default async function DashboardLayout({
   children,
 }: {
   children: React.ReactNode
 }) {
+  const session = await getServerSession(authOptions)
+
+  let userId: string | null = null
+  let categories: Awaited<ReturnType<typeof getCategories>>['data'] = []
+
+  if (session?.user?.email) {
+    const { data: user } = await insforgeAdmin.database
+      .from('users')
+      .select('id')
+      .eq('email', session.user.email)
+      .single()
+
+    if (user) {
+      userId = user.id
+      const result = await getCategories(user.id)
+      categories = result.success ? result.data : []
+    }
+  }
+
   return (
     <Flex direction="column" h="100vh">
       <Header />
@@ -16,6 +40,9 @@ export default function DashboardLayout({
           {children}
         </Box>
       </Flex>
+      {userId && (
+        <FloatingChat userId={userId} categories={categories ?? []} />
+      )}
     </Flex>
   )
 }

--- a/components/chat/ChatInterface.tsx
+++ b/components/chat/ChatInterface.tsx
@@ -1,0 +1,360 @@
+'use client'
+
+import {
+  Box,
+  VStack,
+  HStack,
+  Text,
+  Input,
+  Button,
+  Badge,
+  Spinner,
+  Separator,
+  Icon,
+} from '@chakra-ui/react'
+import { useState, useRef, useEffect } from 'react'
+import { FiSend, FiCheck, FiX, FiMessageSquare } from 'react-icons/fi'
+import { categorizePurchase, type CategorizedTransaction } from '@/lib/actions/ai.actions'
+import { createTransaction } from '@/lib/actions/transactions.actions'
+import { toaster } from '@/lib/toaster'
+import type { Category } from '@/types/database.types'
+
+interface ChatMessage {
+  id: string
+  role: 'user' | 'assistant' | 'system'
+  text: string
+  preview?: CategorizedTransaction & { category_name?: string }
+  timestamp: number
+}
+
+interface Props {
+  userId: string
+  categories: Category[]
+}
+
+const STORAGE_KEY = 'chat-ia-history'
+
+function loadHistory(): ChatMessage[] {
+  if (typeof window === 'undefined') return []
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    return raw ? (JSON.parse(raw) as ChatMessage[]) : []
+  } catch {
+    return []
+  }
+}
+
+function saveHistory(messages: ChatMessage[]) {
+  try {
+    // Guardar solo los últimos 50 mensajes
+    const toSave = messages.slice(-50)
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(toSave))
+  } catch {
+    // localStorage puede estar lleno
+  }
+}
+
+export function ChatInterface({ userId, categories }: Props) {
+  const [messages, setMessages] = useState<ChatMessage[]>([])
+  const [input, setInput] = useState('')
+  const [loading, setLoading] = useState(false)
+  const bottomRef = useRef<HTMLDivElement>(null)
+
+  // Cargar historial al montar
+  useEffect(() => {
+    const history = loadHistory()
+    if (history.length > 0) {
+      setMessages(history)
+    } else {
+      setMessages([
+        {
+          id: 'welcome',
+          role: 'system',
+          text: '¡Hola! Escribe tus gastos o ingresos en lenguaje natural y los categorizo automáticamente. Por ejemplo: "Gasté 45.000 en el supermercado" o "Recibí 500 dólares de salario".',
+          timestamp: Date.now(),
+        },
+      ])
+    }
+  }, [])
+
+  // Scroll al fondo cuando llegan mensajes nuevos
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: 'smooth' })
+  }, [messages])
+
+  const addMessage = (msg: Omit<ChatMessage, 'id' | 'timestamp'>) => {
+    const newMsg: ChatMessage = {
+      ...msg,
+      id: `${Date.now()}-${Math.random()}`,
+      timestamp: Date.now(),
+    }
+    setMessages((prev) => {
+      const updated = [...prev, newMsg]
+      saveHistory(updated)
+      return updated
+    })
+    return newMsg
+  }
+
+  const handleSend = async () => {
+    const text = input.trim()
+    if (!text || loading) return
+
+    setInput('')
+    setLoading(true)
+
+    addMessage({ role: 'user', text })
+
+    const result = await categorizePurchase(
+      text,
+      categories.map((c) => ({ id: c.id, name: c.name, type: c.type }))
+    )
+
+    if (!result.success) {
+      addMessage({
+        role: 'assistant',
+        text: `No pude procesar ese mensaje. ${result.error}. Intenta con más detalle, por ejemplo: "Compré comida por 30.000 pesos".`,
+      })
+      setLoading(false)
+      return
+    }
+
+    const category = categories.find((c) => c.id === result.data.category_id)
+    const preview = { ...result.data, category_name: category?.name ?? 'Sin categoría' }
+
+    const typeLabel = result.data.type === 'expense' ? 'gasto' : 'ingreso'
+    const formattedAmount = new Intl.NumberFormat('es-CO').format(result.data.amount)
+
+    addMessage({
+      role: 'assistant',
+      text: `Detecté un ${typeLabel} de ${formattedAmount} ${result.data.currency} en "${preview.category_name}" para el ${result.data.date}. ¿Confirmas?`,
+      preview,
+    })
+
+    setLoading(false)
+  }
+
+  const handleConfirm = async (msg: ChatMessage) => {
+    if (!msg.preview) return
+
+    const result = await createTransaction(userId, {
+      amount: msg.preview.amount,
+      currency: msg.preview.currency,
+      type: msg.preview.type,
+      category_id: msg.preview.category_id,
+      description: msg.preview.description,
+      date: msg.preview.date,
+      notes: undefined,
+    })
+
+    if (result.success) {
+      toaster.create({ title: 'Transacción guardada', type: 'success', duration: 3000 })
+      // Marcar el mensaje como confirmado (sin preview)
+      setMessages((prev) => {
+        const updated = prev.map((m) =>
+          m.id === msg.id ? { ...m, preview: undefined, text: `✅ ${m.text}` } : m
+        )
+        saveHistory(updated)
+        return updated
+      })
+      addMessage({ role: 'system', text: '¡Listo! La transacción fue registrada correctamente.' })
+    } else {
+      toaster.create({ title: 'Error al guardar', description: result.error, type: 'error', duration: 4000 })
+    }
+  }
+
+  const handleDiscard = (msgId: string) => {
+    setMessages((prev) => {
+      const updated = prev.map((m) =>
+        m.id === msgId ? { ...m, preview: undefined, text: `❌ ${m.text}` } : m
+      )
+      saveHistory(updated)
+      return updated
+    })
+    addMessage({ role: 'system', text: 'Entendido, descartado. ¿Quieres intentarlo de nuevo con más detalle?' })
+  }
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault()
+      handleSend()
+    }
+  }
+
+  const handleClearHistory = () => {
+    localStorage.removeItem(STORAGE_KEY)
+    setMessages([
+      {
+        id: 'welcome',
+        role: 'system',
+        text: '¡Hola! Escribe tus gastos o ingresos en lenguaje natural y los categorizo automáticamente.',
+        timestamp: Date.now(),
+      },
+    ])
+  }
+
+  return (
+    <VStack gap={0} h="full" maxH="calc(100vh - 160px)">
+      {/* Encabezado */}
+      <HStack w="full" p={4} borderBottomWidth="1px" borderColor="gray.200" bg="white" justify="space-between">
+        <HStack gap={2}>
+          <Icon as={FiMessageSquare} color="brand.500" boxSize={5} />
+          <Text fontWeight="semibold" color="gray.700">Chat IA</Text>
+        </HStack>
+        <Button size="xs" variant="ghost" colorPalette="gray" onClick={handleClearHistory}>
+          Limpiar historial
+        </Button>
+      </HStack>
+
+      {/* Mensajes */}
+      <Box flex="1" overflowY="auto" w="full" p={4} bg="gray.50">
+        <VStack gap={3} align="stretch">
+          {messages.map((msg) => (
+            <Box key={msg.id}>
+              {msg.role === 'user' && (
+                <HStack justify="flex-end">
+                  <Box
+                    bg="brand.500"
+                    color="white"
+                    px={4}
+                    py={2}
+                    borderRadius="2xl"
+                    borderBottomRightRadius="sm"
+                    maxW="80%"
+                  >
+                    <Text fontSize="sm">{msg.text}</Text>
+                  </Box>
+                </HStack>
+              )}
+
+              {msg.role === 'assistant' && (
+                <VStack align="flex-start" gap={2} maxW="85%">
+                  <Box
+                    bg="white"
+                    border="1px solid"
+                    borderColor="gray.200"
+                    px={4}
+                    py={2}
+                    borderRadius="2xl"
+                    borderBottomLeftRadius="sm"
+                  >
+                    <Text fontSize="sm" color="gray.700">{msg.text}</Text>
+                  </Box>
+
+                  {msg.preview && (
+                    <Box
+                      bg="white"
+                      border="1px solid"
+                      borderColor="brand.200"
+                      borderRadius="xl"
+                      p={4}
+                      w="full"
+                      shadow="sm"
+                    >
+                      <Text fontSize="xs" fontWeight="bold" color="gray.500" mb={2} textTransform="uppercase">
+                        Vista previa
+                      </Text>
+                      <VStack gap={1} align="stretch" mb={3}>
+                        <HStack justify="space-between">
+                          <Text fontSize="sm" color="gray.600">Tipo</Text>
+                          <Badge colorPalette={msg.preview.type === 'expense' ? 'red' : 'green'} size="sm">
+                            {msg.preview.type === 'expense' ? 'Gasto' : 'Ingreso'}
+                          </Badge>
+                        </HStack>
+                        <Separator />
+                        <HStack justify="space-between">
+                          <Text fontSize="sm" color="gray.600">Monto</Text>
+                          <Text fontSize="sm" fontWeight="bold">
+                            {new Intl.NumberFormat('es-CO').format(msg.preview.amount)} {msg.preview.currency}
+                          </Text>
+                        </HStack>
+                        <Separator />
+                        <HStack justify="space-between">
+                          <Text fontSize="sm" color="gray.600">Descripción</Text>
+                          <Text fontSize="sm">{msg.preview.description}</Text>
+                        </HStack>
+                        <Separator />
+                        <HStack justify="space-between">
+                          <Text fontSize="sm" color="gray.600">Categoría</Text>
+                          <Text fontSize="sm">{msg.preview.category_name}</Text>
+                        </HStack>
+                        <Separator />
+                        <HStack justify="space-between">
+                          <Text fontSize="sm" color="gray.600">Fecha</Text>
+                          <Text fontSize="sm">{msg.preview.date}</Text>
+                        </HStack>
+                      </VStack>
+                      <HStack gap={2}>
+                        <Button
+                          size="sm"
+                          colorPalette="green"
+                          flex="1"
+                          onClick={() => handleConfirm(msg)}
+                        >
+                          <Icon as={FiCheck} />
+                          Confirmar
+                        </Button>
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          colorPalette="red"
+                          flex="1"
+                          onClick={() => handleDiscard(msg.id)}
+                        >
+                          <Icon as={FiX} />
+                          Descartar
+                        </Button>
+                      </HStack>
+                    </Box>
+                  )}
+                </VStack>
+              )}
+
+              {msg.role === 'system' && (
+                <HStack justify="center">
+                  <Text fontSize="xs" color="gray.400" textAlign="center" maxW="70%">
+                    {msg.text}
+                  </Text>
+                </HStack>
+              )}
+            </Box>
+          ))}
+
+          {loading && (
+            <HStack>
+              <Box bg="white" border="1px solid" borderColor="gray.200" px={4} py={2} borderRadius="2xl">
+                <HStack gap={2}>
+                  <Spinner size="xs" color="brand.500" />
+                  <Text fontSize="sm" color="gray.500">Analizando...</Text>
+                </HStack>
+              </Box>
+            </HStack>
+          )}
+
+          <div ref={bottomRef} />
+        </VStack>
+      </Box>
+
+      {/* Input */}
+      <HStack w="full" p={4} borderTopWidth="1px" borderColor="gray.200" bg="white" gap={2}>
+        <Input
+          placeholder="Escribe tu gasto, ej: &quot;Pagué 80.000 en restaurante&quot;"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          onKeyDown={handleKeyDown}
+          disabled={loading}
+          flex="1"
+          size="md"
+        />
+        <Button
+          colorPalette="brand"
+          onClick={handleSend}
+          disabled={!input.trim() || loading}
+          size="md"
+        >
+          <Icon as={FiSend} />
+        </Button>
+      </HStack>
+    </VStack>
+  )
+}

--- a/components/chat/ChatInterface.tsx
+++ b/components/chat/ChatInterface.tsx
@@ -13,7 +13,7 @@ import {
   Icon,
 } from '@chakra-ui/react'
 import { useState, useRef, useEffect } from 'react'
-import { FiSend, FiCheck, FiX, FiMessageSquare } from 'react-icons/fi'
+import { FiSend, FiCheck, FiX, FiMessageSquare, FiXCircle } from 'react-icons/fi'
 import { categorizePurchase, type CategorizedTransaction } from '@/lib/actions/ai.actions'
 import { createTransaction } from '@/lib/actions/transactions.actions'
 import { toaster } from '@/lib/toaster'
@@ -30,6 +30,7 @@ interface ChatMessage {
 interface Props {
   userId: string
   categories: Category[]
+  onClose?: () => void
 }
 
 const STORAGE_KEY = 'chat-ia-history'
@@ -54,7 +55,7 @@ function saveHistory(messages: ChatMessage[]) {
   }
 }
 
-export function ChatInterface({ userId, categories }: Props) {
+export function ChatInterface({ userId, categories, onClose }: Props) {
   const [messages, setMessages] = useState<ChatMessage[]>([])
   const [input, setInput] = useState('')
   const [loading, setLoading] = useState(false)
@@ -201,9 +202,16 @@ export function ChatInterface({ userId, categories }: Props) {
           <Icon as={FiMessageSquare} color="brand.500" boxSize={5} />
           <Text fontWeight="semibold" color="gray.700">Chat IA</Text>
         </HStack>
-        <Button size="xs" variant="ghost" colorPalette="gray" onClick={handleClearHistory}>
-          Limpiar historial
-        </Button>
+        <HStack gap={1}>
+          <Button size="xs" variant="ghost" colorPalette="gray" onClick={handleClearHistory}>
+            Limpiar
+          </Button>
+          {onClose && (
+            <Button size="xs" variant="ghost" colorPalette="gray" onClick={onClose} aria-label="Cerrar chat">
+              <Icon as={FiXCircle} />
+            </Button>
+          )}
+        </HStack>
       </HStack>
 
       {/* Mensajes */}

--- a/components/chat/FloatingChat.tsx
+++ b/components/chat/FloatingChat.tsx
@@ -1,0 +1,77 @@
+'use client'
+
+import { useState } from 'react'
+import { Box, IconButton, Icon } from '@chakra-ui/react'
+import { AnimatePresence, motion } from 'framer-motion'
+import { BsStars } from 'react-icons/bs'
+import { ChatInterface } from './ChatInterface'
+import type { Category } from '@/types/database.types'
+
+interface Props {
+  userId: string
+  categories: Category[]
+}
+
+const MotionBox = motion.create(Box as React.ComponentType<React.ComponentProps<typeof Box>>)
+
+export function FloatingChat({ userId, categories }: Props) {
+  const [isOpen, setIsOpen] = useState(false)
+
+  return (
+    <>
+      <AnimatePresence>
+        {isOpen && (
+          <MotionBox
+            initial={{ opacity: 0, scale: 0.95, y: 16 }}
+            animate={{ opacity: 1, scale: 1, y: 0 }}
+            exit={{ opacity: 0, scale: 0.95, y: 16 }}
+            transition={{ duration: 0.18, ease: 'easeOut' }}
+            position="fixed"
+            bottom="88px"
+            right="24px"
+            w="380px"
+            h="520px"
+            bg="white"
+            borderRadius="2xl"
+            shadow="2xl"
+            borderWidth="1px"
+            borderColor="gray.200"
+            overflow="hidden"
+            zIndex={1000}
+          >
+            <ChatInterface
+              userId={userId}
+              categories={categories}
+              onClose={() => setIsOpen(false)}
+            />
+          </MotionBox>
+        )}
+      </AnimatePresence>
+
+      {/* Botón flotante */}
+      <Box position="fixed" bottom="24px" right="24px" zIndex={1001}>
+        <IconButton
+          aria-label={isOpen ? 'Cerrar chat IA' : 'Abrir chat IA'}
+          borderRadius="full"
+          w="56px"
+          h="56px"
+          colorPalette="brand"
+          shadow="lg"
+          onClick={() => setIsOpen((prev) => !prev)}
+          css={{
+            background: isOpen
+              ? 'var(--chakra-colors-brand-600)'
+              : 'linear-gradient(135deg, var(--chakra-colors-brand-400), var(--chakra-colors-brand-600))',
+            transition: 'transform 0.2s ease, box-shadow 0.2s ease',
+            _hover: {
+              transform: 'scale(1.08)',
+              boxShadow: '0 8px 24px rgba(0,0,0,0.18)',
+            },
+          }}
+        >
+          <Icon as={BsStars} boxSize={5} color="white" />
+        </IconButton>
+      </Box>
+    </>
+  )
+}

--- a/components/dashboard/Sidebar.tsx
+++ b/components/dashboard/Sidebar.tsx
@@ -8,7 +8,6 @@ import {
   FiDollarSign,
   FiTag,
   FiTrendingUp,
-  FiMessageSquare,
   FiSettings,
 } from 'react-icons/fi'
 import { IconType } from 'react-icons'
@@ -18,7 +17,6 @@ const navItems: { href: string; label: string; icon: IconType }[] = [
   { href: '/transactions', label: 'Transacciones', icon: FiDollarSign },
   { href: '/categories', label: 'Categorías', icon: FiTag },
   { href: '/budgets', label: 'Presupuestos', icon: FiTrendingUp },
-  { href: '/chat', label: 'Chat IA', icon: FiMessageSquare },
   { href: '/settings', label: 'Configuración', icon: FiSettings },
 ]
 

--- a/lib/actions/ai.actions.ts
+++ b/lib/actions/ai.actions.ts
@@ -1,9 +1,10 @@
 'use server'
 
-import { GoogleGenerativeAI } from '@google/generative-ai'
+import Anthropic from '@anthropic-ai/sdk'
 
-const genAI = new GoogleGenerativeAI(process.env.GOOGLE_GENERATIVE_AI_API_KEY!)
-const model = genAI.getGenerativeModel({ model: 'gemini-2.0-flash' })
+const client = new Anthropic({
+  apiKey: process.env.ANTHROPIC_API_KEY,
+})
 
 export interface CategorizedTransaction {
   amount: number
@@ -48,13 +49,18 @@ Extrae la siguiente información y responde ÚNICAMENTE con un JSON válido (sin
   "date": "<fecha en formato YYYY-MM-DD - 'ayer' → día anterior, 'la semana pasada' → lunes anterior, si no se menciona usa la fecha actual>"
 }`
 
-    const result = await model.generateContent(prompt)
-    const responseText = result.response.text().trim()
+    const response = await client.messages.create({
+      model: 'claude-haiku-4-5',
+      max_tokens: 500,
+      messages: [{ role: 'user', content: prompt }],
+    })
 
-    // Gemini a veces envuelve el JSON en bloques de código markdown — los eliminamos
-    const clean = responseText.replace(/^```(?:json)?\n?/, '').replace(/\n?```$/, '')
-    const parsed = JSON.parse(clean) as CategorizedTransaction
+    const textContent = response.content.find((b) => b.type === 'text')
+    if (!textContent || textContent.type !== 'text') {
+      return { success: false, error: 'No se recibió respuesta del modelo' }
+    }
 
+    const parsed = JSON.parse(textContent.text) as CategorizedTransaction
     return { success: true, data: parsed }
   } catch (error) {
     console.error('AI categorization error:', error)

--- a/lib/actions/ai.actions.ts
+++ b/lib/actions/ai.actions.ts
@@ -1,0 +1,72 @@
+'use server'
+
+import Anthropic from '@anthropic-ai/sdk'
+
+const client = new Anthropic({
+  apiKey: process.env.ANTHROPIC_API_KEY,
+})
+
+export interface CategorizedTransaction {
+  amount: number
+  description: string
+  category_id: string
+  type: 'income' | 'expense'
+  currency: 'COP' | 'USD' | 'VES'
+  date: string
+}
+
+export interface CategorizePurchaseResult {
+  success: true
+  data: CategorizedTransaction
+}
+
+export interface CategorizePurchaseError {
+  success: false
+  error: string
+}
+
+export async function categorizePurchase(
+  text: string,
+  categories: { id: string; name: string; type: string }[]
+): Promise<CategorizePurchaseResult | CategorizePurchaseError> {
+  try {
+    const today = new Date().toISOString().split('T')[0]
+
+    const prompt = `El usuario escribió: "${text}"
+
+Categorías disponibles:
+${categories.map((c) => `- ID: ${c.id} | Nombre: ${c.name} | Tipo: ${c.type}`).join('\n')}
+
+Fecha actual: ${today}
+
+Extrae la siguiente información y responde ÚNICAMENTE con un JSON válido (sin markdown, sin explicaciones):
+{
+  "amount": <número positivo>,
+  "description": "<descripción breve y clara del gasto/ingreso>",
+  "category_id": "<id de la categoría más apropiada del listado>",
+  "type": "<'income' o 'expense'>",
+  "currency": "<'COP', 'USD' o 'VES' - detecta según el contexto: 'dólares'/'USD'/'$' → USD, 'bolívares'/'VES'/'Bs' → VES, por defecto COP>",
+  "date": "<fecha en formato YYYY-MM-DD - 'ayer' → día anterior, 'la semana pasada' → lunes anterior, si no se menciona usa la fecha actual>"
+}`
+
+    const response = await client.messages.create({
+      model: 'claude-opus-4-6',
+      max_tokens: 500,
+      messages: [{ role: 'user', content: prompt }],
+    })
+
+    const textContent = response.content.find((b) => b.type === 'text')
+    if (!textContent || textContent.type !== 'text') {
+      return { success: false, error: 'No se recibió respuesta del modelo' }
+    }
+
+    const parsed = JSON.parse(textContent.text) as CategorizedTransaction
+    return { success: true, data: parsed }
+  } catch (error) {
+    console.error('AI categorization error:', error)
+    if (error instanceof SyntaxError) {
+      return { success: false, error: 'El modelo no devolvió un JSON válido' }
+    }
+    return { success: false, error: 'Error al procesar con IA' }
+  }
+}

--- a/lib/actions/ai.actions.ts
+++ b/lib/actions/ai.actions.ts
@@ -1,10 +1,9 @@
 'use server'
 
-import Anthropic from '@anthropic-ai/sdk'
+import { GoogleGenerativeAI } from '@google/generative-ai'
 
-const client = new Anthropic({
-  apiKey: process.env.ANTHROPIC_API_KEY,
-})
+const genAI = new GoogleGenerativeAI(process.env.GOOGLE_GENERATIVE_AI_API_KEY!)
+const model = genAI.getGenerativeModel({ model: 'gemini-2.0-flash' })
 
 export interface CategorizedTransaction {
   amount: number
@@ -49,18 +48,13 @@ Extrae la siguiente información y responde ÚNICAMENTE con un JSON válido (sin
   "date": "<fecha en formato YYYY-MM-DD - 'ayer' → día anterior, 'la semana pasada' → lunes anterior, si no se menciona usa la fecha actual>"
 }`
 
-    const response = await client.messages.create({
-      model: 'claude-opus-4-6',
-      max_tokens: 500,
-      messages: [{ role: 'user', content: prompt }],
-    })
+    const result = await model.generateContent(prompt)
+    const responseText = result.response.text().trim()
 
-    const textContent = response.content.find((b) => b.type === 'text')
-    if (!textContent || textContent.type !== 'text') {
-      return { success: false, error: 'No se recibió respuesta del modelo' }
-    }
+    // Gemini a veces envuelve el JSON en bloques de código markdown — los eliminamos
+    const clean = responseText.replace(/^```(?:json)?\n?/, '').replace(/\n?```$/, '')
+    const parsed = JSON.parse(clean) as CategorizedTransaction
 
-    const parsed = JSON.parse(textContent.text) as CategorizedTransaction
     return { success: true, data: parsed }
   } catch (error) {
     console.error('AI categorization error:', error)

--- a/lib/actions/ai.actions.ts
+++ b/lib/actions/ai.actions.ts
@@ -39,14 +39,23 @@ ${categories.map((c) => `- ID: ${c.id} | Nombre: ${c.name} | Tipo: ${c.type}`).j
 
 Fecha actual: ${today}
 
-Extrae la siguiente información y responde ÚNICAMENTE con un JSON válido (sin markdown, sin explicaciones):
+Responde ÚNICAMENTE con un JSON válido (sin markdown, sin explicaciones).
+
+Si el mensaje describe un gasto o ingreso, responde:
 {
+  "valid": true,
   "amount": <número positivo>,
   "description": "<descripción breve y clara del gasto/ingreso>",
   "category_id": "<id de la categoría más apropiada del listado>",
   "type": "<'income' o 'expense'>",
   "currency": "<'COP', 'USD' o 'VES' - detecta según el contexto: 'dólares'/'USD'/'$' → USD, 'bolívares'/'VES'/'Bs' → VES, por defecto COP>",
   "date": "<fecha en formato YYYY-MM-DD - 'ayer' → día anterior, 'la semana pasada' → lunes anterior, si no se menciona usa la fecha actual>"
+}
+
+Si el mensaje NO describe un gasto ni un ingreso, responde:
+{
+  "valid": false,
+  "message": "<mensaje breve y amigable explicando que solo puedes registrar transacciones>"
 }`
 
     const response = await client.messages.create({
@@ -61,7 +70,12 @@ Extrae la siguiente información y responde ÚNICAMENTE con un JSON válido (sin
     }
 
     const clean = textContent.text.trim().replace(/^```(?:json)?\n?/, '').replace(/\n?```$/, '')
-    const parsed = JSON.parse(clean) as CategorizedTransaction
+    const parsed = JSON.parse(clean) as CategorizedTransaction & { valid: boolean; message?: string }
+
+    if (!parsed.valid) {
+      return { success: false, error: parsed.message ?? 'Solo puedo ayudarte a registrar gastos e ingresos.' }
+    }
+
     return { success: true, data: parsed }
   } catch (error) {
     console.error('AI categorization error:', error)

--- a/lib/actions/ai.actions.ts
+++ b/lib/actions/ai.actions.ts
@@ -60,7 +60,8 @@ Extrae la siguiente información y responde ÚNICAMENTE con un JSON válido (sin
       return { success: false, error: 'No se recibió respuesta del modelo' }
     }
 
-    const parsed = JSON.parse(textContent.text) as CategorizedTransaction
+    const clean = textContent.text.trim().replace(/^```(?:json)?\n?/, '').replace(/\n?```$/, '')
+    const parsed = JSON.parse(clean) as CategorizedTransaction
     return { success: true, data: parsed }
   } catch (error) {
     console.error('AI categorization error:', error)

--- a/package.json
+++ b/package.json
@@ -12,12 +12,12 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@anthropic-ai/sdk": "^0.89.0",
     "@chakra-ui/next-js": "^2.4.2",
     "@chakra-ui/react": "^3.34.0",
     "@emotion/cache": "^11.14.0",
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",
+    "@google/generative-ai": "^0.24.1",
     "@insforge/sdk": "^1.2.4",
     "date-fns": "^4.1.0",
     "framer-motion": "^12.38.0",

--- a/package.json
+++ b/package.json
@@ -12,12 +12,12 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.89.0",
     "@chakra-ui/next-js": "^2.4.2",
     "@chakra-ui/react": "^3.34.0",
     "@emotion/cache": "^11.14.0",
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",
-    "@google/generative-ai": "^0.24.1",
     "@insforge/sdk": "^1.2.4",
     "date-fns": "^4.1.0",
     "framer-motion": "^12.38.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.89.0",
     "@chakra-ui/next-js": "^2.4.2",
     "@chakra-ui/react": "^3.34.0",
     "@emotion/cache": "^11.14.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,6 @@ importers:
 
   .:
     dependencies:
-      '@anthropic-ai/sdk':
-        specifier: ^0.89.0
-        version: 0.89.0(zod@4.3.6)
       '@chakra-ui/next-js':
         specifier: ^2.4.2
         version: 2.4.2(@chakra-ui/react@3.34.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(next@16.2.3(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
@@ -26,6 +23,9 @@ importers:
       '@emotion/styled':
         specifier: ^11.14.1
         version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react@19.2.4)
+      '@google/generative-ai':
+        specifier: ^0.24.1
+        version: 0.24.1
       '@insforge/sdk':
         specifier: ^1.2.4
         version: 1.2.4
@@ -96,15 +96,6 @@ packages:
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
-
-  '@anthropic-ai/sdk@0.89.0':
-    resolution: {integrity: sha512-nyGau0zex62EpU91hsHa0zod973YEoiMgzWZ9hC55WdiOLrE4AGpcg4wXI7lFqtvMLqMcLfewQU9sHgQB6psow==}
-    hasBin: true
-    peerDependencies:
-      zod: ^3.25.0 || ^4.0.0
-    peerDependenciesMeta:
-      zod:
-        optional: true
 
   '@ark-ui/react@5.36.0':
     resolution: {integrity: sha512-LjxQb1XyF3CqRnCoaRwm/eImOjIjAjRmrL3ZMzA1J41Is4KnDpc4Zvh1268LQIaRiX/3voUM0uLsjFxVx8MNQA==}
@@ -307,6 +298,10 @@ packages:
 
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
+
+  '@google/generative-ai@0.24.1':
+    resolution: {integrity: sha512-MqO+MLfM6kjxcKoy0p1wRzG3b4ZZXtPI+z2IE26UogS2Cm/XHO+7gGRBh6gcJsOiIVoH93UwKvW4HdgiOZCy9Q==}
+    engines: {node: '>=18.0.0'}
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -1935,10 +1930,6 @@ packages:
   json-parse-even-better-errors@2.3.1:
     resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
 
-  json-schema-to-ts@3.1.1:
-    resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
-    engines: {node: '>=16'}
-
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
 
@@ -2542,9 +2533,6 @@ packages:
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
 
-  ts-algebra@2.0.0:
-    resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
-
   ts-api-utils@2.5.0:
     resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
     engines: {node: '>=18.12'}
@@ -2699,12 +2687,6 @@ packages:
 snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
-
-  '@anthropic-ai/sdk@0.89.0(zod@4.3.6)':
-    dependencies:
-      json-schema-to-ts: 3.1.1
-    optionalDependencies:
-      zod: 4.3.6
 
   '@ark-ui/react@5.36.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
@@ -3056,6 +3038,8 @@ snapshots:
       '@floating-ui/utils': 0.2.11
 
   '@floating-ui/utils@0.2.11': {}
+
+  '@google/generative-ai@0.24.1': {}
 
   '@humanfs/core@0.19.1': {}
 
@@ -5088,11 +5072,6 @@ snapshots:
 
   json-parse-even-better-errors@2.3.1: {}
 
-  json-schema-to-ts@3.1.1:
-    dependencies:
-      '@babel/runtime': 7.29.2
-      ts-algebra: 2.0.0
-
   json-schema-traverse@0.4.1: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
@@ -5750,8 +5729,6 @@ snapshots:
       is-number: 7.0.0
 
   tr46@0.0.3: {}
-
-  ts-algebra@2.0.0: {}
 
   ts-api-utils@2.5.0(typescript@5.9.3):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@anthropic-ai/sdk':
+        specifier: ^0.89.0
+        version: 0.89.0(zod@4.3.6)
       '@chakra-ui/next-js':
         specifier: ^2.4.2
         version: 2.4.2(@chakra-ui/react@3.34.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(next@16.2.3(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
@@ -93,6 +96,15 @@ packages:
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
+
+  '@anthropic-ai/sdk@0.89.0':
+    resolution: {integrity: sha512-nyGau0zex62EpU91hsHa0zod973YEoiMgzWZ9hC55WdiOLrE4AGpcg4wXI7lFqtvMLqMcLfewQU9sHgQB6psow==}
+    hasBin: true
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
 
   '@ark-ui/react@5.36.0':
     resolution: {integrity: sha512-LjxQb1XyF3CqRnCoaRwm/eImOjIjAjRmrL3ZMzA1J41Is4KnDpc4Zvh1268LQIaRiX/3voUM0uLsjFxVx8MNQA==}
@@ -1923,6 +1935,10 @@ packages:
   json-parse-even-better-errors@2.3.1:
     resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
 
+  json-schema-to-ts@3.1.1:
+    resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
+    engines: {node: '>=16'}
+
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
 
@@ -2526,6 +2542,9 @@ packages:
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
 
+  ts-algebra@2.0.0:
+    resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
+
   ts-api-utils@2.5.0:
     resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
     engines: {node: '>=18.12'}
@@ -2680,6 +2699,12 @@ packages:
 snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
+
+  '@anthropic-ai/sdk@0.89.0(zod@4.3.6)':
+    dependencies:
+      json-schema-to-ts: 3.1.1
+    optionalDependencies:
+      zod: 4.3.6
 
   '@ark-ui/react@5.36.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
@@ -5063,6 +5088,11 @@ snapshots:
 
   json-parse-even-better-errors@2.3.1: {}
 
+  json-schema-to-ts@3.1.1:
+    dependencies:
+      '@babel/runtime': 7.29.2
+      ts-algebra: 2.0.0
+
   json-schema-traverse@0.4.1: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
@@ -5720,6 +5750,8 @@ snapshots:
       is-number: 7.0.0
 
   tr46@0.0.3: {}
+
+  ts-algebra@2.0.0: {}
 
   ts-api-utils@2.5.0(typescript@5.9.3):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@anthropic-ai/sdk':
+        specifier: ^0.89.0
+        version: 0.89.0(zod@4.3.6)
       '@chakra-ui/next-js':
         specifier: ^2.4.2
         version: 2.4.2(@chakra-ui/react@3.34.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(next@16.2.3(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
@@ -23,9 +26,6 @@ importers:
       '@emotion/styled':
         specifier: ^11.14.1
         version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react@19.2.4)
-      '@google/generative-ai':
-        specifier: ^0.24.1
-        version: 0.24.1
       '@insforge/sdk':
         specifier: ^1.2.4
         version: 1.2.4
@@ -96,6 +96,15 @@ packages:
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
+
+  '@anthropic-ai/sdk@0.89.0':
+    resolution: {integrity: sha512-nyGau0zex62EpU91hsHa0zod973YEoiMgzWZ9hC55WdiOLrE4AGpcg4wXI7lFqtvMLqMcLfewQU9sHgQB6psow==}
+    hasBin: true
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
 
   '@ark-ui/react@5.36.0':
     resolution: {integrity: sha512-LjxQb1XyF3CqRnCoaRwm/eImOjIjAjRmrL3ZMzA1J41Is4KnDpc4Zvh1268LQIaRiX/3voUM0uLsjFxVx8MNQA==}
@@ -298,10 +307,6 @@ packages:
 
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
-
-  '@google/generative-ai@0.24.1':
-    resolution: {integrity: sha512-MqO+MLfM6kjxcKoy0p1wRzG3b4ZZXtPI+z2IE26UogS2Cm/XHO+7gGRBh6gcJsOiIVoH93UwKvW4HdgiOZCy9Q==}
-    engines: {node: '>=18.0.0'}
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -1930,6 +1935,10 @@ packages:
   json-parse-even-better-errors@2.3.1:
     resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
 
+  json-schema-to-ts@3.1.1:
+    resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
+    engines: {node: '>=16'}
+
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
 
@@ -2533,6 +2542,9 @@ packages:
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
 
+  ts-algebra@2.0.0:
+    resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
+
   ts-api-utils@2.5.0:
     resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
     engines: {node: '>=18.12'}
@@ -2687,6 +2699,12 @@ packages:
 snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
+
+  '@anthropic-ai/sdk@0.89.0(zod@4.3.6)':
+    dependencies:
+      json-schema-to-ts: 3.1.1
+    optionalDependencies:
+      zod: 4.3.6
 
   '@ark-ui/react@5.36.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
@@ -3038,8 +3056,6 @@ snapshots:
       '@floating-ui/utils': 0.2.11
 
   '@floating-ui/utils@0.2.11': {}
-
-  '@google/generative-ai@0.24.1': {}
 
   '@humanfs/core@0.19.1': {}
 
@@ -5072,6 +5088,11 @@ snapshots:
 
   json-parse-even-better-errors@2.3.1: {}
 
+  json-schema-to-ts@3.1.1:
+    dependencies:
+      '@babel/runtime': 7.29.2
+      ts-algebra: 2.0.0
+
   json-schema-traverse@0.4.1: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
@@ -5729,6 +5750,8 @@ snapshots:
       is-number: 7.0.0
 
   tr46@0.0.3: {}
+
+  ts-algebra@2.0.0: {}
 
   ts-api-utils@2.5.0(typescript@5.9.3):
     dependencies:


### PR DESCRIPTION
## Resumen
Interfaz de chat donde el usuario escribe gastos en lenguaje natural y Claude API los categoriza, extrae y registra automáticamente.

## Tareas Completadas
- [x] 10.1: Server Action para categorización IA (#110) — PR #111
- [x] 10.2: Componente ChatInterface (#112) — PR #113
- [x] 10.3: Página de Chat (#114) — PR #115
- [x] 10.4: Mejoras del prompt (moneda COP/USD/VES, fechas relativas) — en ai.actions.ts
- [x] 10.5: Historial de conversación en localStorage — en ChatInterface.tsx

## Funcionalidades implementadas
- **Server Action** `categorizePurchase` usando `@anthropic-ai/sdk` con Claude Opus 4.6
- Detección automática de moneda: "dólares" → USD, "bolívares" → VES, default COP
- Detección de fechas relativas: "ayer", "la semana pasada"
- Soporte para múltiples gastos via mensajes separados
- **ChatInterface** con historial de conversación visual (burbujas usuario/asistente)
- Preview de transacción con todos los detalles antes de confirmar
- Botones confirmar/descartar por cada transacción detectada
- Persistencia en localStorage (últimos 50 mensajes)
- Botón para limpiar historial
- **Página `/chat`** protegida con autenticación, carga categorías del usuario

## Testing
- ✅ Build exitoso (pnpm build)
- ✅ Sin errores de TypeScript
- ✅ Ruta /chat aparece en build output como dinámica (server-rendered)

## Next Steps
FASE 11 (siguiente fase a definir)

Closes #109