### PR TITLE
feat: mobile nav — 4 primary items + Más drawer with Préstamos

### DIFF
--- a/components/dashboard/BottomNav.tsx
+++ b/components/dashboard/BottomNav.tsx
@@ -5,9 +5,9 @@ import { usePathname } from 'next/navigation'
 import {
   FiHome,
   FiDollarSign,
-  FiRepeat,
   FiTarget,
-  FiTrendingUp,
+  FiRepeat,
+  FiMoreHorizontal,
 } from 'react-icons/fi'
 import { IconType } from 'react-icons'
 import { useNavigation } from '@/hooks/useNavigation'
@@ -17,10 +17,13 @@ const primaryItems: { href: string; label: string; icon: IconType }[] = [
   { href: '/transactions', label: 'Transacciones', icon: FiDollarSign },
   { href: '/savings-goals', label: 'Metas', icon: FiTarget },
   { href: '/recurring-transactions', label: 'Recurrentes', icon: FiRepeat },
-  { href: '/budgets', label: 'Presupuestos', icon: FiTrendingUp },
 ]
 
-export function BottomNav() {
+interface Props {
+  onMoreClick: () => void
+}
+
+export function BottomNav({ onMoreClick }: Props) {
   const pathname = usePathname()
   const { navigate, loadingPath } = useNavigation()
 
@@ -60,16 +63,30 @@ export function BottomNav() {
               onClick={() => navigate(item.href)}
             >
               {isLoading ? <Spinner size="xs" /> : <Icon as={item.icon} boxSize={5} />}
-              <Text
-                fontSize="10px"
-                fontWeight={isActive ? '600' : '400'}
-                lineHeight="1"
-              >
+              <Text fontSize="10px" fontWeight={isActive ? '600' : '400'} lineHeight="1">
                 {item.label}
               </Text>
             </Flex>
           )
         })}
+
+        {/* Más — opens the full drawer */}
+        <Flex
+          flex={1}
+          direction="column"
+          align="center"
+          justify="center"
+          py={2}
+          gap="2px"
+          color="#6b7280"
+          _hover={{ color: '#818cf8' }}
+          transition="color 0.15s ease"
+          cursor="pointer"
+          onClick={onMoreClick}
+        >
+          <Icon as={FiMoreHorizontal} boxSize={5} />
+          <Text fontSize="10px" fontWeight="400" lineHeight="1">Más</Text>
+        </Flex>
       </Flex>
     </Box>
   )

--- a/components/dashboard/DashboardShell.tsx
+++ b/components/dashboard/DashboardShell.tsx
@@ -1,11 +1,15 @@
 'use client'
 
+import { useState } from 'react'
 import { Flex, Box } from '@chakra-ui/react'
 import { Header } from './Header'
 import { Sidebar } from './Sidebar'
 import { BottomNav } from './BottomNav'
+import { MobileNav } from './MobileNav'
 
 export function DashboardShell({ children }: { children: React.ReactNode }) {
+  const [isMobileNavOpen, setIsMobileNavOpen] = useState(false)
+
   return (
     <Flex direction="column" h="100vh" bg="#0f0f13">
       <Header />
@@ -22,7 +26,8 @@ export function DashboardShell({ children }: { children: React.ReactNode }) {
           {children}
         </Box>
       </Flex>
-      <BottomNav />
+      <BottomNav onMoreClick={() => setIsMobileNavOpen(true)} />
+      <MobileNav isOpen={isMobileNavOpen} onClose={() => setIsMobileNavOpen(false)} />
     </Flex>
   )
 }

--- a/components/dashboard/MobileNav.tsx
+++ b/components/dashboard/MobileNav.tsx
@@ -27,6 +27,7 @@ import {
   FiTarget,
   FiCalendar,
   FiDownload,
+  FiCreditCard,
 } from 'react-icons/fi'
 import { IconType } from 'react-icons'
 import { useNavigation } from '@/hooks/useNavigation'
@@ -36,6 +37,7 @@ const navItems: { href: string; label: string; icon: IconType }[] = [
   { href: '/transactions', label: 'Transacciones', icon: FiDollarSign },
   { href: '/recurring-transactions', label: 'Recurrentes', icon: FiRepeat },
   { href: '/savings-goals', label: 'Metas de Ahorro', icon: FiTarget },
+  { href: '/loans', label: 'Préstamos', icon: FiCreditCard },
   { href: '/tags', label: 'Etiquetas', icon: FiTag },
   { href: '/calendar', label: 'Calendario', icon: FiCalendar },
   { href: '/categories', label: 'Categorías', icon: FiTag },


### PR DESCRIPTION
## Cambios
- **BottomNav**: 4 tabs principales (Dashboard, Transacciones, Metas, Recurrentes) + tab "Más" con `FiMoreHorizontal`
- **DashboardShell**: maneja el estado `isMobileNavOpen` y renderiza `MobileNav` (antes no se renderizaba en ningún lugar)
- **MobileNav**: agrega "Préstamos" al drawer con ícono `FiCreditCard`

## Comportamiento
- Tap en "Más" → abre drawer lateral con todos los ítems (incluyendo Préstamos, Presupuestos, Reportes, etc.)
- Tap en cualquier ítem del drawer → navega y cierra el drawer