### PR TITLE
fix: reports number formatting, bar chart hover, and default month

### DIFF
--- a/components/ReportFilters.tsx
+++ b/components/ReportFilters.tsx
@@ -27,10 +27,21 @@ interface Props {
   onFilterChange: (filters: ReportFiltersState) => void
 }
 
+function getCurrentMonthRange(): { firstDay: string; lastDay: string } {
+  const now = new Date()
+  const y = now.getFullYear()
+  const m = String(now.getMonth() + 1).padStart(2, '0')
+  const firstDay = `${y}-${m}-01`
+  const last = new Date(y, now.getMonth() + 1, 0)
+  const lastDay = `${last.getFullYear()}-${String(last.getMonth() + 1).padStart(2, '0')}-${String(last.getDate()).padStart(2, '0')}`
+  return { firstDay, lastDay }
+}
+
 export function ReportFilters({ userId, onFilterChange }: Props) {
+  const { firstDay, lastDay } = getCurrentMonthRange()
   const [filters, setFilters] = useState<ReportFiltersState>({
-    startDate: '',
-    endDate: '',
+    startDate: firstDay,
+    endDate: lastDay,
     categoryIds: [],
     transactionType: 'all',
   })
@@ -47,6 +58,12 @@ export function ReportFilters({ userId, onFilterChange }: Props) {
     }
     fetchCategories()
   }, [userId])
+
+  // Notify parent of the initial current-month filter on first render
+  useEffect(() => {
+    onFilterChange(filters)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   const handleTypeChange = (value: string) => {
     const type = value as 'all' | 'income' | 'expense'
@@ -75,9 +92,10 @@ export function ReportFilters({ userId, onFilterChange }: Props) {
   }
 
   const handleReset = () => {
+    const { firstDay, lastDay } = getCurrentMonthRange()
     const newFilters: ReportFiltersState = {
-      startDate: '',
-      endDate: '',
+      startDate: firstDay,
+      endDate: lastDay,
       categoryIds: [],
       transactionType: 'all',
     }

--- a/components/ReportStatistics.tsx
+++ b/components/ReportStatistics.tsx
@@ -5,6 +5,7 @@ import { SimpleGrid, Box, Text, Spinner, Center } from '@chakra-ui/react'
 import { getTransactions } from '@/lib/actions/transactions.actions'
 import type { TransactionWithCategory } from '@/types/database.types'
 import type { ReportFiltersState } from '@/components/ReportFilters'
+import { formatCurrency } from '@/lib/utils/currency'
 
 interface StatCardProps {
   label: string
@@ -100,17 +101,17 @@ export function ReportStatistics({ userId, filters }: Props) {
     <SimpleGrid columns={{ base: 1, md: 3 }} gap={6} mb={8}>
       <StatCard
         label="Ingresos Totales"
-        value={`$${stats.totalIncome.toFixed(2)}`}
+        value={formatCurrency(stats.totalIncome, 'COP')}
         color="#2ECC71"
       />
       <StatCard
         label="Gastos Totales"
-        value={`$${stats.totalExpense.toFixed(2)}`}
+        value={formatCurrency(stats.totalExpense, 'COP')}
         color="#E74C3C"
       />
       <StatCard
         label="Balance Neto"
-        value={`$${stats.netBalance.toFixed(2)}`}
+        value={formatCurrency(Math.abs(stats.netBalance), 'COP')}
         color={stats.netBalance >= 0 ? '#2ECC71' : '#E74C3C'}
       />
     </SimpleGrid>

--- a/components/charts/MonthlyComparisonChart.tsx
+++ b/components/charts/MonthlyComparisonChart.tsx
@@ -16,6 +16,7 @@ import { getTransactions } from '@/lib/actions/transactions.actions'
 import { Card } from '@/components/ui/Card'
 import type { TransactionWithCategory } from '@/types/database.types'
 import type { ReportFiltersState } from '@/components/ReportFilters'
+import { formatCurrency } from '@/lib/utils/currency'
 
 interface ChartDataPoint {
   month: string
@@ -130,12 +131,15 @@ export function MonthlyComparisonChart({ userId, months = 12, filters }: Props) 
             <XAxis dataKey="month" />
             <YAxis />
             <Tooltip
-              formatter={(value) => `$${Number(value).toFixed(2)}`}
+              formatter={(value) => [formatCurrency(Number(value), 'COP'), '']}
               contentStyle={{
-                backgroundColor: '#1a1a1a',
-                border: '1px solid #333',
-                borderRadius: '4px',
+                backgroundColor: '#1a1a23',
+                border: '1px solid #2d2d35',
+                borderRadius: '8px',
+                color: '#ffffff',
               }}
+              labelStyle={{ color: '#B0B0B0' }}
+              cursor={{ fill: 'rgba(255, 255, 255, 0.04)' }}
             />
             <Legend />
             <Bar dataKey="income" fill="#2ECC71" name="Ingresos" />


### PR DESCRIPTION
## Cambios
- ReportStatistics: usa formatCurrency (COP 1.000.000,00 en vez de $1000000.00)
- MonthlyComparisonChart: tooltip con fondo oscuro (#1a1a23), cursor sutil, montos en COP
- ReportFilters: inicializa startDate/endDate al mes actual; el reset también vuelve al mes actual

Closes #203