### PR TITLE
fix: iOS PWA safe areas and MobileNav improvements

### DIFF
--- a/components/dashboard/BottomNav.tsx
+++ b/components/dashboard/BottomNav.tsx
@@ -39,6 +39,7 @@ export function BottomNav({ onMoreClick }: Props) {
       borderTopWidth="1px"
       borderColor="#2d2d35"
       display={{ base: 'block', md: 'none' }}
+      style={{ paddingBottom: 'env(safe-area-inset-bottom)' }}
     >
       <Flex>
         {primaryItems.map((item) => {

--- a/components/dashboard/DashboardShell.tsx
+++ b/components/dashboard/DashboardShell.tsx
@@ -11,7 +11,7 @@ export function DashboardShell({ children }: { children: React.ReactNode }) {
   const [isMobileNavOpen, setIsMobileNavOpen] = useState(false)
 
   return (
-    <Flex direction="column" h="100vh" bg="#0f0f13">
+    <Flex direction="column" h="100dvh" bg="#0f0f13">
       <Header />
       <Flex flex="1" overflow="hidden" bg="#0f0f13">
         <Sidebar />
@@ -20,7 +20,7 @@ export function DashboardShell({ children }: { children: React.ReactNode }) {
           flex="1"
           overflow="auto"
           p={{ base: 4, md: 6, lg: 8 }}
-          pb={{ base: '84px', md: 6, lg: 8 }}
+          pb={{ base: 'calc(84px + env(safe-area-inset-bottom))', md: 6, lg: 8 }}
           bg="#0f0f13"
         >
           {children}

--- a/components/dashboard/Header.tsx
+++ b/components/dashboard/Header.tsx
@@ -34,6 +34,7 @@ export function Header() {
       px={{ base: 4, md: 6 }}
       py={3}
       flexShrink={0}
+      style={{ paddingTop: 'max(12px, env(safe-area-inset-top))' }}
     >
       <Flex justify="space-between" align="center">
         <Flex align="center" gap={2}>

--- a/components/dashboard/MobileNav.tsx
+++ b/components/dashboard/MobileNav.tsx
@@ -6,8 +6,6 @@ import {
   DrawerPositioner,
   DrawerContent,
   DrawerCloseTrigger,
-  DrawerHeader,
-  DrawerTitle,
   DrawerBody,
   VStack,
   Button,
@@ -15,7 +13,6 @@ import {
   Spinner,
 } from '@chakra-ui/react'
 import { usePathname } from 'next/navigation'
-import Image from 'next/image'
 import {
   FiHome,
   FiDollarSign,
@@ -57,17 +54,18 @@ export function MobileNav({ isOpen, onClose }: Props) {
   const { navigate, loadingPath } = useNavigation()
 
   return (
-    <DrawerRoot open={isOpen} onOpenChange={({ open }) => !open && onClose()} placement="start">
+    <DrawerRoot open={isOpen} onOpenChange={({ open }) => !open && onClose()} placement="end">
       <DrawerBackdrop />
       <DrawerPositioner>
-        <DrawerContent bg="#18181d" borderRightWidth="1px" borderColor="#2d2d35" maxW="72">
-          <DrawerHeader borderBottomWidth="1px" borderColor="#2d2d35" py={4} px={4}>
-            <DrawerTitle>
-              <Image src="/brand/money-manager.png" alt="GitPush Money" width={110} height={60} style={{ objectFit: 'contain' }} />
-            </DrawerTitle>
-          </DrawerHeader>
-          <DrawerCloseTrigger color="white" top={3} right={3} />
-          <DrawerBody px={3} py={4}>
+        <DrawerContent
+          bg="#18181d"
+          borderLeftWidth="1px"
+          borderColor="#2d2d35"
+          maxW="72"
+          style={{ paddingTop: 'env(safe-area-inset-top)', paddingBottom: 'env(safe-area-inset-bottom)' }}
+        >
+          <DrawerCloseTrigger color="white" top={3} left={3} />
+          <DrawerBody px={3} pt={12} pb={4}>
             <VStack gap={1} align="stretch">
               {navItems.map((item) => {
                 const isActive = pathname === item.href


### PR DESCRIPTION
## Problema
En iOS como PWA instalada, el header chocaba con la barra de estado y el BottomNav chocaba con el home indicator.

## Cambios
- **Header**: `padding-top: max(12px, env(safe-area-inset-top))` — contenido respeta la barra de estado iOS
- **BottomNav**: `padding-bottom: env(safe-area-inset-bottom)` — tabs no quedan tapadas por el home indicator
- **DashboardShell**: `h=100dvh` (dynamic viewport height) + `pb` del main incluye `safe-area-inset-bottom` en mobile
- **MobileNav**: `placement="end"` (se abre desde la derecha), sin header con logo, con safe areas propias