### PR TITLE
feat: /planificacion con tabs — Metas de Ahorro y Presupuestos

### DIFF
--- a/app/(dashboard)/budgets/page.tsx
+++ b/app/(dashboard)/budgets/page.tsx
@@ -1,34 +1,5 @@
-import { getServerSession } from 'next-auth'
-import { authOptions } from '@/lib/auth'
 import { redirect } from 'next/navigation'
-import { insforgeAdmin } from '@/lib/insforge-admin'
-import { BudgetsPageClient } from './BudgetsPageClient'
-import { getCategories } from '@/lib/actions/categories.actions'
-import { getBudgets } from '@/lib/actions/budgets.actions'
 
-export default async function BudgetsPage() {
-  const session = await getServerSession(authOptions)
-
-  if (!session?.user?.email) {
-    redirect('/login')
-  }
-
-  const { data: user } = await insforgeAdmin.database
-    .from('users')
-    .select('id')
-    .eq('email', session.user.email)
-    .single()
-
-  if (!user) {
-    redirect('/login')
-  }
-
-  const [categoriesResult, budgetsResult] = await Promise.all([
-    getCategories(user.id),
-    getBudgets(user.id),
-  ])
-  const categories = categoriesResult.success ? (categoriesResult.data ?? []) : []
-  const budgets = budgetsResult.success ? (budgetsResult.data ?? []) : []
-
-  return <BudgetsPageClient userId={user.id} categories={categories ?? []} initialBudgets={budgets as any[]} />
+export default function BudgetsPage() {
+  redirect('/planificacion?tab=presupuestos')
 }

--- a/app/(dashboard)/planificacion/PlanificacionPageClient.tsx
+++ b/app/(dashboard)/planificacion/PlanificacionPageClient.tsx
@@ -1,0 +1,79 @@
+'use client'
+
+import { Box, Heading, Tabs } from '@chakra-ui/react'
+import { useRouter } from 'next/navigation'
+import { SavingsGoalsPageContent } from '@/components/savings/SavingsGoalsPageContent'
+import { BudgetsPageClient } from '../budgets/BudgetsPageClient'
+import type { SavingsGoal, Category } from '@/types/database.types'
+
+type Tab = 'metas' | 'presupuestos'
+
+interface Props {
+  userId: string
+  activeTab: Tab
+  initialGoals: SavingsGoal[] | null
+  initialBudgets: unknown[] | null
+  categories: Category[]
+}
+
+export function PlanificacionPageClient({
+  userId,
+  activeTab,
+  initialGoals,
+  initialBudgets,
+  categories,
+}: Props) {
+  const router = useRouter()
+
+  const handleTabChange = (tab: string) => {
+    router.push(`/planificacion?tab=${tab}`)
+  }
+
+  return (
+    <Box p={{ base: 4, md: 6 }}>
+      <Heading size="lg" mb={6} color="white">
+        Planificación
+      </Heading>
+
+      <Tabs.Root
+        value={activeTab}
+        onValueChange={({ value }) => handleTabChange(value)}
+        colorPalette="brand"
+      >
+        <Tabs.List mb={6} borderBottomWidth="1px" borderColor="#2d2d35">
+          <Tabs.Trigger
+            value="metas"
+            color="#B0B0B0"
+            _selected={{ color: 'white', borderBottomColor: '#6366f1' }}
+          >
+            Metas de Ahorro
+          </Tabs.Trigger>
+          <Tabs.Trigger
+            value="presupuestos"
+            color="#B0B0B0"
+            _selected={{ color: 'white', borderBottomColor: '#6366f1' }}
+          >
+            Presupuestos
+          </Tabs.Trigger>
+        </Tabs.List>
+
+        <Tabs.Content value="metas">
+          {initialGoals !== null && (
+            <SavingsGoalsPageContent userId={userId} initialGoals={initialGoals} />
+          )}
+        </Tabs.Content>
+
+        <Tabs.Content value="presupuestos">
+          {initialBudgets !== null && (
+            <BudgetsPageClient
+              userId={userId}
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              initialBudgets={initialBudgets as any[]}
+              categories={categories}
+            />
+          )}
+        </Tabs.Content>
+      </Tabs.Root>
+    </Box>
+  )
+}

--- a/app/(dashboard)/planificacion/page.tsx
+++ b/app/(dashboard)/planificacion/page.tsx
@@ -1,0 +1,62 @@
+import { getServerSession } from 'next-auth'
+import { authOptions } from '@/lib/auth'
+import { redirect } from 'next/navigation'
+import { insforgeAdmin } from '@/lib/insforge-admin'
+import { getSavingsGoals } from '@/lib/actions/savings.actions'
+import { getCategories } from '@/lib/actions/categories.actions'
+import { getBudgets } from '@/lib/actions/budgets.actions'
+import { PlanificacionPageClient } from './PlanificacionPageClient'
+import type { SavingsGoal, Category } from '@/types/database.types'
+
+type Tab = 'metas' | 'presupuestos'
+
+export default async function PlanificacionPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ tab?: string }>
+}) {
+  const session = await getServerSession(authOptions)
+
+  if (!session?.user?.email) {
+    redirect('/login')
+  }
+
+  const { data: user, error: userError } = await insforgeAdmin.database
+    .from('users')
+    .select('id')
+    .eq('email', session.user.email)
+    .single()
+
+  if (!user?.id || userError) {
+    redirect('/login')
+  }
+
+  const params = await searchParams
+  const tab = (params.tab as Tab) || 'metas'
+
+  let initialGoals: SavingsGoal[] | null = null
+  let initialBudgets: unknown[] | null = null
+  let categories: Category[] = []
+
+  if (tab === 'metas') {
+    const result = await getSavingsGoals(user.id)
+    initialGoals = result.success ? (result.data ?? []) : []
+  } else if (tab === 'presupuestos') {
+    const [categoriesResult, budgetsResult] = await Promise.all([
+      getCategories(user.id),
+      getBudgets(user.id),
+    ])
+    categories = categoriesResult.success ? (categoriesResult.data ?? []) : []
+    initialBudgets = budgetsResult.success ? (budgetsResult.data ?? []) : []
+  }
+
+  return (
+    <PlanificacionPageClient
+      userId={user.id}
+      activeTab={tab}
+      initialGoals={initialGoals}
+      initialBudgets={initialBudgets}
+      categories={categories}
+    />
+  )
+}

--- a/app/(dashboard)/savings-goals/page.tsx
+++ b/app/(dashboard)/savings-goals/page.tsx
@@ -1,30 +1,5 @@
-import { getServerSession } from 'next-auth'
-import { authOptions } from '@/lib/auth'
 import { redirect } from 'next/navigation'
-import { insforgeAdmin } from '@/lib/insforge-admin'
-import { SavingsGoalsPageContent } from '@/components/savings/SavingsGoalsPageContent'
-import { getSavingsGoals } from '@/lib/actions/savings.actions'
 
-export default async function SavingsGoalsPage() {
-  const session = await getServerSession(authOptions)
-
-  if (!session?.user?.email) {
-    redirect('/login')
-  }
-
-  const { data: user, error: userError } = await insforgeAdmin.database
-    .from('users')
-    .select('id')
-    .eq('email', session.user.email)
-    .single()
-
-  if (!user?.id || userError) {
-    console.error('User not found or error:', userError)
-    redirect('/login')
-  }
-
-  const goalsResult = await getSavingsGoals(user.id)
-  const goals = goalsResult.success ? (goalsResult.data ?? []) : []
-
-  return <SavingsGoalsPageContent userId={user.id} initialGoals={goals} />
+export default function SavingsGoalsPage() {
+  redirect('/planificacion?tab=metas')
 }

--- a/lib/actions/budgets.actions.ts
+++ b/lib/actions/budgets.actions.ts
@@ -83,6 +83,7 @@ export async function createBudget(userId: string, data: CreateBudgetInput) {
     if (error) throw error
 
     revalidatePath('/budgets')
+    revalidatePath('/planificacion')
     revalidatePath('/dashboard')
     return { success: true, data: budget }
   } catch (error) {
@@ -110,6 +111,7 @@ export async function updateBudget(
     if (error) throw error
 
     revalidatePath('/budgets')
+    revalidatePath('/planificacion')
     revalidatePath('/dashboard')
     return { success: true, data: budget }
   } catch (error) {
@@ -129,6 +131,7 @@ export async function deleteBudget(id: string, userId: string) {
     if (error) throw error
 
     revalidatePath('/budgets')
+    revalidatePath('/planificacion')
     revalidatePath('/dashboard')
     return { success: true }
   } catch (error) {

--- a/lib/actions/savings.actions.ts
+++ b/lib/actions/savings.actions.ts
@@ -41,6 +41,7 @@ export async function createSavingsGoal(userId: string, data: CreateSavingsGoalI
     if (error) throw error
 
     revalidatePath('/savings-goals')
+    revalidatePath('/planificacion')
     return { success: true, data: goal as SavingsGoal }
   } catch (error) {
     console.error('Create savings goal error:', error)
@@ -83,6 +84,7 @@ export async function updateSavingsGoal(id: string, userId: string, data: Update
     if (error) throw error
 
     revalidatePath('/savings-goals')
+    revalidatePath('/planificacion')
     return { success: true, data: goal as SavingsGoal }
   } catch (error) {
     console.error('Update savings goal error:', error)
@@ -101,6 +103,7 @@ export async function deleteSavingsGoal(id: string, userId: string) {
     if (error) throw error
 
     revalidatePath('/savings-goals')
+    revalidatePath('/planificacion')
     return { success: true }
   } catch (error) {
     console.error('Delete savings goal error:', error)
@@ -135,6 +138,7 @@ export async function addFundsToGoal(id: string, userId: string, data: AddFundsI
     if (updateError) throw updateError
 
     revalidatePath('/savings-goals')
+    revalidatePath('/planificacion')
     return { success: true, data: updated as SavingsGoal }
   } catch (error) {
     console.error('Add funds to goal error:', error)
@@ -155,6 +159,7 @@ export async function markGoalAsCompleted(id: string, userId: string) {
     if (error) throw error
 
     revalidatePath('/savings-goals')
+    revalidatePath('/planificacion')
     return { success: true, data: goal as SavingsGoal }
   } catch (error) {
     console.error('Mark goal as completed error:', error)


### PR DESCRIPTION
## Cambios
- Nueva página `/planificacion` con tabs (Metas de Ahorro | Presupuestos)
- Fetch server-side solo del tab activo vía `?tab=X`
- `/savings-goals` y `/budgets` redirigen a `/planificacion`
- `revalidatePath('/planificacion')` agregado a savings y budgets actions

## Testing
- ✅ Build exitoso

Closes #226