### PR TITLE
fix: calendar dark theme contrast and amount formatting

### DIFF
--- a/components/calendar/TransactionCalendar.tsx
+++ b/components/calendar/TransactionCalendar.tsx
@@ -22,6 +22,7 @@ import {
 import { FiX } from 'react-icons/fi'
 import { useState } from 'react'
 import type { TransactionWithCategory } from '@/types/database.types'
+import { formatCurrency } from '@/lib/utils/currency'
 
 interface Props {
   userId: string
@@ -119,10 +120,11 @@ export function TransactionCalendar({ initialTransactions }: Props) {
                   borderWidth="1px"
                   borderRadius="md"
                   p="2"
-                  bg={hasTransactions ? 'blue.50' : 'bg.muted'}
+                  bg={hasTransactions ? '#1a1a27' : 'transparent'}
+                  borderColor={hasTransactions ? '#4F46E5' : '#2d2d35'}
                   cursor={hasTransactions ? 'pointer' : 'default'}
                   onClick={() => hasTransactions && handleDayClick(day)}
-                  _hover={hasTransactions ? { bg: 'blue.100' } : {}}
+                  _hover={hasTransactions ? { bg: '#252535' } : { bg: '#1a1a1a' }}
                   transition="background 0.2s"
                 >
                   <VStack alignItems="flex-start" gap="1" height="100%">
@@ -140,7 +142,7 @@ export function TransactionCalendar({ initialTransactions }: Props) {
                             width="100%"
                             justifyContent="flex-start"
                           >
-                            {t.amount.toLocaleString()} {t.currency}
+                            {formatCurrency(Number(t.amount), t.currency)}
                           </Badge>
                         ))}
                         {dayTransactions.length > 2 && (
@@ -194,8 +196,8 @@ export function TransactionCalendar({ initialTransactions }: Props) {
                     >
                       <HStack justifyContent="space-between" mb="1">
                         <Text fontWeight="bold">{txn.description}</Text>
-                        <Text fontWeight="bold" color={txn.type === 'income' ? 'green.600' : 'red.600'}>
-                          {txn.type === 'income' ? '+' : '-'} {txn.amount.toLocaleString()} {txn.currency}
+                        <Text fontWeight="bold" color={txn.type === 'income' ? '#10B981' : '#F43F5E'}>
+                          {txn.type === 'income' ? '+' : '-'}{formatCurrency(Number(txn.amount), txn.currency)}
                         </Text>
                       </HStack>
                       <HStack justifyContent="space-between" fontSize="sm" color="fg.muted">


### PR DESCRIPTION
## Cambios
- Reemplaza colores light (blue.50/blue.100) con colores del tema oscuro
- Días con transacciones: fondo oscuro (#1a1a27) + borde indigo (#4F46E5)
- Usa formatCurrency para montos (COP 50.000,00)
- Colores de monto en dialog mejorados (#10B981 income / #F43F5E expense)

Closes #201