### PR TITLE
feat: /movimientos con tabs — Transacciones, Recurrentes y Préstamos

### DIFF
--- a/app/(dashboard)/loans/page.tsx
+++ b/app/(dashboard)/loans/page.tsx
@@ -1,38 +1,5 @@
-import { getServerSession } from 'next-auth'
-import { authOptions } from '@/lib/auth'
 import { redirect } from 'next/navigation'
-import { insforgeAdmin } from '@/lib/insforge-admin'
-import { getLoans } from '@/lib/actions/loans.actions'
-import { getAccounts } from '@/lib/actions/accounts.actions'
-import { LoansPageClient } from './LoansPageClient'
 
-export default async function LoansPage() {
-  const session = await getServerSession(authOptions)
-
-  if (!session?.user?.email) {
-    redirect('/login')
-  }
-
-  const { data: user, error: userError } = await insforgeAdmin.database
-    .from('users')
-    .select('id')
-    .eq('email', session.user.email)
-    .single()
-
-  if (!user?.id || userError) {
-    redirect('/login')
-  }
-
-  const [loansResult, accountsResult] = await Promise.all([
-    getLoans(user.id),
-    getAccounts(user.id),
-  ])
-
-  return (
-    <LoansPageClient
-      userId={user.id}
-      initialLoans={loansResult.success && loansResult.data ? loansResult.data : []}
-      accounts={accountsResult.success && accountsResult.data ? accountsResult.data : []}
-    />
-  )
+export default function LoansPage() {
+  redirect('/movimientos?tab=prestamos')
 }

--- a/app/(dashboard)/movimientos/MovimientosPageClient.tsx
+++ b/app/(dashboard)/movimientos/MovimientosPageClient.tsx
@@ -1,0 +1,112 @@
+'use client'
+
+import { Box, Heading, Tabs } from '@chakra-ui/react'
+import { useRouter } from 'next/navigation'
+import { TransactionsPageClient } from '../transactions/TransactionsPageClient'
+import { RecurringTransactionsPageContent } from '@/components/recurring/RecurringTransactionsPageContent'
+import { LoansPageClient } from '../loans/LoansPageClient'
+import type {
+  Account,
+  Category,
+  TransactionWithCategory,
+  LoanWithAccount,
+  RecurringTransactionWithCategory,
+} from '@/types/database.types'
+
+type Tab = 'transacciones' | 'recurrentes' | 'prestamos'
+
+interface Props {
+  userId: string
+  activeTab: Tab
+  categories: Category[]
+  accounts: Account[]
+  initialTransactions: TransactionWithCategory[] | null
+  initialRecurring: RecurringTransactionWithCategory[] | null
+  initialLoans: LoanWithAccount[] | null
+}
+
+export function MovimientosPageClient({
+  userId,
+  activeTab,
+  categories,
+  accounts,
+  initialTransactions,
+  initialRecurring,
+  initialLoans,
+}: Props) {
+  const router = useRouter()
+
+  const handleTabChange = (tab: string) => {
+    router.push(`/movimientos?tab=${tab}`)
+  }
+
+  return (
+    <Box p={{ base: 4, md: 6 }}>
+      <Heading size="lg" mb={6} color="white">
+        Movimientos
+      </Heading>
+
+      <Tabs.Root
+        value={activeTab}
+        onValueChange={({ value }) => handleTabChange(value)}
+        colorPalette="brand"
+      >
+        <Tabs.List mb={6} borderBottomWidth="1px" borderColor="#2d2d35">
+          <Tabs.Trigger
+            value="transacciones"
+            color="#B0B0B0"
+            _selected={{ color: 'white', borderBottomColor: '#6366f1' }}
+          >
+            Transacciones
+          </Tabs.Trigger>
+          <Tabs.Trigger
+            value="recurrentes"
+            color="#B0B0B0"
+            _selected={{ color: 'white', borderBottomColor: '#6366f1' }}
+          >
+            Recurrentes
+          </Tabs.Trigger>
+          <Tabs.Trigger
+            value="prestamos"
+            color="#B0B0B0"
+            _selected={{ color: 'white', borderBottomColor: '#6366f1' }}
+          >
+            Préstamos
+          </Tabs.Trigger>
+        </Tabs.List>
+
+        <Tabs.Content value="transacciones">
+          {initialTransactions !== null && (
+            <TransactionsPageClient
+              userId={userId}
+              categories={categories}
+              initialTransactions={initialTransactions}
+              accounts={accounts}
+            />
+          )}
+        </Tabs.Content>
+
+        <Tabs.Content value="recurrentes">
+          {initialRecurring !== null && (
+            <RecurringTransactionsPageContent
+              userId={userId}
+              categories={categories}
+              accounts={accounts}
+              initialTransactions={initialRecurring}
+            />
+          )}
+        </Tabs.Content>
+
+        <Tabs.Content value="prestamos">
+          {initialLoans !== null && (
+            <LoansPageClient
+              userId={userId}
+              initialLoans={initialLoans}
+              accounts={accounts}
+            />
+          )}
+        </Tabs.Content>
+      </Tabs.Root>
+    </Box>
+  )
+}

--- a/app/(dashboard)/movimientos/page.tsx
+++ b/app/(dashboard)/movimientos/page.tsx
@@ -1,0 +1,74 @@
+import { getServerSession } from 'next-auth'
+import { authOptions } from '@/lib/auth'
+import { redirect } from 'next/navigation'
+import { insforgeAdmin } from '@/lib/insforge-admin'
+import { getCategories } from '@/lib/actions/categories.actions'
+import { getAccounts } from '@/lib/actions/accounts.actions'
+import { getTransactions } from '@/lib/actions/transactions.actions'
+import { getRecurringTransactions } from '@/lib/actions/recurring.actions'
+import { getLoans } from '@/lib/actions/loans.actions'
+import { MovimientosPageClient } from './MovimientosPageClient'
+import type { TransactionWithCategory, Account } from '@/types/database.types'
+
+type Tab = 'transacciones' | 'recurrentes' | 'prestamos'
+
+export default async function MovimientosPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ tab?: string }>
+}) {
+  const session = await getServerSession(authOptions)
+
+  if (!session?.user?.email) {
+    redirect('/login')
+  }
+
+  const { data: user, error: userError } = await insforgeAdmin.database
+    .from('users')
+    .select('id')
+    .eq('email', session.user.email)
+    .single()
+
+  if (!user?.id || userError) {
+    redirect('/login')
+  }
+
+  const params = await searchParams
+  const tab = (params.tab as Tab) || 'transacciones'
+
+  const [categoriesResult, accountsResult] = await Promise.all([
+    getCategories(user.id),
+    getAccounts(user.id),
+  ])
+  const categories = categoriesResult.success ? (categoriesResult.data ?? []) : []
+  const accounts = (accountsResult.success ? accountsResult.data : []) as Account[]
+
+  let initialTransactions: TransactionWithCategory[] | null = null
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let initialRecurring: any[] | null = null
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let initialLoans: any[] | null = null
+
+  if (tab === 'transacciones') {
+    const result = await getTransactions(user.id, 500)
+    initialTransactions = result.success ? ((result.data ?? []) as TransactionWithCategory[]) : []
+  } else if (tab === 'recurrentes') {
+    const result = await getRecurringTransactions(user.id)
+    initialRecurring = result.success ? (result.data ?? []) : []
+  } else if (tab === 'prestamos') {
+    const result = await getLoans(user.id)
+    initialLoans = result.success && result.data ? result.data : []
+  }
+
+  return (
+    <MovimientosPageClient
+      userId={user.id}
+      activeTab={tab}
+      categories={categories}
+      accounts={accounts}
+      initialTransactions={initialTransactions}
+      initialRecurring={initialRecurring}
+      initialLoans={initialLoans}
+    />
+  )
+}

--- a/app/(dashboard)/recurring-transactions/page.tsx
+++ b/app/(dashboard)/recurring-transactions/page.tsx
@@ -1,38 +1,5 @@
-import { getServerSession } from 'next-auth'
-import { authOptions } from '@/lib/auth'
 import { redirect } from 'next/navigation'
-import { insforgeAdmin } from '@/lib/insforge-admin'
-import { RecurringTransactionsPageContent } from '@/components/recurring/RecurringTransactionsPageContent'
-import { getCategories } from '@/lib/actions/categories.actions'
-import { getRecurringTransactions } from '@/lib/actions/recurring.actions'
-import { getAccounts } from '@/lib/actions/accounts.actions'
 
-export default async function RecurringTransactionsPage() {
-  const session = await getServerSession(authOptions)
-
-  if (!session?.user?.email) {
-    redirect('/login')
-  }
-
-  const { data: user, error: userError } = await insforgeAdmin.database
-    .from('users')
-    .select('id')
-    .eq('email', session.user.email)
-    .single()
-
-  if (!user?.id || userError) {
-    console.error('User not found or error:', userError)
-    redirect('/login')
-  }
-
-  const [categoriesResult, transactionsResult, accountsResult] = await Promise.all([
-    getCategories(user.id),
-    getRecurringTransactions(user.id),
-    getAccounts(user.id),
-  ])
-  const categories = categoriesResult.success ? (categoriesResult.data ?? []) : []
-  const transactions = transactionsResult.success ? (transactionsResult.data ?? []) : []
-  const accounts = accountsResult.success ? (accountsResult.data ?? []) : []
-
-  return <RecurringTransactionsPageContent userId={user.id} categories={categories} accounts={accounts} initialTransactions={transactions} />
+export default function RecurringTransactionsPage() {
+  redirect('/movimientos?tab=recurrentes')
 }

--- a/app/(dashboard)/transactions/page.tsx
+++ b/app/(dashboard)/transactions/page.tsx
@@ -1,38 +1,5 @@
-import { getServerSession } from 'next-auth'
-import { authOptions } from '@/lib/auth'
 import { redirect } from 'next/navigation'
-import { insforgeAdmin } from '@/lib/insforge-admin'
-import { TransactionsPageClient } from './TransactionsPageClient'
-import { getCategories } from '@/lib/actions/categories.actions'
-import { getTransactions } from '@/lib/actions/transactions.actions'
-import { getAccounts } from '@/lib/actions/accounts.actions'
-import type { TransactionWithCategory, Account } from '@/types/database.types'
 
-export default async function TransactionsPage() {
-  const session = await getServerSession(authOptions)
-
-  if (!session?.user?.email) {
-    redirect('/login')
-  }
-
-  const { data: user } = await insforgeAdmin.database
-    .from('users')
-    .select('id')
-    .eq('email', session.user.email)
-    .single()
-
-  if (!user) {
-    redirect('/login')
-  }
-
-  const [categoriesResult, transactionsResult, accountsResult] = await Promise.all([
-    getCategories(user.id),
-    getTransactions(user.id, 500),
-    getAccounts(user.id),
-  ])
-  const categories = categoriesResult.success ? (categoriesResult.data ?? []) : []
-  const transactions = transactionsResult.success ? ((transactionsResult.data ?? []) as TransactionWithCategory[]) : []
-  const accounts = (accountsResult.success ? accountsResult.data : []) as Account[]
-
-  return <TransactionsPageClient userId={user.id} categories={categories ?? []} initialTransactions={transactions} accounts={accounts} />
+export default function TransactionsPage() {
+  redirect('/movimientos?tab=transacciones')
 }

--- a/components/dashboard/BottomNav.tsx
+++ b/components/dashboard/BottomNav.tsx
@@ -4,9 +4,9 @@ import { Box, Flex, Text, Icon, Spinner } from '@chakra-ui/react'
 import { usePathname } from 'next/navigation'
 import {
   FiHome,
-  FiDollarSign,
+  FiLayers,
   FiTarget,
-  FiRepeat,
+  FiBarChart2,
   FiMoreHorizontal,
 } from 'react-icons/fi'
 import { IconType } from 'react-icons'
@@ -14,9 +14,9 @@ import { useNavigation } from '@/hooks/useNavigation'
 
 const primaryItems: { href: string; label: string; icon: IconType }[] = [
   { href: '/dashboard', label: 'Dashboard', icon: FiHome },
-  { href: '/transactions', label: 'Transacciones', icon: FiDollarSign },
+  { href: '/movimientos', label: 'Movimientos', icon: FiLayers },
   { href: '/savings-goals', label: 'Metas', icon: FiTarget },
-  { href: '/recurring-transactions', label: 'Recurrentes', icon: FiRepeat },
+  { href: '/reports', label: 'Reportes', icon: FiBarChart2 },
 ]
 
 interface Props {

--- a/components/dashboard/MobileNav.tsx
+++ b/components/dashboard/MobileNav.tsx
@@ -15,31 +15,26 @@ import {
 import { usePathname } from 'next/navigation'
 import {
   FiHome,
-  FiDollarSign,
   FiTag,
   FiTrendingUp,
   FiBarChart2,
   FiSettings,
-  FiRepeat,
   FiTarget,
   FiCalendar,
   FiDownload,
-  FiCreditCard,
+  FiLayers,
 } from 'react-icons/fi'
 import { IconType } from 'react-icons'
 import { useNavigation } from '@/hooks/useNavigation'
 
 const navItems: { href: string; label: string; icon: IconType }[] = [
   { href: '/dashboard', label: 'Dashboard', icon: FiHome },
-  { href: '/transactions', label: 'Transacciones', icon: FiDollarSign },
-  { href: '/recurring-transactions', label: 'Recurrentes', icon: FiRepeat },
+  { href: '/movimientos', label: 'Movimientos', icon: FiLayers },
   { href: '/savings-goals', label: 'Metas de Ahorro', icon: FiTarget },
-  { href: '/loans', label: 'Préstamos', icon: FiCreditCard },
-  { href: '/tags', label: 'Etiquetas', icon: FiTag },
   { href: '/calendar', label: 'Calendario', icon: FiCalendar },
-  { href: '/categories', label: 'Categorías', icon: FiTag },
   { href: '/reports', label: 'Reportes', icon: FiBarChart2 },
   { href: '/budgets', label: 'Presupuestos', icon: FiTrendingUp },
+  { href: '/categories', label: 'Categorías', icon: FiTag },
   { href: '/export-data', label: 'Exportar', icon: FiDownload },
   { href: '/settings', label: 'Configuración', icon: FiSettings },
 ]

--- a/components/dashboard/Sidebar.tsx
+++ b/components/dashboard/Sidebar.tsx
@@ -4,31 +4,26 @@ import { Box, VStack, Button, Icon, Spinner } from '@chakra-ui/react'
 import { usePathname } from 'next/navigation'
 import {
   FiHome,
-  FiDollarSign,
   FiTag,
   FiTrendingUp,
   FiBarChart2,
   FiSettings,
-  FiRepeat,
   FiTarget,
   FiCalendar,
   FiDownload,
-  FiCreditCard,
+  FiLayers,
 } from 'react-icons/fi'
 import { IconType } from 'react-icons'
 import { useNavigation } from '@/hooks/useNavigation'
 
 const navItems: { href: string; label: string; icon: IconType }[] = [
   { href: '/dashboard', label: 'Dashboard', icon: FiHome },
-  { href: '/transactions', label: 'Transacciones', icon: FiDollarSign },
-  { href: '/recurring-transactions', label: 'Recurrentes', icon: FiRepeat },
+  { href: '/movimientos', label: 'Movimientos', icon: FiLayers },
   { href: '/savings-goals', label: 'Metas de Ahorro', icon: FiTarget },
-  { href: '/loans', label: 'Préstamos', icon: FiCreditCard },
-  // { href: '/tags', label: 'Etiquetas', icon: FiTag },
   { href: '/calendar', label: 'Calendario', icon: FiCalendar },
-  { href: '/categories', label: 'Categorías', icon: FiTag },
   { href: '/reports', label: 'Reportes', icon: FiBarChart2 },
   { href: '/budgets', label: 'Presupuestos', icon: FiTrendingUp },
+  { href: '/categories', label: 'Categorías', icon: FiTag },
   { href: '/export-data', label: 'Exportar', icon: FiDownload },
   { href: '/settings', label: 'Configuración', icon: FiSettings },
 ]

--- a/lib/actions/loans.actions.ts
+++ b/lib/actions/loans.actions.ts
@@ -36,6 +36,7 @@ export async function createLoan(userId: string, input: LoanFormData) {
   }
 
   revalidatePath('/loans')
+  revalidatePath('/movimientos')
   revalidatePath('/dashboard')
   return { success: true, data }
 }
@@ -82,6 +83,7 @@ export async function updateLoan(userId: string, loanId: string, input: LoanForm
   if (error) return { success: false, error: error.message }
 
   revalidatePath('/loans')
+  revalidatePath('/movimientos')
   revalidatePath('/dashboard')
   return { success: true, data }
 }
@@ -115,6 +117,7 @@ export async function deleteLoan(userId: string, loanId: string) {
   if (error) return { success: false, error: error.message }
 
   revalidatePath('/loans')
+  revalidatePath('/movimientos')
   revalidatePath('/dashboard')
   return { success: true }
 }
@@ -154,6 +157,7 @@ export async function settleLoan(userId: string, loanId: string) {
   if (error) return { success: false, error: error.message }
 
   revalidatePath('/loans')
+  revalidatePath('/movimientos')
   revalidatePath('/dashboard')
   return { success: true }
 }

--- a/lib/actions/recurring.actions.ts
+++ b/lib/actions/recurring.actions.ts
@@ -41,6 +41,7 @@ export async function createRecurringTransaction(
     if (error) throw error
 
     revalidatePath('/recurring-transactions')
+    revalidatePath('/movimientos')
     return { success: true, data: transaction as RecurringTransactionWithCategory }
   } catch (error) {
     console.error('Create recurring transaction error:', error)
@@ -88,6 +89,7 @@ export async function updateRecurringTransaction(
     if (error) throw error
 
     revalidatePath('/recurring-transactions')
+    revalidatePath('/movimientos')
     return { success: true, data: transaction as RecurringTransactionWithCategory }
   } catch (error) {
     console.error('Update recurring transaction error:', error)
@@ -106,6 +108,7 @@ export async function deleteRecurringTransaction(id: string, userId: string) {
     if (error) throw error
 
     revalidatePath('/recurring-transactions')
+    revalidatePath('/movimientos')
     return { success: true }
   } catch (error) {
     console.error('Delete recurring transaction error:', error)
@@ -126,6 +129,7 @@ export async function toggleRecurringTransaction(id: string, userId: string, isA
     if (error) throw error
 
     revalidatePath('/recurring-transactions')
+    revalidatePath('/movimientos')
     return { success: true, data: data as RecurringTransactionWithCategory }
   } catch (error) {
     console.error('Toggle recurring transaction error:', error)
@@ -138,6 +142,7 @@ export async function generateRecurringTransactions(userId: string) {
     const result = await generateRecurringForUser(userId)
     console.log('[generateRecurringTransactions] result:', JSON.stringify(result))
     revalidatePath('/recurring-transactions')
+    revalidatePath('/movimientos')
     if (result.errors.length > 0) {
       return {
         success: true,

--- a/lib/actions/transactions.actions.ts
+++ b/lib/actions/transactions.actions.ts
@@ -31,6 +31,7 @@ export async function createTransaction(
     }
 
     revalidatePath('/transactions')
+    revalidatePath('/movimientos')
     revalidatePath('/dashboard')
     revalidatePath('/settings')
     revalidatePath('/calendar')
@@ -102,6 +103,7 @@ export async function updateTransaction(
     }
 
     revalidatePath('/transactions')
+    revalidatePath('/movimientos')
     revalidatePath('/dashboard')
     revalidatePath('/settings')
     revalidatePath('/calendar')
@@ -135,6 +137,7 @@ export async function deleteTransaction(id: string, userId: string) {
     }
 
     revalidatePath('/transactions')
+    revalidatePath('/movimientos')
     revalidatePath('/dashboard')
     revalidatePath('/settings')
     revalidatePath('/calendar')


### PR DESCRIPTION
## Cambios
- Nueva página `/movimientos` con Chakra UI Tabs (Transacciones | Recurrentes | Préstamos)
- Cada tab hace fetch server-side solo cuando se activa (vía URL searchParam `?tab=X`)
- `/transactions`, `/recurring-transactions`, `/loans` redirigen a `/movimientos`
- `Sidebar`, `BottomNav` y `MobileNav` actualizados con item único "Movimientos"
- `revalidatePath('/movimientos')` agregado a `transactions.actions.ts`, `recurring.actions.ts` y `loans.actions.ts`

## Testing
- ✅ Build exitoso sin errores TypeScript
- ✅ Rutas antiguas redirigen correctamente
- ✅ Nav desktop y móvil apuntan a /movimientos

Closes #224