### PR TITLE
feat: InputAmount component with 1.000,00 format for all money inputs

### DIFF
--- a/components/budgets/BudgetForm.tsx
+++ b/components/budgets/BudgetForm.tsx
@@ -6,6 +6,7 @@ import { createBudget, updateBudget } from '@/lib/actions/budgets.actions'
 import { toaster } from '@/lib/toaster'
 import { FormDialog } from '@/components/ui/FormDialog'
 import { FormInput } from '@/components/ui/FormInput'
+import { InputAmount } from '@/components/ui/InputAmount'
 import { RadioSelect } from '@/components/ui/RadioSelect'
 import { CurrencySelect } from '@/components/ui/CurrencySelect'
 import { CategorySelect } from '@/components/ui/CategorySelect'
@@ -44,7 +45,7 @@ interface Props {
 const defaultForm = {
   type: 'expense' as 'income' | 'expense',
   category_id: '',
-  amount: '',
+  amount: undefined as number | undefined,
   currency: 'COP' as Currency,
   period: 'monthly' as 'monthly' | 'yearly',
   start_date: new Date().toISOString().split('T')[0],
@@ -61,7 +62,7 @@ export function BudgetForm({ isOpen, onClose, userId, categories, onSuccess, edi
         setFormData({
           type: (category?.type || 'expense') as 'income' | 'expense',
           category_id: editingBudget.category_id,
-          amount: String(editingBudget.amount),
+          amount: Number(editingBudget.amount) as number | undefined,
           currency: editingBudget.currency,
           period: editingBudget.period,
           start_date: editingBudget.start_date,
@@ -84,7 +85,7 @@ export function BudgetForm({ isOpen, onClose, userId, categories, onSuccess, edi
 
     const budgetData = {
       category_id: formData.category_id,
-      amount: parseFloat(formData.amount),
+      amount: formData.amount ?? 0,
       currency: formData.currency,
       period: formData.period,
       start_date: formData.start_date,
@@ -134,15 +135,11 @@ export function BudgetForm({ isOpen, onClose, userId, categories, onSuccess, edi
             required
           />
 
-          <FormInput
+          <InputAmount
             label="Monto del Presupuesto"
             value={formData.amount}
             onChange={(v) => setFormData({ ...formData, amount: v })}
-            type="number"
-            min="0"
-            step="0.01"
-            placeholder="0.00"
-            required
+            isRequired
           />
 
           <CurrencySelect

--- a/components/recurring/RecurringTransactionForm.tsx
+++ b/components/recurring/RecurringTransactionForm.tsx
@@ -6,6 +6,7 @@ import { createRecurringTransaction, updateRecurringTransaction } from '@/lib/ac
 import { toaster } from '@/lib/toaster'
 import { FormDialog } from '@/components/ui/FormDialog'
 import { FormInput } from '@/components/ui/FormInput'
+import { InputAmount } from '@/components/ui/InputAmount'
 import { RadioSelect } from '@/components/ui/RadioSelect'
 import { CurrencySelect } from '@/components/ui/CurrencySelect'
 import { CategorySelect } from '@/components/ui/CategorySelect'
@@ -29,7 +30,7 @@ interface Props {
 
 const defaultForm = {
   type: 'expense' as 'income' | 'expense',
-  amount: '',
+  amount: undefined as number | undefined,
   currency: 'COP' as Currency,
   category_id: '',
   description: '',
@@ -54,7 +55,7 @@ export function RecurringTransactionForm({
     if (initialData) {
       setForm({
         type: initialData.type,
-        amount: String(initialData.amount),
+        amount: Number(initialData.amount) as number | undefined,
         currency: initialData.currency as Currency,
         category_id: initialData.category_id,
         description: initialData.description,
@@ -75,7 +76,7 @@ export function RecurringTransactionForm({
 
     setLoading(true)
     const payload = {
-      amount: parseFloat(form.amount as string),
+      amount: form.amount ?? 0,
       currency: form.currency,
       type: form.type,
       category_id: form.category_id,
@@ -121,14 +122,11 @@ export function RecurringTransactionForm({
             required
           />
 
-          <FormInput
+          <InputAmount
             label="Monto"
             value={form.amount}
             onChange={(v) => setForm({ ...form, amount: v })}
-            type="number"
-            placeholder="0.00"
-            step="0.01"
-            required
+            isRequired
           />
 
           <CurrencySelect

--- a/components/savings/SavingsGoalCard.tsx
+++ b/components/savings/SavingsGoalCard.tsx
@@ -1,6 +1,7 @@
 'use client'
 
-import { Box, VStack, HStack, Text, Button, Badge, IconButton, Input } from '@chakra-ui/react'
+import { Box, VStack, HStack, Text, Button, Badge, IconButton } from '@chakra-ui/react'
+import { InputAmount } from '@/components/ui/InputAmount'
 import { FiEdit2, FiTrash2 } from 'react-icons/fi'
 import { useState } from 'react'
 import { useRouter } from 'next/navigation'
@@ -26,7 +27,7 @@ function getStatusBadge(goal: SavingsGoal) {
 export function SavingsGoalCard({ goal, userId, onEdit }: Props) {
   const router = useRouter()
   const [isAddFundsOpen, setIsAddFundsOpen] = useState(false)
-  const [fundsAmount, setFundsAmount] = useState('')
+  const [fundsAmount, setFundsAmount] = useState<number | undefined>(undefined)
   const [loading, setLoading] = useState(false)
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
   const [deleteLoading, setDeleteLoading] = useState(false)
@@ -35,16 +36,16 @@ export function SavingsGoalCard({ goal, userId, onEdit }: Props) {
   const status = getStatusBadge(goal)
 
   const handleAddFunds = async () => {
-    if (!fundsAmount) {
+    if (!fundsAmount || fundsAmount <= 0) {
       toaster.create({ title: 'Por favor ingresa un monto', type: 'error', duration: 3000 })
       return
     }
     setLoading(true)
-    const result = await addFundsToGoal(goal.id, userId, { amount: parseFloat(fundsAmount) })
+    const result = await addFundsToGoal(goal.id, userId, { amount: fundsAmount ?? 0 })
     setLoading(false)
     if (result.success) {
       toaster.create({ title: 'Fondos añadidos', type: 'success', duration: 3000 })
-      setFundsAmount('')
+      setFundsAmount(undefined)
       setIsAddFundsOpen(false)
       router.refresh()
     } else {
@@ -142,16 +143,15 @@ export function SavingsGoalCard({ goal, userId, onEdit }: Props) {
 
       <FormDialog
         isOpen={isAddFundsOpen}
-        onClose={() => { setIsAddFundsOpen(false); setFundsAmount('') }}
+        onClose={() => { setIsAddFundsOpen(false); setFundsAmount(undefined) }}
         title="Añadir Fondos"
       >
         <VStack gap="4">
-          <Input
-            type="number"
-            placeholder="Monto"
+          <InputAmount
+            label="Monto"
             value={fundsAmount}
-            onChange={(e) => setFundsAmount(e.target.value)}
-            step="0.01"
+            onChange={setFundsAmount}
+            isRequired
           />
           <PrimaryButton width="full" loading={loading} onClick={handleAddFunds}>
             Añadir

--- a/components/savings/SavingsGoalForm.tsx
+++ b/components/savings/SavingsGoalForm.tsx
@@ -6,6 +6,7 @@ import { createSavingsGoal, updateSavingsGoal } from '@/lib/actions/savings.acti
 import { toaster } from '@/lib/toaster'
 import { FormDialog } from '@/components/ui/FormDialog'
 import { FormInput } from '@/components/ui/FormInput'
+import { InputAmount } from '@/components/ui/InputAmount'
 import { CurrencySelect } from '@/components/ui/CurrencySelect'
 import { PrimaryButton } from '@/components/ui/PrimaryButton'
 import type { Currency, SavingsGoal } from '@/types/database.types'
@@ -21,7 +22,7 @@ interface Props {
 
 const defaultForm = {
   name: '',
-  target_amount: '',
+  target_amount: undefined as number | undefined,
   currency: 'COP' as Currency,
   deadline: '',
 }
@@ -34,7 +35,7 @@ export function SavingsGoalForm({ isOpen, onClose, userId, onSuccess, initialDat
     if (initialData) {
       setForm({
         name: initialData.name,
-        target_amount: String(initialData.target_amount),
+        target_amount: Number(initialData.target_amount) as number | undefined,
         currency: initialData.currency,
         deadline: initialData.deadline ?? '',
       })
@@ -52,7 +53,7 @@ export function SavingsGoalForm({ isOpen, onClose, userId, onSuccess, initialDat
     setLoading(true)
     const payload = {
       name: form.name,
-      target_amount: parseFloat(form.target_amount),
+      target_amount: form.target_amount ?? 0,
       currency: form.currency,
       deadline: form.deadline || undefined,
     }
@@ -93,14 +94,11 @@ export function SavingsGoalForm({ isOpen, onClose, userId, onSuccess, initialDat
             required
           />
 
-          <FormInput
+          <InputAmount
             label="Monto Objetivo"
             value={form.target_amount}
             onChange={(v) => setForm({ ...form, target_amount: v })}
-            type="number"
-            placeholder="0.00"
-            step="0.01"
-            required
+            isRequired
           />
 
           <CurrencySelect

--- a/components/settings/AccountForm.tsx
+++ b/components/settings/AccountForm.tsx
@@ -6,6 +6,7 @@ import { createAccount, updateAccount } from '@/lib/actions/accounts.actions'
 import { toaster } from '@/lib/toaster'
 import { FormDialog } from '@/components/ui/FormDialog'
 import { FormInput } from '@/components/ui/FormInput'
+import { InputAmount } from '@/components/ui/InputAmount'
 import { RadioSelect } from '@/components/ui/RadioSelect'
 import { CurrencySelect } from '@/components/ui/CurrencySelect'
 import { PrimaryButton } from '@/components/ui/PrimaryButton'
@@ -32,7 +33,7 @@ const defaultForm = {
   name: '',
   type: 'bank' as 'bank' | 'digital' | 'crypto' | 'cash',
   currency: 'COP' as Currency,
-  balance: '0',
+  balance: 0 as number | undefined,
   icon: '💳',
   color: '#6366f1',
 }
@@ -47,7 +48,7 @@ export function AccountForm({ isOpen, onClose, userId, editingAccount, onSuccess
         name: editingAccount.name,
         type: editingAccount.type,
         currency: editingAccount.currency as Currency,
-        balance: String(editingAccount.balance),
+        balance: Number(editingAccount.balance) as number | undefined,
         icon: editingAccount.icon ?? '💳',
         color: editingAccount.color ?? '#6366f1',
       })
@@ -64,7 +65,7 @@ export function AccountForm({ isOpen, onClose, userId, editingAccount, onSuccess
       name: formData.name,
       type: formData.type,
       currency: formData.currency,
-      balance: parseFloat(formData.balance) || 0,
+      balance: formData.balance ?? 0,
       icon: formData.icon || null,
       color: formData.color || null,
     }
@@ -118,13 +119,10 @@ export function AccountForm({ isOpen, onClose, userId, editingAccount, onSuccess
             required
           />
 
-          <FormInput
+          <InputAmount
             label={editingAccount ? 'Balance actual' : 'Balance inicial'}
             value={formData.balance}
             onChange={(v) => setFormData({ ...formData, balance: v })}
-            type="number"
-            step="0.01"
-            min="0"
           />
 
           <HStack gap={4} w="full">

--- a/components/settings/AccountMovementForm.tsx
+++ b/components/settings/AccountMovementForm.tsx
@@ -6,6 +6,7 @@ import { createAccountMovement } from '@/lib/actions/account_movements.actions'
 import { toaster } from '@/lib/toaster'
 import { FormDialog } from '@/components/ui/FormDialog'
 import { FormInput } from '@/components/ui/FormInput'
+import { InputAmount } from '@/components/ui/InputAmount'
 const CURRENCY_OPTIONS: { value: string; label: string }[] = [
   { value: 'COP', label: 'COP - Peso Colombiano' },
   { value: 'USD', label: 'USD - Dólar' },
@@ -24,10 +25,10 @@ interface Props {
 
 const defaultForm = {
   from_account_id: '',
-  from_amount: '',
+  from_amount: undefined as number | undefined,
   from_currency: 'COP' as Currency,
   to_account_id: '',
-  to_amount: '',
+  to_amount: undefined as number | undefined,
   to_currency: 'COP' as Currency,
   description: '',
   date: new Date().toISOString().split('T')[0],
@@ -43,10 +44,10 @@ export function AccountMovementForm({ isOpen, onClose, userId, accounts, onSucce
 
     const result = await createAccountMovement(userId, {
       from_account_id: formData.from_account_id,
-      from_amount: parseFloat(formData.from_amount),
+      from_amount: formData.from_amount ?? 0,
       from_currency: formData.from_currency,
       to_account_id: formData.to_account_id,
-      to_amount: parseFloat(formData.to_amount),
+      to_amount: formData.to_amount ?? 0,
       to_currency: formData.to_currency,
       description: formData.description || null,
       date: formData.date,
@@ -84,14 +85,11 @@ export function AccountMovementForm({ isOpen, onClose, userId, accounts, onSucce
             </NativeSelectRoot>
           </FieldRoot>
 
-          <FormInput
+          <InputAmount
             label="Monto enviado"
             value={formData.from_amount}
             onChange={(v) => setFormData({ ...formData, from_amount: v })}
-            type="number"
-            step="0.01"
-            min="0.01"
-            required
+            isRequired
           />
 
           <FieldRoot required>
@@ -127,14 +125,11 @@ export function AccountMovementForm({ isOpen, onClose, userId, accounts, onSucce
             </NativeSelectRoot>
           </FieldRoot>
 
-          <FormInput
+          <InputAmount
             label="Monto recibido"
             value={formData.to_amount}
             onChange={(v) => setFormData({ ...formData, to_amount: v })}
-            type="number"
-            step="0.01"
-            min="0.01"
-            required
+            isRequired
           />
 
           <FieldRoot required>

--- a/components/transactions/TransactionEditForm.tsx
+++ b/components/transactions/TransactionEditForm.tsx
@@ -6,6 +6,7 @@ import { updateTransaction } from '@/lib/actions/transactions.actions'
 import { toaster } from '@/lib/toaster'
 import { FormDialog } from '@/components/ui/FormDialog'
 import { FormInput } from '@/components/ui/FormInput'
+import { InputAmount } from '@/components/ui/InputAmount'
 import { FormTextarea } from '@/components/ui/FormTextarea'
 import { RadioSelect } from '@/components/ui/RadioSelect'
 import { CurrencySelect } from '@/components/ui/CurrencySelect'
@@ -33,7 +34,7 @@ export function TransactionEditForm({ isOpen, onClose, userId, categories, accou
   const [loading, setLoading] = useState(false)
   const [formData, setFormData] = useState({
     type: transaction.type,
-    amount: String(transaction.amount),
+    amount: Number(transaction.amount) as number | undefined,
     currency: transaction.currency as Currency,
     category_id: transaction.category_id,
     account_id: transaction.account_id ?? '',
@@ -45,7 +46,7 @@ export function TransactionEditForm({ isOpen, onClose, userId, categories, accou
   useEffect(() => {
     setFormData({
       type: transaction.type,
-      amount: String(transaction.amount),
+      amount: Number(transaction.amount) as number | undefined,
       currency: transaction.currency as Currency,
       category_id: transaction.category_id,
       account_id: transaction.account_id ?? '',
@@ -61,7 +62,7 @@ export function TransactionEditForm({ isOpen, onClose, userId, categories, accou
 
     const result = await updateTransaction(transaction.id, userId, {
       ...formData,
-      amount: parseFloat(formData.amount),
+      amount: formData.amount ?? 0,
       account_id: formData.account_id || null,
     })
 
@@ -87,14 +88,11 @@ export function TransactionEditForm({ isOpen, onClose, userId, categories, accou
             required
           />
 
-          <FormInput
+          <InputAmount
             label="Monto"
             value={formData.amount}
             onChange={(v) => setFormData({ ...formData, amount: v })}
-            type="number"
-            step="0.01"
-            min="0.01"
-            required
+            isRequired
           />
 
           <CurrencySelect
@@ -133,7 +131,7 @@ export function TransactionEditForm({ isOpen, onClose, userId, categories, accou
 
           <Box w="full" minH="10">
             <CurrencyPreview
-              amount={parseFloat(formData.amount) || 0}
+              amount={formData.amount ?? 0}
               fromCurrency={formData.currency}
             />
           </Box>

--- a/components/transactions/TransactionForm.tsx
+++ b/components/transactions/TransactionForm.tsx
@@ -6,6 +6,7 @@ import { createTransaction } from '@/lib/actions/transactions.actions'
 import { toaster } from '@/lib/toaster'
 import { FormDialog } from '@/components/ui/FormDialog'
 import { FormInput } from '@/components/ui/FormInput'
+import { InputAmount } from '@/components/ui/InputAmount'
 import { FormTextarea } from '@/components/ui/FormTextarea'
 import { RadioSelect } from '@/components/ui/RadioSelect'
 import { CurrencySelect } from '@/components/ui/CurrencySelect'
@@ -30,7 +31,7 @@ interface Props {
 
 const defaultForm = {
   type: 'expense' as 'income' | 'expense',
-  amount: '',
+  amount: undefined as number | undefined,
   currency: 'COP' as Currency,
   category_id: '',
   account_id: '',
@@ -49,7 +50,7 @@ export function TransactionForm({ isOpen, onClose, userId, categories, accounts 
 
     const result = await createTransaction(userId, {
       ...formData,
-      amount: parseFloat(formData.amount),
+      amount: formData.amount ?? 0,
       account_id: formData.account_id || null,
     })
 
@@ -76,14 +77,11 @@ export function TransactionForm({ isOpen, onClose, userId, categories, accounts 
             required
           />
 
-          <FormInput
+          <InputAmount
             label="Monto"
             value={formData.amount}
             onChange={(v) => setFormData({ ...formData, amount: v })}
-            type="number"
-            step="0.01"
-            min="0.01"
-            required
+            isRequired
           />
 
           <CurrencySelect
@@ -122,7 +120,7 @@ export function TransactionForm({ isOpen, onClose, userId, categories, accounts 
 
           <Box w="full" minH="10">
             <CurrencyPreview
-              amount={parseFloat(formData.amount) || 0}
+              amount={formData.amount ?? 0}
               fromCurrency={formData.currency}
             />
           </Box>

--- a/components/ui/InputAmount.tsx
+++ b/components/ui/InputAmount.tsx
@@ -1,0 +1,87 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { FieldRoot, FieldLabel, FieldErrorText, Input } from '@chakra-ui/react'
+
+interface InputAmountProps {
+  label: string
+  value: number | undefined
+  onChange: (value: number | undefined) => void
+  placeholder?: string
+  isRequired?: boolean
+  isInvalid?: boolean
+  errorMessage?: string
+  isDisabled?: boolean
+}
+
+const formatter = new Intl.NumberFormat('es-CO', {
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+})
+
+function formatAmount(value: number | undefined): string {
+  if (value === undefined || value === 0) return ''
+  return formatter.format(value)
+}
+
+function parseAmount(raw: string): number | undefined {
+  // Remove thousands separators (.) and replace decimal comma with dot
+  const cleaned = raw.replace(/\./g, '').replace(',', '.')
+  const parsed = parseFloat(cleaned)
+  return isNaN(parsed) ? undefined : parsed
+}
+
+export function InputAmount({
+  label,
+  value,
+  onChange,
+  placeholder = '0,00',
+  isRequired,
+  isInvalid,
+  errorMessage,
+  isDisabled,
+}: InputAmountProps) {
+  const [focused, setFocused] = useState(false)
+  const [rawInput, setRawInput] = useState('')
+
+  useEffect(() => {
+    if (!focused) {
+      setRawInput(formatAmount(value))
+    }
+  }, [value, focused])
+
+  function handleFocus() {
+    setFocused(true)
+    // Show raw number for easy editing (comma as decimal)
+    setRawInput(value !== undefined && value !== 0 ? String(value).replace('.', ',') : '')
+  }
+
+  function handleBlur() {
+    setFocused(false)
+    const parsed = parseAmount(rawInput)
+    onChange(parsed)
+    setRawInput(formatAmount(parsed))
+  }
+
+  function handleChange(e: React.ChangeEvent<HTMLInputElement>) {
+    // Allow digits, dot (thousands), comma (decimal), minus
+    const val = e.target.value.replace(/[^0-9.,\-]/g, '')
+    setRawInput(val)
+  }
+
+  return (
+    <FieldRoot required={isRequired} invalid={isInvalid} disabled={isDisabled} width="100%">
+      <FieldLabel>{label}</FieldLabel>
+      <Input
+        type="text"
+        inputMode="decimal"
+        value={focused ? rawInput : formatAmount(value)}
+        onChange={handleChange}
+        onFocus={handleFocus}
+        onBlur={handleBlur}
+        placeholder={placeholder}
+      />
+      {isInvalid && errorMessage && <FieldErrorText>{errorMessage}</FieldErrorText>}
+    </FieldRoot>
+  )
+}


### PR DESCRIPTION
## Cambios

Nuevo componente `components/ui/InputAmount.tsx` con formato es-CO (`1.000,00`):
- Muestra el valor formateado cuando el campo no tiene foco
- Al enfocar muestra el número raw para edición libre
- Al desenfocar parsea, formatea y llama `onChange(number)`
- Elimina todos los `parseFloat()` manuales en los handlers de submit

**Componentes actualizados (9 inputs en 7 archivos):**
- `TransactionForm`, `TransactionEditForm`
- `BudgetForm`, `RecurringTransactionForm`
- `SavingsGoalForm`, `SavingsGoalCard`
- `AccountForm`, `AccountMovementForm` (×2)

## Testing
- ✅ TypeScript compila sin errores
- [ ] Abrir cualquier formulario con monto → tipear `1500000` → perder foco → debe mostrar `1.500.000,00`
- [ ] Submit del formulario funciona con el valor numérico correcto
- [ ] Editar registro existente → monto carga formateado

Closes #189