### PR TITLE
feat: debts/loans module with create, edit, settle, and delete

### DIFF
--- a/app/(dashboard)/loans/LoansPageClient.tsx
+++ b/app/(dashboard)/loans/LoansPageClient.tsx
@@ -1,0 +1,122 @@
+'use client'
+
+import { Box, Heading, Button, HStack, Text, useDisclosure } from '@chakra-ui/react'
+import { useState, useCallback } from 'react'
+import { useRouter } from 'next/navigation'
+import { FiPlus } from 'react-icons/fi'
+import { Card } from '@/components/ui/Card'
+import { LoanForm } from '@/components/loans/LoanForm'
+import { LoansTable } from '@/components/loans/LoansTable'
+import { deleteLoan, settleLoan } from '@/lib/actions/loans.actions'
+import { toaster } from '@/lib/toaster'
+import type { Account, LoanWithAccount } from '@/types/database.types'
+
+interface Props {
+  userId: string
+  initialLoans: LoanWithAccount[]
+  accounts: Account[]
+}
+
+export function LoansPageClient({ userId, initialLoans, accounts }: Props) {
+  const router = useRouter()
+  const { open: isCreateOpen, onOpen: onCreateOpen, onClose: onCreateClose } = useDisclosure()
+  const { open: isEditOpen, onOpen: onEditOpen, onClose: onEditClose } = useDisclosure()
+  const [editingLoan, setEditingLoan] = useState<LoanWithAccount | null>(null)
+
+  const handleEdit = useCallback((loan: LoanWithAccount) => {
+    setEditingLoan(loan)
+    onEditOpen()
+  }, [onEditOpen])
+
+  const handleSettle = useCallback(async (loan: LoanWithAccount) => {
+    const result = await settleLoan(userId, loan.id)
+    if (result.success) {
+      toaster.create({
+        title: loan.type === 'lent' ? '¡Ya te pagaron! Saldo actualizado.' : '¡Deuda saldada! Saldo actualizado.',
+        type: 'success',
+        duration: 3000,
+      })
+      router.refresh()
+    } else {
+      toaster.create({ title: result.error ?? 'Error al saldar', type: 'error', duration: 4000 })
+    }
+  }, [userId, router])
+
+  const handleDelete = useCallback(async (loan: LoanWithAccount) => {
+    const result = await deleteLoan(userId, loan.id)
+    if (result.success) {
+      toaster.create({ title: 'Préstamo eliminado', type: 'success', duration: 3000 })
+      router.refresh()
+    } else {
+      toaster.create({ title: result.error ?? 'Error al eliminar', type: 'error', duration: 4000 })
+    }
+  }, [userId, router])
+
+  const handleEditClose = useCallback(() => {
+    onEditClose()
+    setEditingLoan(null)
+  }, [onEditClose])
+
+  const activeLoans = initialLoans.filter((l) => l.status === 'active')
+  const settledLoans = initialLoans.filter((l) => l.status === 'settled')
+
+  return (
+    <Box>
+      <HStack justify="space-between" mb={{ base: 4, md: 6 }}>
+        <Heading size={{ base: 'md', md: 'lg' }} color="white">Deudas y Préstamos</Heading>
+        <Button
+          bg="#4F46E5"
+          color="white"
+          _hover={{ bg: '#4338CA' }}
+          onClick={onCreateOpen}
+          size={{ base: 'sm', md: 'md' }}
+        >
+          <FiPlus />
+          <Text display={{ base: 'none', sm: 'inline' }}>Registrar Préstamo</Text>
+          <Text display={{ base: 'inline', sm: 'none' }}>Nuevo</Text>
+        </Button>
+      </HStack>
+
+      <Card mb={6}>
+        <Heading size="sm" mb={4} color="white">Activos</Heading>
+        <LoansTable
+          loans={activeLoans}
+          onEdit={handleEdit}
+          onSettle={handleSettle}
+          onDelete={handleDelete}
+        />
+      </Card>
+
+      {settledLoans.length > 0 && (
+        <Card>
+          <Heading size="sm" mb={4} color="#B0B0B0">Historial — Saldados</Heading>
+          <LoansTable
+            loans={settledLoans}
+            onEdit={handleEdit}
+            onSettle={handleSettle}
+            onDelete={handleDelete}
+          />
+        </Card>
+      )}
+
+      <LoanForm
+        isOpen={isCreateOpen}
+        onClose={onCreateClose}
+        userId={userId}
+        accounts={accounts}
+        onSuccess={() => router.refresh()}
+      />
+
+      {editingLoan && (
+        <LoanForm
+          isOpen={isEditOpen}
+          onClose={handleEditClose}
+          userId={userId}
+          accounts={accounts}
+          loan={editingLoan}
+          onSuccess={() => { router.refresh(); handleEditClose() }}
+        />
+      )}
+    </Box>
+  )
+}

--- a/app/(dashboard)/loans/page.tsx
+++ b/app/(dashboard)/loans/page.tsx
@@ -1,0 +1,38 @@
+import { getServerSession } from 'next-auth'
+import { authOptions } from '@/lib/auth'
+import { redirect } from 'next/navigation'
+import { insforgeAdmin } from '@/lib/insforge-admin'
+import { getLoans } from '@/lib/actions/loans.actions'
+import { getAccounts } from '@/lib/actions/accounts.actions'
+import { LoansPageClient } from './LoansPageClient'
+
+export default async function LoansPage() {
+  const session = await getServerSession(authOptions)
+
+  if (!session?.user?.email) {
+    redirect('/login')
+  }
+
+  const { data: user, error: userError } = await insforgeAdmin.database
+    .from('users')
+    .select('id')
+    .eq('email', session.user.email)
+    .single()
+
+  if (!user?.id || userError) {
+    redirect('/login')
+  }
+
+  const [loansResult, accountsResult] = await Promise.all([
+    getLoans(user.id),
+    getAccounts(user.id),
+  ])
+
+  return (
+    <LoansPageClient
+      userId={user.id}
+      initialLoans={loansResult.success && loansResult.data ? loansResult.data : []}
+      accounts={accountsResult.success && accountsResult.data ? accountsResult.data : []}
+    />
+  )
+}

--- a/components/dashboard/Sidebar.tsx
+++ b/components/dashboard/Sidebar.tsx
@@ -13,6 +13,7 @@ import {
   FiTarget,
   FiCalendar,
   FiDownload,
+  FiCreditCard,
 } from 'react-icons/fi'
 import { IconType } from 'react-icons'
 import { useNavigation } from '@/hooks/useNavigation'
@@ -22,6 +23,7 @@ const navItems: { href: string; label: string; icon: IconType }[] = [
   { href: '/transactions', label: 'Transacciones', icon: FiDollarSign },
   { href: '/recurring-transactions', label: 'Recurrentes', icon: FiRepeat },
   { href: '/savings-goals', label: 'Metas de Ahorro', icon: FiTarget },
+  { href: '/loans', label: 'Préstamos', icon: FiCreditCard },
   { href: '/tags', label: 'Etiquetas', icon: FiTag },
   { href: '/calendar', label: 'Calendario', icon: FiCalendar },
   { href: '/categories', label: 'Categorías', icon: FiTag },

--- a/components/loans/LoanForm.tsx
+++ b/components/loans/LoanForm.tsx
@@ -1,0 +1,129 @@
+'use client'
+
+import { VStack, FieldRoot, FieldLabel, NativeSelectRoot, NativeSelectField } from '@chakra-ui/react'
+import { useState } from 'react'
+import { createLoan, updateLoan } from '@/lib/actions/loans.actions'
+import { toaster } from '@/lib/toaster'
+import { FormDialog } from '@/components/ui/FormDialog'
+import { FormInput } from '@/components/ui/FormInput'
+import { InputAmount } from '@/components/ui/InputAmount'
+import { RadioSelect } from '@/components/ui/RadioSelect'
+import { CurrencySelect } from '@/components/ui/CurrencySelect'
+import { PrimaryButton } from '@/components/ui/PrimaryButton'
+import type { Account, Currency, LoanWithAccount } from '@/types/database.types'
+
+const TYPE_OPTIONS = [
+  { value: 'lent', label: 'Yo presté (me lo deben)' },
+  { value: 'borrowed', label: 'Me prestaron (lo debo)' },
+]
+
+interface Props {
+  isOpen: boolean
+  onClose: () => void
+  userId: string
+  accounts: Account[]
+  onSuccess: () => void
+  loan?: LoanWithAccount
+}
+
+export function LoanForm({ isOpen, onClose, userId, accounts, onSuccess, loan }: Props) {
+  const [loading, setLoading] = useState(false)
+  const [formData, setFormData] = useState({
+    type: (loan?.type ?? 'lent') as 'lent' | 'borrowed',
+    person_name: loan?.person_name ?? '',
+    amount: loan?.amount as number | undefined,
+    currency: (loan?.currency ?? 'COP') as Currency,
+    account_id: loan?.account_id ?? '',
+    notes: loan?.notes ?? '',
+  })
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!formData.amount || formData.amount <= 0) {
+      toaster.create({ title: 'Ingresa un monto válido', type: 'error', duration: 3000 })
+      return
+    }
+    setLoading(true)
+    try {
+      const input = {
+        type: formData.type,
+        person_name: formData.person_name,
+        amount: formData.amount,
+        currency: formData.currency,
+        account_id: formData.account_id || null,
+        notes: formData.notes || null,
+      }
+      const result = loan
+        ? await updateLoan(userId, loan.id, input)
+        : await createLoan(userId, input)
+
+      if (result.success) {
+        toaster.create({ title: loan ? 'Préstamo actualizado' : 'Préstamo registrado', type: 'success', duration: 3000 })
+        onSuccess()
+        onClose()
+      } else {
+        toaster.create({ title: result.error ?? 'Error al guardar', type: 'error', duration: 4000 })
+      }
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <FormDialog isOpen={isOpen} onClose={onClose} title={loan ? 'Editar Préstamo' : 'Registrar Préstamo'}>
+      <form onSubmit={handleSubmit}>
+        <VStack gap={4}>
+          <RadioSelect
+            label="Tipo"
+            options={TYPE_OPTIONS}
+            value={formData.type}
+            onChange={(v) => setFormData((p) => ({ ...p, type: v as 'lent' | 'borrowed' }))}
+          />
+          <FormInput
+            label="Nombre de la persona"
+            placeholder="Ej: Juan Pérez"
+            value={formData.person_name}
+            onChange={(v) => setFormData((p) => ({ ...p, person_name: v }))}
+            required
+          />
+          <InputAmount
+            label="Monto"
+            value={formData.amount}
+            onChange={(v) => setFormData((p) => ({ ...p, amount: v }))}
+          />
+          <CurrencySelect
+            value={formData.currency}
+            onChange={(v) => setFormData((p) => ({ ...p, currency: v }))}
+          />
+          {accounts.length > 0 && (
+            <FieldRoot>
+              <FieldLabel>Cuenta</FieldLabel>
+              <NativeSelectRoot>
+                <NativeSelectField
+                  value={formData.account_id}
+                  onChange={(e) => setFormData((p) => ({ ...p, account_id: e.target.value }))}
+                >
+                  <option value="">Sin cuenta</option>
+                  {accounts.map((a) => (
+                    <option key={a.id} value={a.id}>
+                      {a.icon} {a.name} ({a.currency})
+                    </option>
+                  ))}
+                </NativeSelectField>
+              </NativeSelectRoot>
+            </FieldRoot>
+          )}
+          <FormInput
+            label="Notas (opcional)"
+            placeholder="Motivo del préstamo..."
+            value={formData.notes}
+            onChange={(v) => setFormData((p) => ({ ...p, notes: v }))}
+          />
+          <PrimaryButton type="submit" loading={loading} width="100%">
+            {loan ? 'Guardar Cambios' : 'Registrar Préstamo'}
+          </PrimaryButton>
+        </VStack>
+      </form>
+    </FormDialog>
+  )
+}

--- a/components/loans/LoansTable.tsx
+++ b/components/loans/LoansTable.tsx
@@ -1,0 +1,207 @@
+'use client'
+
+import { useState } from 'react'
+import { Box, VStack, HStack, Text, Badge, Button, IconButton } from '@chakra-ui/react'
+import { FiEdit2, FiTrash2, FiCheckCircle } from 'react-icons/fi'
+import { formatCurrency } from '@/lib/utils/currency'
+import { DataTable, type ColumnDef } from '@/components/ui/DataTable'
+import { ConfirmDialog } from '@/components/ui/ConfirmDialog'
+import type { LoanWithAccount } from '@/types/database.types'
+
+interface Props {
+  loans: LoanWithAccount[]
+  onEdit: (loan: LoanWithAccount) => void
+  onSettle: (loan: LoanWithAccount) => void
+  onDelete: (loan: LoanWithAccount) => void
+}
+
+function settleLabel(loan: LoanWithAccount) {
+  return loan.type === 'lent' ? '¡Ya me pagaron!' : '¡Ya pagué!'
+}
+
+export function LoansTable({ loans, onEdit, onSettle, onDelete }: Props) {
+  const [confirmLoan, setConfirmLoan] = useState<LoanWithAccount | null>(null)
+
+  if (loans.length === 0) {
+    return (
+      <Box py={6} textAlign="center">
+        <Text color="#B0B0B0">No hay registros.</Text>
+      </Box>
+    )
+  }
+
+  const columns: ColumnDef<LoanWithAccount>[] = [
+    {
+      key: 'person_name',
+      header: 'Persona',
+      render: (l) => <Text fontWeight="500">{l.person_name}</Text>,
+    },
+    {
+      key: 'type',
+      header: 'Tipo',
+      render: (l) => (
+        <Badge colorPalette={l.type === 'lent' ? 'blue' : 'orange'}>
+          {l.type === 'lent' ? 'Presté' : 'Me prestaron'}
+        </Badge>
+      ),
+    },
+    {
+      key: 'amount',
+      header: 'Monto',
+      textAlign: 'right',
+      render: (l) => (
+        <Text fontWeight="600" color={l.type === 'lent' ? '#F43F5E' : '#10B981'}>
+          {formatCurrency(Number(l.amount), l.currency)}
+        </Text>
+      ),
+    },
+    {
+      key: 'account',
+      header: 'Cuenta',
+      render: (l) => (
+        <Text color="#B0B0B0" fontSize="sm">
+          {l.account ? `${l.account.icon ?? ''} ${l.account.name}` : '—'}
+        </Text>
+      ),
+    },
+    {
+      key: 'notes',
+      header: 'Notas',
+      render: (l) => (
+        <Text color="#B0B0B0" fontSize="sm">{l.notes ?? '—'}</Text>
+      ),
+    },
+    {
+      key: 'actions',
+      header: 'Acciones',
+      render: (l) => (
+        <HStack gap={1}>
+          {l.status === 'active' && (
+            <>
+              <Button
+                size="xs"
+                bg="#4F46E5"
+                color="white"
+                _hover={{ bg: '#4338CA' }}
+                onClick={() => onSettle(l)}
+                title={settleLabel(l)}
+              >
+                <FiCheckCircle />
+                <Text display={{ base: 'none', lg: 'inline' }} ml={1}>{settleLabel(l)}</Text>
+              </Button>
+              <IconButton
+                aria-label="Editar"
+                size="xs"
+                variant="ghost"
+                onClick={() => onEdit(l)}
+              >
+                <FiEdit2 />
+              </IconButton>
+            </>
+          )}
+          <IconButton
+            aria-label="Eliminar"
+            size="xs"
+            variant="ghost"
+            color="#F43F5E"
+            onClick={() => setConfirmLoan(l)}
+          >
+            <FiTrash2 />
+          </IconButton>
+        </HStack>
+      ),
+    },
+  ]
+
+  return (
+    <>
+      {/* Desktop table */}
+      <Box display={{ base: 'none', md: 'block' }}>
+        <DataTable data={loans} columns={columns} emptyMessage="No hay registros." size="sm" />
+      </Box>
+
+      {/* Mobile cards */}
+      <VStack gap={3} align="stretch" display={{ base: 'flex', md: 'none' }}>
+        {loans.map((loan) => (
+          <Box
+            key={loan.id}
+            bg="#1a1a23"
+            borderRadius="lg"
+            borderWidth="1px"
+            borderColor="#2d2d35"
+            p={4}
+            opacity={loan.status === 'settled' ? 0.6 : 1}
+          >
+            <HStack justify="space-between" mb={2}>
+              <Text fontWeight="600" color="white">{loan.person_name}</Text>
+              <Text fontWeight="700" color={loan.type === 'lent' ? '#F43F5E' : '#10B981'}>
+                {formatCurrency(Number(loan.amount), loan.currency)}
+              </Text>
+            </HStack>
+            <HStack gap={2} mb={3} flexWrap="wrap">
+              <Badge colorPalette={loan.type === 'lent' ? 'blue' : 'orange'} fontSize="xs">
+                {loan.type === 'lent' ? 'Presté' : 'Me prestaron'}
+              </Badge>
+              {loan.account && (
+                <Text fontSize="xs" color="#B0B0B0">
+                  {loan.account.icon ?? ''} {loan.account.name}
+                </Text>
+              )}
+              {loan.notes && (
+                <Text fontSize="xs" color="#808080">{loan.notes}</Text>
+              )}
+            </HStack>
+            <HStack gap={2}>
+              {loan.status === 'active' && (
+                <>
+                  <Button
+                    size="sm"
+                    bg="#4F46E5"
+                    color="white"
+                    _hover={{ bg: '#4338CA' }}
+                    flex={1}
+                    onClick={() => onSettle(loan)}
+                  >
+                    <FiCheckCircle />
+                    {settleLabel(loan)}
+                  </Button>
+                  <IconButton
+                    aria-label="Editar"
+                    size="sm"
+                    variant="outline"
+                    onClick={() => onEdit(loan)}
+                  >
+                    <FiEdit2 />
+                  </IconButton>
+                </>
+              )}
+              <IconButton
+                aria-label="Eliminar"
+                size="sm"
+                variant="ghost"
+                color="#F43F5E"
+                onClick={() => setConfirmLoan(loan)}
+              >
+                <FiTrash2 />
+              </IconButton>
+            </HStack>
+          </Box>
+        ))}
+      </VStack>
+
+      <ConfirmDialog
+        isOpen={confirmLoan !== null}
+        onClose={() => setConfirmLoan(null)}
+        onConfirm={() => {
+          if (confirmLoan) {
+            onDelete(confirmLoan)
+            setConfirmLoan(null)
+          }
+        }}
+        title="Eliminar préstamo"
+        description={`¿Eliminar el préstamo de ${confirmLoan?.person_name ?? ''}? ${confirmLoan?.status === 'active' ? 'El saldo de la cuenta será revertido.' : ''}`}
+        confirmLabel="Eliminar"
+      />
+    </>
+  )
+}

--- a/lib/actions/loans.actions.ts
+++ b/lib/actions/loans.actions.ts
@@ -1,0 +1,159 @@
+'use server'
+
+import { insforgeAdmin } from '@/lib/insforge-admin'
+import { applyBalanceDelta } from '@/lib/utils/balance-updater'
+import { loanSchema, type LoanFormData } from '@/lib/validations/loan'
+import { revalidatePath } from 'next/cache'
+
+export async function getLoans(userId: string) {
+  const { data, error } = await insforgeAdmin.database
+    .from('loans')
+    .select('*, account:accounts(id, name, currency, icon)')
+    .eq('user_id', userId)
+    .order('created_at', { ascending: false })
+
+  if (error) return { success: false, error: error.message }
+  return { success: true, data }
+}
+
+export async function createLoan(userId: string, input: LoanFormData) {
+  const parsed = loanSchema.safeParse(input)
+  if (!parsed.success) return { success: false, error: parsed.error.issues[0].message }
+
+  const { person_name, amount, currency, account_id, type, notes } = parsed.data
+
+  const { data, error } = await insforgeAdmin.database
+    .from('loans')
+    .insert({ user_id: userId, person_name, amount, currency, account_id, type, notes })
+    .select()
+    .single()
+
+  if (error) return { success: false, error: error.message }
+
+  // lent = money leaves my account; borrowed = money enters my account
+  if (account_id) {
+    await applyBalanceDelta(account_id, amount, currency, type === 'lent' ? 'subtract' : 'add')
+  }
+
+  revalidatePath('/loans')
+  revalidatePath('/dashboard')
+  return { success: true, data }
+}
+
+export async function updateLoan(userId: string, loanId: string, input: LoanFormData) {
+  const parsed = loanSchema.safeParse(input)
+  if (!parsed.success) return { success: false, error: parsed.error.issues[0].message }
+
+  const { data: old, error: fetchErr } = await insforgeAdmin.database
+    .from('loans')
+    .select('*')
+    .eq('id', loanId)
+    .eq('user_id', userId)
+    .single()
+
+  if (fetchErr || !old) return { success: false, error: 'Préstamo no encontrado' }
+  if (old.status === 'settled') return { success: false, error: 'No se puede editar un préstamo saldado' }
+
+  // Reverse old balance effect
+  if (old.account_id) {
+    await applyBalanceDelta(
+      old.account_id,
+      old.amount,
+      old.currency,
+      old.type === 'lent' ? 'add' : 'subtract'
+    )
+  }
+
+  const { person_name, amount, currency, account_id, type, notes } = parsed.data
+
+  // Apply new balance effect
+  if (account_id) {
+    await applyBalanceDelta(account_id, amount, currency, type === 'lent' ? 'subtract' : 'add')
+  }
+
+  const { data, error } = await insforgeAdmin.database
+    .from('loans')
+    .update({ person_name, amount, currency, account_id, type, notes, updated_at: new Date().toISOString() })
+    .eq('id', loanId)
+    .eq('user_id', userId)
+    .select()
+    .single()
+
+  if (error) return { success: false, error: error.message }
+
+  revalidatePath('/loans')
+  revalidatePath('/dashboard')
+  return { success: true, data }
+}
+
+export async function deleteLoan(userId: string, loanId: string) {
+  const { data: loan, error: fetchErr } = await insforgeAdmin.database
+    .from('loans')
+    .select('*')
+    .eq('id', loanId)
+    .eq('user_id', userId)
+    .single()
+
+  if (fetchErr || !loan) return { success: false, error: 'Préstamo no encontrado' }
+
+  // Only reverse balance if loan is still active
+  if (loan.status === 'active' && loan.account_id) {
+    await applyBalanceDelta(
+      loan.account_id,
+      loan.amount,
+      loan.currency,
+      loan.type === 'lent' ? 'add' : 'subtract'
+    )
+  }
+
+  const { error } = await insforgeAdmin.database
+    .from('loans')
+    .delete()
+    .eq('id', loanId)
+    .eq('user_id', userId)
+
+  if (error) return { success: false, error: error.message }
+
+  revalidatePath('/loans')
+  revalidatePath('/dashboard')
+  return { success: true }
+}
+
+export async function settleLoan(userId: string, loanId: string) {
+  const { data: loan, error: fetchErr } = await insforgeAdmin.database
+    .from('loans')
+    .select('*')
+    .eq('id', loanId)
+    .eq('user_id', userId)
+    .single()
+
+  if (fetchErr || !loan) return { success: false, error: 'Préstamo no encontrado' }
+  if (loan.status === 'settled') return { success: false, error: 'Ya está saldado' }
+
+  // lent settled = I got paid back → add money back
+  // borrowed settled = I paid back → subtract money
+  if (loan.account_id) {
+    await applyBalanceDelta(
+      loan.account_id,
+      loan.amount,
+      loan.currency,
+      loan.type === 'lent' ? 'add' : 'subtract'
+    )
+  }
+
+  const { error } = await insforgeAdmin.database
+    .from('loans')
+    .update({
+      status: 'settled',
+      settled_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    })
+    .eq('id', loanId)
+    .eq('user_id', userId)
+
+  if (error) return { success: false, error: error.message }
+
+  revalidatePath('/loans')
+  revalidatePath('/dashboard')
+  return { success: true }
+}

--- a/lib/validations/loan.ts
+++ b/lib/validations/loan.ts
@@ -1,0 +1,12 @@
+import { z } from 'zod'
+
+export const loanSchema = z.object({
+  person_name: z.string().min(1, 'El nombre es requerido'),
+  amount: z.number().positive('El monto debe ser mayor a 0'),
+  currency: z.enum(['COP', 'USD', 'VES']),
+  account_id: z.string().uuid().nullable(),
+  type: z.enum(['lent', 'borrowed']),
+  notes: z.string().optional().nullable(),
+})
+
+export type LoanFormData = z.infer<typeof loanSchema>

--- a/types/database.types.ts
+++ b/types/database.types.ts
@@ -155,3 +155,25 @@ export interface TransactionWithTags extends Transaction {
   category: Category
   tags?: Tag[]
 }
+
+export type LoanType = 'lent' | 'borrowed'
+export type LoanStatus = 'active' | 'settled'
+
+export interface Loan {
+  id: string
+  user_id: string
+  person_name: string
+  amount: number
+  currency: Currency
+  account_id: string | null
+  type: LoanType
+  status: LoanStatus
+  notes: string | null
+  created_at: string
+  updated_at: string
+  settled_at: string | null
+}
+
+export interface LoanWithAccount extends Loan {
+  account: Pick<Account, 'id' | 'name' | 'currency' | 'icon'> | null
+}


### PR DESCRIPTION
## Cambios
- Tabla `loans` en Insforge con RLS (migración ejecutada manualmente)
- Server actions: `createLoan`, `updateLoan`, `deleteLoan`, `settleLoan`
- Página `/loans`: tabla desktop (DataTable) + cards mobile
- Botón contextual: ¡Ya me pagaron! / ¡Ya pagué!
- Integración de saldo automática con `applyBalanceDelta`
- Link "Préstamos" en el Sidebar

## Lógica de saldo
- `lent`: crear → saldo baja; saldar → saldo sube
- `borrowed`: crear → saldo sube; saldar → saldo baja

Closes #211