### PR TITLE
feat: add optional account field to recurring transactions

### DIFF
--- a/app/(dashboard)/recurring-transactions/page.tsx
+++ b/app/(dashboard)/recurring-transactions/page.tsx
@@ -5,6 +5,7 @@ import { insforgeAdmin } from '@/lib/insforge-admin'
 import { RecurringTransactionsPageContent } from '@/components/recurring/RecurringTransactionsPageContent'
 import { getCategories } from '@/lib/actions/categories.actions'
 import { getRecurringTransactions } from '@/lib/actions/recurring.actions'
+import { getAccounts } from '@/lib/actions/accounts.actions'
 
 export default async function RecurringTransactionsPage() {
   const session = await getServerSession(authOptions)
@@ -24,12 +25,14 @@ export default async function RecurringTransactionsPage() {
     redirect('/login')
   }
 
-  const [categoriesResult, transactionsResult] = await Promise.all([
+  const [categoriesResult, transactionsResult, accountsResult] = await Promise.all([
     getCategories(user.id),
     getRecurringTransactions(user.id),
+    getAccounts(user.id),
   ])
   const categories = categoriesResult.success ? (categoriesResult.data ?? []) : []
   const transactions = transactionsResult.success ? (transactionsResult.data ?? []) : []
+  const accounts = accountsResult.success ? (accountsResult.data ?? []) : []
 
-  return <RecurringTransactionsPageContent userId={user.id} categories={categories} initialTransactions={transactions} />
+  return <RecurringTransactionsPageContent userId={user.id} categories={categories} accounts={accounts} initialTransactions={transactions} />
 }

--- a/components/recurring/RecurringTransactionForm.tsx
+++ b/components/recurring/RecurringTransactionForm.tsx
@@ -10,7 +10,7 @@ import { RadioSelect } from '@/components/ui/RadioSelect'
 import { CurrencySelect } from '@/components/ui/CurrencySelect'
 import { CategorySelect } from '@/components/ui/CategorySelect'
 import { PrimaryButton } from '@/components/ui/PrimaryButton'
-import type { Category, Currency, RecurringTransactionWithCategory } from '@/types/database.types'
+import type { Account, Category, Currency, RecurringTransactionWithCategory } from '@/types/database.types'
 
 const TYPE_OPTIONS = [
   { value: 'expense', label: 'Gasto' },
@@ -22,6 +22,7 @@ interface Props {
   onClose: () => void
   userId: string
   categories: Category[]
+  accounts: Account[]
   onSuccess: () => void
   initialData?: RecurringTransactionWithCategory
   transactionId?: string
@@ -32,6 +33,7 @@ const defaultForm = {
   amount: '',
   currency: 'COP' as Currency,
   category_id: '',
+  account_id: '',
   description: '',
   frequency: 'monthly' as 'daily' | 'weekly' | 'monthly' | 'yearly',
   start_date: new Date().toISOString().split('T')[0],
@@ -43,6 +45,7 @@ export function RecurringTransactionForm({
   onClose,
   userId,
   categories,
+  accounts,
   onSuccess,
   initialData,
   transactionId,
@@ -57,6 +60,7 @@ export function RecurringTransactionForm({
         amount: String(initialData.amount),
         currency: initialData.currency as Currency,
         category_id: initialData.category_id,
+        account_id: initialData.account_id ?? '',
         description: initialData.description,
         frequency: initialData.frequency,
         start_date: initialData.start_date,
@@ -79,6 +83,7 @@ export function RecurringTransactionForm({
       currency: form.currency,
       type: form.type,
       category_id: form.category_id,
+      account_id: form.account_id || null,
       description: form.description,
       frequency: form.frequency,
       start_date: form.start_date,
@@ -151,6 +156,25 @@ export function RecurringTransactionForm({
             placeholder="Ej: Suscripción Netflix"
             required
           />
+
+          {accounts.length > 0 && (
+            <FieldRoot>
+              <FieldLabel>Cuenta asociada <span style={{ color: '#B0B0B0', fontSize: '0.85em' }}>(opcional)</span></FieldLabel>
+              <NativeSelectRoot>
+                <NativeSelectField
+                  value={form.account_id}
+                  onChange={(e) => setForm({ ...form, account_id: e.target.value })}
+                >
+                  <option value="">Sin cuenta</option>
+                  {accounts.map((acc) => (
+                    <option key={acc.id} value={acc.id}>
+                      {acc.name} ({acc.currency})
+                    </option>
+                  ))}
+                </NativeSelectField>
+              </NativeSelectRoot>
+            </FieldRoot>
+          )}
 
           <FieldRoot required>
             <FieldLabel>Frecuencia</FieldLabel>

--- a/components/recurring/RecurringTransactionsPageContent.tsx
+++ b/components/recurring/RecurringTransactionsPageContent.tsx
@@ -6,15 +6,16 @@ import { useRouter } from 'next/navigation'
 import { FiPlus } from 'react-icons/fi'
 import { RecurringTransactionForm } from '@/components/recurring/RecurringTransactionForm'
 import { RecurringTransactionsList } from '@/components/recurring/RecurringTransactionsList'
-import type { Category, RecurringTransactionWithCategory } from '@/types/database.types'
+import type { Account, Category, RecurringTransactionWithCategory } from '@/types/database.types'
 
 interface Props {
   userId: string
   categories: Category[]
+  accounts: Account[]
   initialTransactions: RecurringTransactionWithCategory[]
 }
 
-export function RecurringTransactionsPageContent({ userId, categories, initialTransactions }: Props) {
+export function RecurringTransactionsPageContent({ userId, categories, accounts, initialTransactions }: Props) {
   const [isFormOpen, setIsFormOpen] = useState(false)
   const [editingTransaction, setEditingTransaction] = useState<RecurringTransactionWithCategory | null>(null)
   const router = useRouter()
@@ -39,6 +40,7 @@ export function RecurringTransactionsPageContent({ userId, categories, initialTr
         onClose={handleClose}
         userId={userId}
         categories={categories}
+        accounts={accounts}
         initialData={editingTransaction ?? undefined}
         transactionId={editingTransaction?.id}
         onSuccess={() => {

--- a/lib/actions/recurring.actions.ts
+++ b/lib/actions/recurring.actions.ts
@@ -28,6 +28,7 @@ export async function createRecurringTransaction(
         currency: validated.currency,
         type: validated.type,
         category_id: validated.category_id,
+        account_id: validated.account_id ?? null,
         description: validated.description,
         frequency: validated.frequency,
         start_date: validated.start_date,

--- a/lib/validations/recurring.ts
+++ b/lib/validations/recurring.ts
@@ -5,6 +5,7 @@ export const createRecurringTransactionSchema = z.object({
   currency: z.enum(['COP', 'USD', 'VES']),
   type: z.enum(['income', 'expense']),
   category_id: z.string().uuid(),
+  account_id: z.string().uuid().nullable().optional(),
   description: z.string().min(1, 'Description is required'),
   frequency: z.enum(['daily', 'weekly', 'monthly', 'yearly']),
   start_date: z.string(),

--- a/types/database.types.ts
+++ b/types/database.types.ts
@@ -108,6 +108,7 @@ export interface RecurringTransaction {
   currency: Currency
   type: TransactionType
   category_id: string
+  account_id: string | null
   description: string
   frequency: RecurrenceFrequency
   start_date: string // ISO date


### PR DESCRIPTION
## Cambios

- `RecurringTransaction` type ahora incluye `account_id: string | null`
- Schema de validación acepta `account_id` como UUID opcional
- `createRecurringTransaction` persiste el `account_id` en DB
- Formulario muestra selector de cuenta cuando el usuario tiene cuentas configuradas
- La página carga las cuentas en paralelo y las pasa al formulario

## Testing
- ✅ TypeScript compila sin errores
- [ ] Ir a Gastos Recurrentes → crear nueva → verificar que aparece "Cuenta asociada (opcional)"
- [ ] Seleccionar cuenta → guardar → verificar en InsForge que `account_id` está guardado
- [ ] Editar recurrente existente → verificar que el campo carga correctamente

Closes #187