### PR TITLE
fix: exchange rates idempotent cron + manual trigger + dashboard counts

### DIFF
--- a/app/(dashboard)/settings/SettingsPageClient.tsx
+++ b/app/(dashboard)/settings/SettingsPageClient.tsx
@@ -4,6 +4,7 @@ import { Box, Heading, VStack, Text, Separator, Tabs } from '@chakra-ui/react'
 import { CurrencySelector } from '@/components/settings/CurrencySelector'
 import { ExchangeRatesForm } from '@/components/settings/ExchangeRatesForm'
 import { AccountsTab } from '@/components/settings/AccountsTab'
+import { CronActionsPanel } from '@/components/settings/CronActionsPanel'
 import type {
   Currency,
   ExchangeRate,
@@ -77,6 +78,18 @@ export function SettingsPageClient({
                 hoy.
               </Text>
               <ExchangeRatesForm initialRates={initialRates} />
+            </Box>
+
+            <Separator />
+
+            <Box>
+              <Text fontWeight="semibold" mb={1} color="white">
+                Mantenimiento
+              </Text>
+              <Text fontSize="sm" color="#B0B0B0" mb={4}>
+                Ejecuta manualmente los procesos automáticos del sistema.
+              </Text>
+              <CronActionsPanel userId={userId} />
             </Box>
           </VStack>
         </Tabs.Content>

--- a/app/api/cron/update-exchange-rates/route.ts
+++ b/app/api/cron/update-exchange-rates/route.ts
@@ -1,65 +1,22 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { insforgeAdmin } from '@/lib/insforge-admin'
+import { updateExchangeRates } from '@/lib/actions/exchangeRates.actions'
 
 export async function GET(req: NextRequest) {
-  const start = new Date().toISOString()
-  console.log(`[cron:update-exchange-rates] start=${start}`)
+  console.log(`[cron:update-exchange-rates] start=${new Date().toISOString()}`)
 
   const authHeader = req.headers.get('authorization')
   const cronSecret = process.env.CRON_SECRET
 
   if (cronSecret && authHeader !== `Bearer ${cronSecret}`) {
-    console.error('[cron:update-exchange-rates] Unauthorized — invalid or missing CRON_SECRET')
+    console.error('[cron:update-exchange-rates] Unauthorized')
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
-  const apiKey = process.env.EXCHANGE_RATE_API_KEY
-  if (!apiKey) {
-    console.error('[cron:update-exchange-rates] EXCHANGE_RATE_API_KEY is not configured')
-    return NextResponse.json({ error: 'Missing EXCHANGE_RATE_API_KEY' }, { status: 500 })
+  const result = await updateExchangeRates()
+
+  if (!result.success) {
+    return NextResponse.json({ error: result.error }, { status: 500 })
   }
 
-  try {
-    const res = await fetch(`https://v6.exchangerate-api.com/v6/${apiKey}/latest/USD`)
-
-    if (!res.ok) {
-      const body = await res.text()
-      console.error(`[cron:update-exchange-rates] exchangerate-api error status=${res.status} body=${body}`)
-      throw new Error(`exchangerate-api responded with ${res.status}`)
-    }
-
-    const json = await res.json()
-    const usdCop: number = json.conversion_rates.COP
-    const usdVes: number = json.conversion_rates.VES
-    console.log(`[cron:update-exchange-rates] fetched rates usdCop=${usdCop} usdVes=${usdVes}`)
-
-    const today = new Date().toISOString().split('T')[0]
-
-    const rates = [
-      { from_currency: 'USD', to_currency: 'COP', rate: usdCop, date: today },
-      { from_currency: 'COP', to_currency: 'USD', rate: 1 / usdCop, date: today },
-      { from_currency: 'USD', to_currency: 'VES', rate: usdVes, date: today },
-      { from_currency: 'VES', to_currency: 'USD', rate: 1 / usdVes, date: today },
-      { from_currency: 'VES', to_currency: 'COP', rate: usdCop / usdVes, date: today },
-      { from_currency: 'COP', to_currency: 'VES', rate: usdVes / usdCop, date: today },
-    ]
-
-    const { error } = await insforgeAdmin.database
-      .from('exchange_rates')
-      .upsert(rates, { onConflict: 'from_currency,to_currency,date' })
-
-    if (error) {
-      console.error('[cron:update-exchange-rates] DB upsert error:', JSON.stringify(error))
-      throw error
-    }
-
-    console.log(`[cron:update-exchange-rates] done upserted=${rates.length} rows date=${today}`)
-    return NextResponse.json({
-      ok: true,
-      rates: { usdCop, usdVes, vesCop: usdCop / usdVes },
-    })
-  } catch (error) {
-    console.error('[cron:update-exchange-rates] unhandled error:', error)
-    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
-  }
+  return NextResponse.json({ ok: true, ...result.data })
 }

--- a/components/dashboard/FinancialCards.tsx
+++ b/components/dashboard/FinancialCards.tsx
@@ -52,12 +52,12 @@ export const FinancialCards = memo(function FinancialCards({
       <StatCard
         label="Gastos"
         value={formatCurrency(summary.totalExpense, preferredCurrency)}
-        helpText={`${summary.transactionCount} transacciones`}
+        helpText={`${summary.expenseCount} transacciones`}
       />
       <StatCard
         label="Ingresos"
         value={formatCurrency(summary.totalIncome, preferredCurrency)}
-        helpText="Este mes"
+        helpText={`${summary.incomeCount} transacciones`}
       />
     </SimpleGrid>
   )

--- a/components/settings/CronActionsPanel.tsx
+++ b/components/settings/CronActionsPanel.tsx
@@ -1,0 +1,120 @@
+'use client'
+
+import { useState } from 'react'
+import { Box, Button, Text, VStack, HStack, Badge } from '@chakra-ui/react'
+import { updateExchangeRates } from '@/lib/actions/exchangeRates.actions'
+import { generateRecurringTransactions } from '@/lib/actions/recurring.actions'
+
+interface Props {
+  userId: string
+}
+
+type ActionStatus = 'idle' | 'loading' | 'success' | 'error'
+
+interface ActionState {
+  status: ActionStatus
+  message: string
+}
+
+export function CronActionsPanel({ userId }: Props) {
+  const [ratesState, setRatesState] = useState<ActionState>({ status: 'idle', message: '' })
+  const [recurringState, setRecurringState] = useState<ActionState>({ status: 'idle', message: '' })
+
+  async function handleUpdateRates() {
+    setRatesState({ status: 'loading', message: '' })
+    const result = await updateExchangeRates()
+    if (result.success && result.data) {
+      const d = result.data as { usdCop: number; usdVes: number; date: string }
+      setRatesState({
+        status: 'success',
+        message: `Tasas actualizadas (${d.date}): USD→COP ${d.usdCop.toFixed(2)}, USD→VES ${d.usdVes.toFixed(2)}`,
+      })
+    } else {
+      setRatesState({ status: 'error', message: result.error ?? 'Error desconocido' })
+    }
+  }
+
+  async function handleGenerateRecurring() {
+    setRecurringState({ status: 'loading', message: '' })
+    const result = await generateRecurringTransactions(userId)
+    if (result.success && result.data) {
+      setRecurringState({
+        status: 'success',
+        message: `${result.data.generated} transacción(es) generada(s)`,
+      })
+    } else {
+      setRecurringState({ status: 'error', message: result.error ?? 'Error desconocido' })
+    }
+  }
+
+  return (
+    <VStack gap={4} align="stretch">
+      <ActionRow
+        label="Tasas de cambio"
+        description="Obtiene las tasas actuales desde exchangerate-api y las guarda en la base de datos."
+        buttonLabel="Actualizar ahora"
+        state={ratesState}
+        onAction={handleUpdateRates}
+      />
+      <ActionRow
+        label="Transacciones recurrentes"
+        description="Genera las transacciones recurrentes pendientes para hoy."
+        buttonLabel="Generar ahora"
+        state={recurringState}
+        onAction={handleGenerateRecurring}
+      />
+    </VStack>
+  )
+}
+
+interface ActionRowProps {
+  label: string
+  description: string
+  buttonLabel: string
+  state: ActionState
+  onAction: () => void
+}
+
+function ActionRow({ label, description, buttonLabel, state, onAction }: ActionRowProps) {
+  return (
+    <Box
+      p={4}
+      borderRadius="md"
+      borderWidth="1px"
+      borderColor="#2d2d35"
+      bg="#1a1a22"
+    >
+      <HStack justify="space-between" align="flex-start" gap={4}>
+        <Box flex={1}>
+          <Text fontWeight="semibold" color="white" mb={1}>
+            {label}
+          </Text>
+          <Text fontSize="sm" color="#B0B0B0">
+            {description}
+          </Text>
+          {state.status !== 'idle' && (
+            <HStack mt={2} gap={2} align="center">
+              {state.status === 'success' && (
+                <Badge colorPalette="green" size="sm">{state.message}</Badge>
+              )}
+              {state.status === 'error' && (
+                <Badge colorPalette="red" size="sm">{state.message}</Badge>
+              )}
+            </HStack>
+          )}
+        </Box>
+        <Button
+          size="sm"
+          variant="outline"
+          colorPalette="brand"
+          loading={state.status === 'loading'}
+          loadingText="Ejecutando..."
+          onClick={onAction}
+          flexShrink={0}
+        >
+          {buttonLabel}
+        </Button>
+      </HStack>
+    </Box>
+  )
+}

--- a/hooks/useFinancialSummary.ts
+++ b/hooks/useFinancialSummary.ts
@@ -9,6 +9,8 @@ interface FinancialSummary {
   balance: number
   currency: Currency
   transactionCount: number
+  incomeCount: number
+  expenseCount: number
 }
 
 export function useFinancialSummary(
@@ -30,21 +32,20 @@ export function useFinancialSummary(
       return rate ? rate.rate : 1
     }
 
-    const income = filtered
-      .filter((t) => t.type === 'income')
-      .reduce(
-        (sum, t) =>
-          sum + Number(t.amount) * getRateMultiplier(t.currency as Currency, preferredCurrency),
-        0
-      )
+    const incomeTransactions = filtered.filter((t) => t.type === 'income')
+    const expenseTransactions = filtered.filter((t) => t.type === 'expense')
 
-    const expense = filtered
-      .filter((t) => t.type === 'expense')
-      .reduce(
-        (sum, t) =>
-          sum + Number(t.amount) * getRateMultiplier(t.currency as Currency, preferredCurrency),
-        0
-      )
+    const income = incomeTransactions.reduce(
+      (sum, t) =>
+        sum + Number(t.amount) * getRateMultiplier(t.currency as Currency, preferredCurrency),
+      0
+    )
+
+    const expense = expenseTransactions.reduce(
+      (sum, t) =>
+        sum + Number(t.amount) * getRateMultiplier(t.currency as Currency, preferredCurrency),
+      0
+    )
 
     return {
       totalIncome: income,
@@ -52,6 +53,8 @@ export function useFinancialSummary(
       balance: income - expense,
       currency: preferredCurrency,
       transactionCount: filtered.length,
+      incomeCount: incomeTransactions.length,
+      expenseCount: expenseTransactions.length,
     }
   }, [transactions, month, preferredCurrency, exchangeRates])
 

--- a/lib/actions/exchangeRates.actions.ts
+++ b/lib/actions/exchangeRates.actions.ts
@@ -3,6 +3,61 @@
 import { insforgeAdmin } from '@/lib/insforge-admin'
 import type { Currency } from '@/types/database.types'
 
+export async function updateExchangeRates() {
+  const apiKey = process.env.EXCHANGE_RATE_API_KEY
+  if (!apiKey) {
+    return { success: false, error: 'EXCHANGE_RATE_API_KEY no configurada' }
+  }
+
+  try {
+    const res = await fetch(`https://v6.exchangerate-api.com/v6/${apiKey}/latest/USD`)
+    if (!res.ok) {
+      const body = await res.text()
+      console.error(`[updateExchangeRates] API error status=${res.status} body=${body}`)
+      return { success: false, error: `exchangerate-api respondió con ${res.status}` }
+    }
+
+    const json = await res.json()
+    const usdCop: number = json.conversion_rates.COP
+    const usdVes: number = json.conversion_rates.VES
+    const today = new Date().toISOString().split('T')[0]
+
+    const rates = [
+      { from_currency: 'USD', to_currency: 'COP', rate: usdCop, date: today },
+      { from_currency: 'COP', to_currency: 'USD', rate: 1 / usdCop, date: today },
+      { from_currency: 'USD', to_currency: 'VES', rate: usdVes, date: today },
+      { from_currency: 'VES', to_currency: 'USD', rate: 1 / usdVes, date: today },
+      { from_currency: 'VES', to_currency: 'COP', rate: usdCop / usdVes, date: today },
+      { from_currency: 'COP', to_currency: 'VES', rate: usdVes / usdCop, date: today },
+    ]
+
+    const { error: deleteError } = await insforgeAdmin.database
+      .from('exchange_rates')
+      .delete()
+      .eq('date', today)
+
+    if (deleteError) {
+      console.error('[updateExchangeRates] delete error:', JSON.stringify(deleteError))
+      return { success: false, error: 'Error al limpiar tasas del día' }
+    }
+
+    const { error: insertError } = await insforgeAdmin.database
+      .from('exchange_rates')
+      .insert(rates)
+
+    if (insertError) {
+      console.error('[updateExchangeRates] insert error:', JSON.stringify(insertError))
+      return { success: false, error: 'Error al guardar tasas' }
+    }
+
+    console.log(`[updateExchangeRates] done date=${today} usdCop=${usdCop} usdVes=${usdVes}`)
+    return { success: true, data: { usdCop, usdVes, vesCop: usdCop / usdVes, date: today } }
+  } catch (error) {
+    console.error('[updateExchangeRates] unhandled error:', error)
+    return { success: false, error: 'Error interno al actualizar tasas' }
+  }
+}
+
 export async function getLatestRates() {
   try {
     const { data, error } = await insforgeAdmin.database

--- a/vercel.json
+++ b/vercel.json
@@ -6,7 +6,7 @@
     },
     {
       "path": "/api/cron/update-exchange-rates",
-      "schedule": "5 15 * * *"
+      "schedule": "0 17 * * *"
     }
   ]
 }


### PR DESCRIPTION
## Cambios

- **Fix cron duplicados**: `updateExchangeRates()` ahora usa delete-then-insert para garantizar exactamente 6 registros por día en `exchange_rates`. Resuelve el bug de 12 registros en lugar de 6.
- **Server action reutilizable**: La lógica de actualización de tasas se extrajo a `lib/actions/exchangeRates.actions.ts` (`updateExchangeRates()`). El route handler del cron la delega, y el botón manual también la llama.
- **Panel de mantenimiento en Settings**: Nuevo componente `CronActionsPanel` con botones para ejecutar manualmente "Actualizar tasas de cambio" y "Generar transacciones recurrentes".
- **Fix dashboard**: `useFinancialSummary` ahora expone `expenseCount` e `incomeCount` separados. `FinancialCards` muestra el conteo correcto en cada card (antes mostraba el total en la card de Gastos y "Este mes" en Ingresos).
- **vercel.json**: Schedule revertido a `0 17 * * *`.

## Testing
- ✅ TypeScript compila sin errores
- [ ] Ir a Settings → verificar sección "Mantenimiento"
- [ ] Clic en "Actualizar ahora" → verificar 6 registros en InsForge `exchange_rates` para hoy
- [ ] Dashboard → verificar que Gastos e Ingresos muestran su conteo individual

Closes #185