### PR TITLE
feat: update account movements with differentiated currencies per account

### DIFF
--- a/components/settings/AccountMovementForm.tsx
+++ b/components/settings/AccountMovementForm.tsx
@@ -6,7 +6,11 @@ import { createAccountMovement } from '@/lib/actions/account_movements.actions'
 import { toaster } from '@/lib/toaster'
 import { FormDialog } from '@/components/ui/FormDialog'
 import { FormInput } from '@/components/ui/FormInput'
-import { CurrencySelect } from '@/components/ui/CurrencySelect'
+const CURRENCY_OPTIONS: { value: string; label: string }[] = [
+  { value: 'COP', label: 'COP - Peso Colombiano' },
+  { value: 'USD', label: 'USD - Dólar' },
+  { value: 'VES', label: 'VES - Bolívar (Bs)' },
+]
 import { PrimaryButton } from '@/components/ui/PrimaryButton'
 import type { Account, Currency } from '@/types/database.types'
 
@@ -20,9 +24,11 @@ interface Props {
 
 const defaultForm = {
   from_account_id: '',
+  from_amount: '',
+  from_currency: 'COP' as Currency,
   to_account_id: '',
-  amount: '',
-  currency: 'COP' as Currency,
+  to_amount: '',
+  to_currency: 'COP' as Currency,
   description: '',
   date: new Date().toISOString().split('T')[0],
 }
@@ -37,9 +43,11 @@ export function AccountMovementForm({ isOpen, onClose, userId, accounts, onSucce
 
     const result = await createAccountMovement(userId, {
       from_account_id: formData.from_account_id,
+      from_amount: parseFloat(formData.from_amount),
+      from_currency: formData.from_currency,
       to_account_id: formData.to_account_id,
-      amount: parseFloat(formData.amount),
-      currency: formData.currency,
+      to_amount: parseFloat(formData.to_amount),
+      to_currency: formData.to_currency,
       description: formData.description || null,
       date: formData.date,
     })
@@ -76,6 +84,30 @@ export function AccountMovementForm({ isOpen, onClose, userId, accounts, onSucce
             </NativeSelectRoot>
           </FieldRoot>
 
+          <FormInput
+            label="Monto enviado"
+            value={formData.from_amount}
+            onChange={(v) => setFormData({ ...formData, from_amount: v })}
+            type="number"
+            step="0.01"
+            min="0.01"
+            required
+          />
+
+          <FieldRoot required>
+            <FieldLabel>Moneda origen</FieldLabel>
+            <NativeSelectRoot>
+              <NativeSelectField
+                value={formData.from_currency}
+                onChange={(e) => setFormData({ ...formData, from_currency: e.target.value as Currency })}
+              >
+                {CURRENCY_OPTIONS.map((c) => (
+                  <option key={c.value} value={c.value}>{c.label}</option>
+                ))}
+              </NativeSelectField>
+            </NativeSelectRoot>
+          </FieldRoot>
+
           <FieldRoot required>
             <FieldLabel>Cuenta destino</FieldLabel>
             <NativeSelectRoot>
@@ -96,27 +128,34 @@ export function AccountMovementForm({ isOpen, onClose, userId, accounts, onSucce
           </FieldRoot>
 
           <FormInput
-            label="Monto"
-            value={formData.amount}
-            onChange={(v) => setFormData({ ...formData, amount: v })}
+            label="Monto recibido"
+            value={formData.to_amount}
+            onChange={(v) => setFormData({ ...formData, to_amount: v })}
             type="number"
             step="0.01"
             min="0.01"
             required
           />
 
-          <CurrencySelect
-            value={formData.currency}
-            onChange={(v) => setFormData({ ...formData, currency: v })}
-            showFullLabel
-            required
-          />
+          <FieldRoot required>
+            <FieldLabel>Moneda destino</FieldLabel>
+            <NativeSelectRoot>
+              <NativeSelectField
+                value={formData.to_currency}
+                onChange={(e) => setFormData({ ...formData, to_currency: e.target.value as Currency })}
+              >
+                {CURRENCY_OPTIONS.map((c) => (
+                  <option key={c.value} value={c.value}>{c.label}</option>
+                ))}
+              </NativeSelectField>
+            </NativeSelectRoot>
+          </FieldRoot>
 
           <FormInput
             label="Descripción (opcional)"
             value={formData.description}
             onChange={(v) => setFormData({ ...formData, description: v })}
-            placeholder="Ej: Transferencia mensual"
+            placeholder="Ej: Cambio de dólares"
           />
 
           <FormInput

--- a/components/settings/AccountsTab.tsx
+++ b/components/settings/AccountsTab.tsx
@@ -93,23 +93,30 @@ export function AccountsTab({ userId, initialAccounts, initialMovements }: Props
     { key: 'date', header: 'Fecha', render: (m) => new Date(m.date).toLocaleDateString('es-CO') },
     {
       key: 'from',
-      header: 'Origen',
+      header: 'Cuenta origen',
       render: (m) => (
         <Text fontSize="sm">{m.from_account?.icon ?? '💳'} {m.from_account?.name ?? '—'}</Text>
       ),
     },
     {
+      key: 'from_amount',
+      header: 'Monto enviado',
+      render: (m) => (
+        <Text fontWeight="semibold">{formatCurrency(m.from_amount, m.from_currency)}</Text>
+      ),
+    },
+    {
       key: 'to',
-      header: 'Destino',
+      header: 'Cuenta destino',
       render: (m) => (
         <Text fontSize="sm">{m.to_account?.icon ?? '💳'} {m.to_account?.name ?? '—'}</Text>
       ),
     },
     {
-      key: 'amount',
-      header: 'Monto',
+      key: 'to_amount',
+      header: 'Monto recibido',
       render: (m) => (
-        <Text fontWeight="semibold">{formatCurrency(m.amount, m.currency)}</Text>
+        <Text fontWeight="semibold">{formatCurrency(m.to_amount, m.to_currency)}</Text>
       ),
     },
     { key: 'description', header: 'Descripción', render: (m) => m.description ?? '—' },

--- a/lib/actions/account_movements.actions.ts
+++ b/lib/actions/account_movements.actions.ts
@@ -41,15 +41,15 @@ export async function createAccountMovement(userId: string, data: CreateAccountM
 
     if (error) throw error
 
-    // Actualizar balances
+    // Actualizar balances con montos diferenciados por moneda
     await Promise.all([
       insforgeAdmin.database.rpc('decrement_account_balance', {
         account_id: validated.from_account_id,
-        amount: validated.amount,
+        amount: validated.from_amount,
       }),
       insforgeAdmin.database.rpc('increment_account_balance', {
         account_id: validated.to_account_id,
-        amount: validated.amount,
+        amount: validated.to_amount,
       }),
     ])
 
@@ -83,15 +83,15 @@ export async function deleteAccountMovement(id: string, userId: string) {
 
     if (error) throw error
 
-    // Revertir balances
+    // Revertir balances con montos diferenciados por moneda
     await Promise.all([
       insforgeAdmin.database.rpc('increment_account_balance', {
         account_id: movement.from_account_id,
-        amount: movement.amount,
+        amount: movement.from_amount,
       }),
       insforgeAdmin.database.rpc('decrement_account_balance', {
         account_id: movement.to_account_id,
-        amount: movement.amount,
+        amount: movement.to_amount,
       }),
     ])
 

--- a/lib/validations/account.ts
+++ b/lib/validations/account.ts
@@ -13,9 +13,11 @@ export const updateAccountSchema = createAccountSchema.partial()
 
 export const createAccountMovementSchema = z.object({
   from_account_id: z.string().uuid(),
+  from_amount: z.number().positive('El monto enviado debe ser mayor a 0'),
+  from_currency: z.enum(['COP', 'USD', 'VES']),
   to_account_id: z.string().uuid(),
-  amount: z.number().positive('El monto debe ser mayor a 0'),
-  currency: z.enum(['COP', 'USD', 'VES']),
+  to_amount: z.number().positive('El monto recibido debe ser mayor a 0'),
+  to_currency: z.enum(['COP', 'USD', 'VES']),
   description: z.string().nullable().optional(),
   date: z.string(),
 })

--- a/types/database.types.ts
+++ b/types/database.types.ts
@@ -50,9 +50,11 @@ export interface AccountMovement {
   id: string
   user_id: string
   from_account_id: string
+  from_amount: number
+  from_currency: Currency
   to_account_id: string
-  amount: number
-  currency: Currency
+  to_amount: number
+  to_currency: Currency
   description: string | null
   date: string
   created_at: string


### PR DESCRIPTION
## Cambios

### Tipos TypeScript (`types/database.types.ts`)
- `AccountMovement`: reemplazados `amount` y `currency` por `from_amount`, `from_currency`, `to_amount`, `to_currency`

### Validaciones (`lib/validations/account.ts`)
- `createAccountMovementSchema`: campos separados por cuenta origen y destino

### Server Actions (`lib/actions/account_movements.actions.ts`)
- `createAccountMovement`: usa `from_amount` para decrementar cuenta origen y `to_amount` para incrementar cuenta destino
- `deleteAccountMovement`: revierte usando los montos correspondientes

### Formulario (`components/settings/AccountMovementForm.tsx`)
- Nuevos campos: monto enviado + moneda origen / monto recibido + moneda destino
- Sin conversión automática — montos manuales

### Tabla (`components/settings/AccountsTab.tsx`)
- Columnas: Fecha | Cuenta origen | Monto enviado | Cuenta destino | Monto recibido | Descripción | Acción

## Testing
- ✅ Build exitoso sin errores TypeScript

Closes #179
Related to #178