### PR TITLE
feat: replace Chat IA page with floating chat widget

### DIFF
--- a/app/(dashboard)/layout.tsx
+++ b/app/(dashboard)/layout.tsx
@@ -1,12 +1,36 @@
 import { Flex, Box } from '@chakra-ui/react'
+import { getServerSession } from 'next-auth'
+import { authOptions } from '@/lib/auth'
+import { insforgeAdmin } from '@/lib/insforge-admin'
+import { getCategories } from '@/lib/actions/categories.actions'
 import { Header } from '@/components/dashboard/Header'
 import { Sidebar } from '@/components/dashboard/Sidebar'
+import { FloatingChat } from '@/components/chat/FloatingChat'
 
-export default function DashboardLayout({
+export default async function DashboardLayout({
   children,
 }: {
   children: React.ReactNode
 }) {
+  const session = await getServerSession(authOptions)
+
+  let userId: string | null = null
+  let categories: Awaited<ReturnType<typeof getCategories>>['data'] = []
+
+  if (session?.user?.email) {
+    const { data: user } = await insforgeAdmin.database
+      .from('users')
+      .select('id')
+      .eq('email', session.user.email)
+      .single()
+
+    if (user) {
+      userId = user.id
+      const result = await getCategories(user.id)
+      categories = result.success ? result.data : []
+    }
+  }
+
   return (
     <Flex direction="column" h="100vh">
       <Header />
@@ -16,6 +40,9 @@ export default function DashboardLayout({
           {children}
         </Box>
       </Flex>
+      {userId && (
+        <FloatingChat userId={userId} categories={categories ?? []} />
+      )}
     </Flex>
   )
 }

--- a/components/chat/ChatInterface.tsx
+++ b/components/chat/ChatInterface.tsx
@@ -13,7 +13,7 @@ import {
   Icon,
 } from '@chakra-ui/react'
 import { useState, useRef, useEffect } from 'react'
-import { FiSend, FiCheck, FiX, FiMessageSquare } from 'react-icons/fi'
+import { FiSend, FiCheck, FiX, FiMessageSquare, FiXCircle } from 'react-icons/fi'
 import { categorizePurchase, type CategorizedTransaction } from '@/lib/actions/ai.actions'
 import { createTransaction } from '@/lib/actions/transactions.actions'
 import { toaster } from '@/lib/toaster'
@@ -30,6 +30,7 @@ interface ChatMessage {
 interface Props {
   userId: string
   categories: Category[]
+  onClose?: () => void
 }
 
 const STORAGE_KEY = 'chat-ia-history'
@@ -54,7 +55,7 @@ function saveHistory(messages: ChatMessage[]) {
   }
 }
 
-export function ChatInterface({ userId, categories }: Props) {
+export function ChatInterface({ userId, categories, onClose }: Props) {
   const [messages, setMessages] = useState<ChatMessage[]>([])
   const [input, setInput] = useState('')
   const [loading, setLoading] = useState(false)
@@ -201,9 +202,16 @@ export function ChatInterface({ userId, categories }: Props) {
           <Icon as={FiMessageSquare} color="brand.500" boxSize={5} />
           <Text fontWeight="semibold" color="gray.700">Chat IA</Text>
         </HStack>
-        <Button size="xs" variant="ghost" colorPalette="gray" onClick={handleClearHistory}>
-          Limpiar historial
-        </Button>
+        <HStack gap={1}>
+          <Button size="xs" variant="ghost" colorPalette="gray" onClick={handleClearHistory}>
+            Limpiar
+          </Button>
+          {onClose && (
+            <Button size="xs" variant="ghost" colorPalette="gray" onClick={onClose} aria-label="Cerrar chat">
+              <Icon as={FiXCircle} />
+            </Button>
+          )}
+        </HStack>
       </HStack>
 
       {/* Mensajes */}

--- a/components/chat/FloatingChat.tsx
+++ b/components/chat/FloatingChat.tsx
@@ -1,0 +1,77 @@
+'use client'
+
+import { useState } from 'react'
+import { Box, IconButton, Icon } from '@chakra-ui/react'
+import { AnimatePresence, motion } from 'framer-motion'
+import { BsStars } from 'react-icons/bs'
+import { ChatInterface } from './ChatInterface'
+import type { Category } from '@/types/database.types'
+
+interface Props {
+  userId: string
+  categories: Category[]
+}
+
+const MotionBox = motion.create(Box as React.ComponentType<React.ComponentProps<typeof Box>>)
+
+export function FloatingChat({ userId, categories }: Props) {
+  const [isOpen, setIsOpen] = useState(false)
+
+  return (
+    <>
+      <AnimatePresence>
+        {isOpen && (
+          <MotionBox
+            initial={{ opacity: 0, scale: 0.95, y: 16 }}
+            animate={{ opacity: 1, scale: 1, y: 0 }}
+            exit={{ opacity: 0, scale: 0.95, y: 16 }}
+            transition={{ duration: 0.18, ease: 'easeOut' }}
+            position="fixed"
+            bottom="88px"
+            right="24px"
+            w="380px"
+            h="520px"
+            bg="white"
+            borderRadius="2xl"
+            shadow="2xl"
+            borderWidth="1px"
+            borderColor="gray.200"
+            overflow="hidden"
+            zIndex={1000}
+          >
+            <ChatInterface
+              userId={userId}
+              categories={categories}
+              onClose={() => setIsOpen(false)}
+            />
+          </MotionBox>
+        )}
+      </AnimatePresence>
+
+      {/* Botón flotante */}
+      <Box position="fixed" bottom="24px" right="24px" zIndex={1001}>
+        <IconButton
+          aria-label={isOpen ? 'Cerrar chat IA' : 'Abrir chat IA'}
+          borderRadius="full"
+          w="56px"
+          h="56px"
+          colorPalette="brand"
+          shadow="lg"
+          onClick={() => setIsOpen((prev) => !prev)}
+          css={{
+            background: isOpen
+              ? 'var(--chakra-colors-brand-600)'
+              : 'linear-gradient(135deg, var(--chakra-colors-brand-400), var(--chakra-colors-brand-600))',
+            transition: 'transform 0.2s ease, box-shadow 0.2s ease',
+            _hover: {
+              transform: 'scale(1.08)',
+              boxShadow: '0 8px 24px rgba(0,0,0,0.18)',
+            },
+          }}
+        >
+          <Icon as={BsStars} boxSize={5} color="white" />
+        </IconButton>
+      </Box>
+    </>
+  )
+}

--- a/components/dashboard/Sidebar.tsx
+++ b/components/dashboard/Sidebar.tsx
@@ -8,7 +8,6 @@ import {
   FiDollarSign,
   FiTag,
   FiTrendingUp,
-  FiMessageSquare,
   FiSettings,
 } from 'react-icons/fi'
 import { IconType } from 'react-icons'
@@ -18,7 +17,6 @@ const navItems: { href: string; label: string; icon: IconType }[] = [
   { href: '/transactions', label: 'Transacciones', icon: FiDollarSign },
   { href: '/categories', label: 'Categorías', icon: FiTag },
   { href: '/budgets', label: 'Presupuestos', icon: FiTrendingUp },
-  { href: '/chat', label: 'Chat IA', icon: FiMessageSquare },
   { href: '/settings', label: 'Configuración', icon: FiSettings },
 ]
 


### PR DESCRIPTION
## Cambios
- Creado `components/chat/FloatingChat.tsx` con animación framer-motion
- Botón circular con icono `BsStars` (estrellas IA), gradiente brand, posición fija bottom-right
- Panel 380×520px con slide-up animation al abrir
- `ChatInterface` acepta prop `onClose` → muestra botón X en el header
- `layout.tsx` ahora es async, obtiene userId+categories y renderiza FloatingChat
- Removido 'Chat IA' del sidebar (ahora es el widget flotante)

## Testing
- ✅ TypeScript sin errores
- ✅ Build exitoso

Closes #121