### PR TITLE
feat: categorías integradas como tab en /settings

### DIFF
--- a/app/(dashboard)/categories/page.tsx
+++ b/app/(dashboard)/categories/page.tsx
@@ -1,30 +1,5 @@
-import { getServerSession } from 'next-auth'
-import { authOptions } from '@/lib/auth'
 import { redirect } from 'next/navigation'
-import { insforgeAdmin } from '@/lib/insforge-admin'
-import { getCategories } from '@/lib/actions/categories.actions'
-import { CategoriesPageClient } from './CategoriesPageClient'
-import type { Category } from '@/types/database.types'
 
-export default async function CategoriesPage() {
-  const session = await getServerSession(authOptions)
-
-  if (!session?.user?.email) {
-    redirect('/login')
-  }
-
-  const { data: user } = await insforgeAdmin.database
-    .from('users')
-    .select('id')
-    .eq('email', session.user.email)
-    .single()
-
-  if (!user) {
-    redirect('/login')
-  }
-
-  const categoriesResult = await getCategories(user.id)
-  const categories = (categoriesResult.success ? categoriesResult.data : []) as Category[]
-
-  return <CategoriesPageClient userId={user.id} initialCategories={categories} />
+export default function CategoriesPage() {
+  redirect('/settings?tab=categorias')
 }

--- a/app/(dashboard)/settings/SettingsPageClient.tsx
+++ b/app/(dashboard)/settings/SettingsPageClient.tsx
@@ -1,16 +1,20 @@
 'use client'
 
 import { Box, Heading, VStack, Text, Separator, Tabs } from '@chakra-ui/react'
+import { useRouter } from 'next/navigation'
 import { CurrencySelector } from '@/components/settings/CurrencySelector'
 import { ExchangeRatesForm } from '@/components/settings/ExchangeRatesForm'
 import { AccountsTab } from '@/components/settings/AccountsTab'
-// import { CronActionsPanel } from '@/components/settings/CronActionsPanel'
+import { CategoriesPageClient } from '../categories/CategoriesPageClient'
 import type {
   Currency,
   ExchangeRate,
   Account,
   AccountMovementWithAccounts,
+  Category,
 } from '@/types/database.types'
+
+type Tab = 'general' | 'accounts' | 'categorias'
 
 interface Props {
   userId: string
@@ -18,6 +22,8 @@ interface Props {
   initialRates: ExchangeRate[]
   initialAccounts: Account[]
   initialMovements: AccountMovementWithAccounts[]
+  activeTab: Tab
+  initialCategories: Category[]
 }
 
 export function SettingsPageClient({
@@ -26,7 +32,15 @@ export function SettingsPageClient({
   initialRates,
   initialAccounts,
   initialMovements,
+  activeTab,
+  initialCategories,
 }: Props) {
+  const router = useRouter()
+
+  const handleTabChange = (tab: string) => {
+    router.push(`/settings?tab=${tab}`)
+  }
+
   return (
     <Box p={6}>
       <Heading size="lg" mb={8} color="white">
@@ -34,7 +48,8 @@ export function SettingsPageClient({
       </Heading>
 
       <Tabs.Root
-        defaultValue="general"
+        value={activeTab}
+        onValueChange={({ value }) => handleTabChange(value)}
         colorPalette="brand"
         style={{ width: '100%' }}
       >
@@ -52,6 +67,13 @@ export function SettingsPageClient({
             _selected={{ color: 'white', borderBottomColor: '#6366f1' }}
           >
             Cuentas
+          </Tabs.Trigger>
+          <Tabs.Trigger
+            value="categorias"
+            color="#B0B0B0"
+            _selected={{ color: 'white', borderBottomColor: '#6366f1' }}
+          >
+            Categorías
           </Tabs.Trigger>
         </Tabs.List>
 
@@ -79,18 +101,6 @@ export function SettingsPageClient({
               </Text>
               <ExchangeRatesForm initialRates={initialRates} />
             </Box>
-
-            {/* <Separator /> */}
-
-            {/* <Box>
-              <Text fontWeight="semibold" mb={1} color="white">
-                Mantenimiento
-              </Text>
-              <Text fontSize="sm" color="#B0B0B0" mb={4}>
-                Ejecuta manualmente los procesos automáticos del sistema.
-              </Text>
-              <CronActionsPanel userId={userId} />
-            </Box> */}
           </VStack>
         </Tabs.Content>
 
@@ -100,6 +110,15 @@ export function SettingsPageClient({
             initialAccounts={initialAccounts}
             initialMovements={initialMovements}
           />
+        </Tabs.Content>
+
+        <Tabs.Content value="categorias">
+          {initialCategories.length >= 0 && (
+            <CategoriesPageClient
+              userId={userId}
+              initialCategories={initialCategories}
+            />
+          )}
         </Tabs.Content>
       </Tabs.Root>
     </Box>

--- a/app/(dashboard)/settings/page.tsx
+++ b/app/(dashboard)/settings/page.tsx
@@ -6,10 +6,17 @@ import { getUserProfile } from '@/lib/actions/users.actions'
 import { getAllRatePairs } from '@/lib/actions/exchangeRates.actions'
 import { getAccounts } from '@/lib/actions/accounts.actions'
 import { getAccountMovements } from '@/lib/actions/account_movements.actions'
+import { getCategories } from '@/lib/actions/categories.actions'
 import { SettingsPageClient } from './SettingsPageClient'
-import type { User, ExchangeRate, Account, AccountMovementWithAccounts } from '@/types/database.types'
+import type { User, ExchangeRate, Account, AccountMovementWithAccounts, Category } from '@/types/database.types'
 
-export default async function SettingsPage() {
+type Tab = 'general' | 'accounts' | 'categorias'
+
+export default async function SettingsPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ tab?: string }>
+}) {
   const session = await getServerSession(authOptions)
 
   if (!session?.user?.email) {
@@ -25,6 +32,9 @@ export default async function SettingsPage() {
   if (!userRow) {
     redirect('/login')
   }
+
+  const params = await searchParams
+  const tab = (params.tab as Tab) || 'general'
 
   const [profileResult, ratesResult, accountsResult, movementsResult] = await Promise.all([
     getUserProfile(userRow.id),
@@ -42,6 +52,12 @@ export default async function SettingsPage() {
     redirect('/login')
   }
 
+  let initialCategories: Category[] = []
+  if (tab === 'categorias') {
+    const result = await getCategories(userRow.id)
+    initialCategories = result.success ? (result.data ?? []) : []
+  }
+
   return (
     <SettingsPageClient
       userId={userRow.id}
@@ -49,6 +65,8 @@ export default async function SettingsPage() {
       initialRates={rates}
       initialAccounts={accounts}
       initialMovements={movements}
+      activeTab={tab}
+      initialCategories={initialCategories}
     />
   )
 }

--- a/components/dashboard/BottomNav.tsx
+++ b/components/dashboard/BottomNav.tsx
@@ -15,7 +15,7 @@ import { useNavigation } from '@/hooks/useNavigation'
 const primaryItems: { href: string; label: string; icon: IconType }[] = [
   { href: '/dashboard', label: 'Dashboard', icon: FiHome },
   { href: '/movimientos', label: 'Movimientos', icon: FiLayers },
-  { href: '/savings-goals', label: 'Metas', icon: FiTarget },
+  { href: '/planificacion', label: 'Planificación', icon: FiTarget },
   { href: '/reports', label: 'Reportes', icon: FiBarChart2 },
 ]
 

--- a/components/dashboard/MobileNav.tsx
+++ b/components/dashboard/MobileNav.tsx
@@ -15,8 +15,6 @@ import {
 import { usePathname } from 'next/navigation'
 import {
   FiHome,
-  FiTag,
-  FiTrendingUp,
   FiBarChart2,
   FiSettings,
   FiTarget,
@@ -30,11 +28,9 @@ import { useNavigation } from '@/hooks/useNavigation'
 const navItems: { href: string; label: string; icon: IconType }[] = [
   { href: '/dashboard', label: 'Dashboard', icon: FiHome },
   { href: '/movimientos', label: 'Movimientos', icon: FiLayers },
-  { href: '/savings-goals', label: 'Metas de Ahorro', icon: FiTarget },
+  { href: '/planificacion', label: 'Planificación', icon: FiTarget },
   { href: '/calendar', label: 'Calendario', icon: FiCalendar },
   { href: '/reports', label: 'Reportes', icon: FiBarChart2 },
-  { href: '/budgets', label: 'Presupuestos', icon: FiTrendingUp },
-  { href: '/categories', label: 'Categorías', icon: FiTag },
   { href: '/export-data', label: 'Exportar', icon: FiDownload },
   { href: '/settings', label: 'Configuración', icon: FiSettings },
 ]

--- a/components/dashboard/Sidebar.tsx
+++ b/components/dashboard/Sidebar.tsx
@@ -4,8 +4,6 @@ import { Box, VStack, Button, Icon, Spinner } from '@chakra-ui/react'
 import { usePathname } from 'next/navigation'
 import {
   FiHome,
-  FiTag,
-  FiTrendingUp,
   FiBarChart2,
   FiSettings,
   FiTarget,
@@ -19,11 +17,9 @@ import { useNavigation } from '@/hooks/useNavigation'
 const navItems: { href: string; label: string; icon: IconType }[] = [
   { href: '/dashboard', label: 'Dashboard', icon: FiHome },
   { href: '/movimientos', label: 'Movimientos', icon: FiLayers },
-  { href: '/savings-goals', label: 'Metas de Ahorro', icon: FiTarget },
+  { href: '/planificacion', label: 'Planificación', icon: FiTarget },
   { href: '/calendar', label: 'Calendario', icon: FiCalendar },
   { href: '/reports', label: 'Reportes', icon: FiBarChart2 },
-  { href: '/budgets', label: 'Presupuestos', icon: FiTrendingUp },
-  { href: '/categories', label: 'Categorías', icon: FiTag },
   { href: '/export-data', label: 'Exportar', icon: FiDownload },
   { href: '/settings', label: 'Configuración', icon: FiSettings },
 ]

--- a/lib/actions/categories.actions.ts
+++ b/lib/actions/categories.actions.ts
@@ -47,6 +47,7 @@ export async function createCategory(
 
     if (error) throw error
     revalidatePath('/categories')
+    revalidatePath('/settings')
     return { success: true, data: category }
   } catch (error) {
     console.error('Create category error:', error)
@@ -72,6 +73,7 @@ export async function updateCategory(
 
     if (error) throw error
     revalidatePath('/categories')
+    revalidatePath('/settings')
     return { success: true, data: category }
   } catch (error) {
     console.error('Update category error:', error)
@@ -101,6 +103,7 @@ export async function deleteCategory(id: string, userId: string) {
 
     if (error) throw error
     revalidatePath('/categories')
+    revalidatePath('/settings')
     return { success: true }
   } catch (error) {
     console.error('Delete category error:', error)


### PR DESCRIPTION
## Cambios
- Tab 'Categorías' agregado en /settings (URL: ?tab=categorias)
- /categories redirige a /settings?tab=categorias
- Fetch de categorías solo cuando el tab está activo
- Sidebar y MobileNav: /categories eliminado, /savings-goals → /planificacion
- categories.actions: agrega revalidatePath('/settings')

## Testing
- ✅ Build exitoso

Closes #228
EOF
