### PR TITLE
fix: COP symbol and 2 decimal places in currency formatting

### DIFF
--- a/lib/utils/currency.ts
+++ b/lib/utils/currency.ts
@@ -7,14 +7,25 @@ export function formatCurrency(amount: number, currency: string): string {
     }).format(amount)}`
   }
 
+  // COP: use 'COP' prefix instead of the locale '$' symbol
+  if (currency === 'COP') {
+    return `COP ${new Intl.NumberFormat('es-CO', {
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    }).format(amount)}`
+  }
+
   try {
     return new Intl.NumberFormat('es-CO', {
       style: 'currency',
       currency,
-      minimumFractionDigits: 0,
-      maximumFractionDigits: 0,
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
     }).format(amount)
   } catch {
-    return `${currency} ${amount.toLocaleString('es-CO')}`
+    return `${currency} ${amount.toLocaleString('es-CO', {
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    })}`
   }
 }


### PR DESCRIPTION
## Cambios
- Reemplaza símbolo `$` por `COP` para pesos colombianos
- Agrega 2 decimales a todos los montos (1.000.000,00)
- Mantiene formato VES (Bs) y fallback para otras divisas

## Resultado
- Antes: `$ 1.000.000`
- Después: `COP 1.000.000,00`

Closes #199