### PR TITLE
fix: formato de montos y orden de gráficos en reportes

### DIFF
--- a/components/ReportsContent.tsx
+++ b/components/ReportsContent.tsx
@@ -31,14 +31,14 @@ export function ReportsContent({ userId }: Props) {
       <ReportStatistics userId={userId} filters={filters} />
 
       <SimpleGrid columns={{ base: 1, md: 2 }} gap={6}>
-        <Box gridColumn={{ base: 'auto', md: '1 / -1' }}>
-          <AccumulatedBalanceChart userId={userId} filters={filters} />
-        </Box>
+        <ExpensesByCategoryChart userId={userId} type="expense" filters={filters} />
+        <ExpensesByCategoryChart userId={userId} type="income" filters={filters} />
         <Box gridColumn={{ base: 'auto', md: '1 / -1' }}>
           <MonthlyComparisonChart userId={userId} months={12} filters={filters} />
         </Box>
-        <ExpensesByCategoryChart userId={userId} type="expense" filters={filters} />
-        <ExpensesByCategoryChart userId={userId} type="income" filters={filters} />
+        <Box gridColumn={{ base: 'auto', md: '1 / -1' }}>
+          <AccumulatedBalanceChart userId={userId} filters={filters} />
+        </Box>
       </SimpleGrid>
     </Box>
   )

--- a/components/charts/AccumulatedBalanceChart.tsx
+++ b/components/charts/AccumulatedBalanceChart.tsx
@@ -16,6 +16,7 @@ import { getTransactions } from '@/lib/actions/transactions.actions'
 import { Card } from '@/components/ui/Card'
 import type { TransactionWithCategory } from '@/types/database.types'
 import type { ReportFiltersState } from '@/components/ReportFilters'
+import { formatCurrency } from '@/lib/utils/currency'
 
 interface ChartDataPoint {
   date: string
@@ -125,7 +126,7 @@ export function AccumulatedBalanceChart({ userId, filters }: Props) {
           Balance Acumulado
         </Heading>
         <Text fontSize="2xl" fontWeight="bold" color={currentBalance >= 0 ? '#2ECC71' : '#E74C3C'}>
-          ${currentBalance.toFixed(2)}
+          {formatCurrency(currentBalance, 'COP')}
         </Text>
       </Box>
       <Box h="400px">
@@ -137,14 +138,16 @@ export function AccumulatedBalanceChart({ userId, filters }: Props) {
               tick={{ fontSize: 12 }}
               interval={Math.floor(chartData.length / 5)}
             />
-            <YAxis />
+            <YAxis tickFormatter={(value) => formatCurrency(Number(value), 'COP')} width={110} />
             <Tooltip
-              formatter={(value) => `$${Number(value).toFixed(2)}`}
+              formatter={(value) => [formatCurrency(Number(value), 'COP'), 'Balance']}
               contentStyle={{
-                backgroundColor: '#1a1a1a',
-                border: '1px solid #333',
-                borderRadius: '4px',
+                backgroundColor: '#1a1a23',
+                border: '1px solid #2d2d35',
+                borderRadius: '8px',
+                color: '#ffffff',
               }}
+              labelStyle={{ color: '#B0B0B0' }}
             />
             <Legend />
             <Area

--- a/components/charts/MonthlyComparisonChart.tsx
+++ b/components/charts/MonthlyComparisonChart.tsx
@@ -129,7 +129,7 @@ export function MonthlyComparisonChart({ userId, months = 12, filters }: Props) 
           <BarChart data={chartData} margin={{ top: 10, right: 10, left: 0, bottom: 10 }}>
             <CartesianGrid strokeDasharray="3 3" />
             <XAxis dataKey="month" />
-            <YAxis />
+            <YAxis tickFormatter={(value) => formatCurrency(Number(value), 'COP')} width={110} />
             <Tooltip
               formatter={(value) => [formatCurrency(Number(value), 'COP'), '']}
               contentStyle={{


### PR DESCRIPTION
## Cambios
- `MonthlyComparisonChart`: YAxis ahora usa `formatCurrency` (ej: `COP 1.000.000,00`)
- `AccumulatedBalanceChart`: título y tooltip usan `formatCurrency` en vez de `$x.toFixed(2)`
- `ReportsContent`: gráficos de torta (pie charts) aparecen antes del bar chart

Closes #230