### PR TITLE
fix: transaction date inputs use local timezone

### DIFF
--- a/components/budgets/BudgetForm.tsx
+++ b/components/budgets/BudgetForm.tsx
@@ -13,6 +13,7 @@ import { CategorySelect } from '@/components/ui/CategorySelect'
 import { PrimaryButton } from '@/components/ui/PrimaryButton'
 import { CancelButton } from '@/components/ui/CancelButton'
 import type { Category, Currency } from '@/types/database.types'
+import { getLocalDateString } from '@/lib/utils/dates'
 
 const TYPE_OPTIONS = [
   { value: 'expense', label: 'Gasto' },
@@ -48,7 +49,7 @@ const defaultForm = {
   amount: undefined as number | undefined,
   currency: 'COP' as Currency,
   period: 'monthly' as 'monthly' | 'yearly',
-  start_date: new Date().toISOString().split('T')[0],
+  start_date: getLocalDateString(),
 }
 
 export function BudgetForm({ isOpen, onClose, userId, categories, onSuccess, editingBudget }: Props) {

--- a/components/calendar/TransactionCalendar.tsx
+++ b/components/calendar/TransactionCalendar.tsx
@@ -23,6 +23,7 @@ import { FiX } from 'react-icons/fi'
 import { useState } from 'react'
 import type { TransactionWithCategory } from '@/types/database.types'
 import { formatCurrency } from '@/lib/utils/currency'
+import { getLocalDateString } from '@/lib/utils/dates'
 
 interface Props {
   userId: string
@@ -46,9 +47,7 @@ export function TransactionCalendar({ initialTransactions }: Props) {
   }
 
   const getTransactionsForDay = (day: number) => {
-    const dateStr = new Date(currentDate.getFullYear(), currentDate.getMonth(), day)
-      .toISOString()
-      .split('T')[0]
+    const dateStr = getLocalDateString(new Date(currentDate.getFullYear(), currentDate.getMonth(), day))
     return transactions.filter(t => t.date === dateStr)
   }
 

--- a/components/recurring/RecurringTransactionForm.tsx
+++ b/components/recurring/RecurringTransactionForm.tsx
@@ -12,6 +12,7 @@ import { CurrencySelect } from '@/components/ui/CurrencySelect'
 import { CategorySelect } from '@/components/ui/CategorySelect'
 import { PrimaryButton } from '@/components/ui/PrimaryButton'
 import type { Account, Category, Currency, RecurringTransactionWithCategory } from '@/types/database.types'
+import { getLocalDateString } from '@/lib/utils/dates'
 
 const TYPE_OPTIONS = [
   { value: 'expense', label: 'Gasto' },
@@ -37,7 +38,7 @@ const defaultForm = {
   account_id: '',
   description: '',
   frequency: 'monthly' as 'daily' | 'weekly' | 'monthly' | 'yearly',
-  start_date: new Date().toISOString().split('T')[0],
+  start_date: getLocalDateString(),
   end_date: '',
 }
 

--- a/components/settings/AccountMovementForm.tsx
+++ b/components/settings/AccountMovementForm.tsx
@@ -14,6 +14,7 @@ const CURRENCY_OPTIONS: { value: string; label: string }[] = [
 ]
 import { PrimaryButton } from '@/components/ui/PrimaryButton'
 import type { Account, Currency } from '@/types/database.types'
+import { getLocalDateString } from '@/lib/utils/dates'
 
 interface Props {
   isOpen: boolean
@@ -31,7 +32,7 @@ const defaultForm = {
   to_amount: undefined as number | undefined,
   to_currency: 'COP' as Currency,
   description: '',
-  date: new Date().toISOString().split('T')[0],
+  date: getLocalDateString(),
 }
 
 export function AccountMovementForm({ isOpen, onClose, userId, accounts, onSuccess }: Props) {

--- a/components/transactions/TransactionForm.tsx
+++ b/components/transactions/TransactionForm.tsx
@@ -14,6 +14,7 @@ import { CategorySelect } from '@/components/ui/CategorySelect'
 import { PrimaryButton } from '@/components/ui/PrimaryButton'
 import { CurrencyPreview } from './CurrencyPreview'
 import type { Account, Category, Currency } from '@/types/database.types'
+import { getLocalDateString } from '@/lib/utils/dates'
 
 const TYPE_OPTIONS = [
   { value: 'expense', label: 'Gasto' },
@@ -36,7 +37,7 @@ const defaultForm = {
   category_id: '',
   account_id: '',
   description: '',
-  date: new Date().toISOString().split('T')[0],
+  date: getLocalDateString(),
   notes: '',
 }
 

--- a/lib/utils/dates.ts
+++ b/lib/utils/dates.ts
@@ -1,0 +1,6 @@
+export function getLocalDateString(date: Date = new Date()): string {
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+  return `${year}-${month}-${day}`
+}


### PR DESCRIPTION
## Problema
new Date().toISOString().split('T')[0] retorna fecha UTC. En Colombia (UTC-5) después de las 7pm retorna el día siguiente.

## Cambios
- Crea helper getLocalDateString() en lib/utils/dates.ts
- Reemplaza toISOString() en: TransactionForm, AccountMovementForm, BudgetForm, RecurringTransactionForm
- Corrige también getTransactionsForDay en TransactionCalendar

Closes #209