### PR TITLE
feat: abono parcial en préstamos

### DIFF
--- a/app/(dashboard)/loans/LoansPageClient.tsx
+++ b/app/(dashboard)/loans/LoansPageClient.tsx
@@ -6,6 +6,7 @@ import { useRouter } from 'next/navigation'
 import { FiPlus } from 'react-icons/fi'
 import { Card } from '@/components/ui/Card'
 import { LoanForm } from '@/components/loans/LoanForm'
+import { LoanPaymentForm } from '@/components/loans/LoanPaymentForm'
 import { LoansTable } from '@/components/loans/LoansTable'
 import { deleteLoan, settleLoan } from '@/lib/actions/loans.actions'
 import { toaster } from '@/lib/toaster'
@@ -21,12 +22,19 @@ export function LoansPageClient({ userId, initialLoans, accounts }: Props) {
   const router = useRouter()
   const { open: isCreateOpen, onOpen: onCreateOpen, onClose: onCreateClose } = useDisclosure()
   const { open: isEditOpen, onOpen: onEditOpen, onClose: onEditClose } = useDisclosure()
+  const { open: isPaymentOpen, onOpen: onPaymentOpen, onClose: onPaymentClose } = useDisclosure()
   const [editingLoan, setEditingLoan] = useState<LoanWithAccount | null>(null)
+  const [payingLoan, setPayingLoan] = useState<LoanWithAccount | null>(null)
 
   const handleEdit = useCallback((loan: LoanWithAccount) => {
     setEditingLoan(loan)
     onEditOpen()
   }, [onEditOpen])
+
+  const handlePayment = useCallback((loan: LoanWithAccount) => {
+    setPayingLoan(loan)
+    onPaymentOpen()
+  }, [onPaymentOpen])
 
   const handleSettle = useCallback(async (loan: LoanWithAccount) => {
     const result = await settleLoan(userId, loan.id)
@@ -57,6 +65,11 @@ export function LoansPageClient({ userId, initialLoans, accounts }: Props) {
     setEditingLoan(null)
   }, [onEditClose])
 
+  const handlePaymentClose = useCallback(() => {
+    onPaymentClose()
+    setPayingLoan(null)
+  }, [onPaymentClose])
+
   const activeLoans = initialLoans.filter((l) => l.status === 'active')
   const settledLoans = initialLoans.filter((l) => l.status === 'settled')
 
@@ -84,6 +97,7 @@ export function LoansPageClient({ userId, initialLoans, accounts }: Props) {
           onEdit={handleEdit}
           onSettle={handleSettle}
           onDelete={handleDelete}
+          onPayment={handlePayment}
         />
       </Card>
 
@@ -95,6 +109,7 @@ export function LoansPageClient({ userId, initialLoans, accounts }: Props) {
             onEdit={handleEdit}
             onSettle={handleSettle}
             onDelete={handleDelete}
+            onPayment={handlePayment}
           />
         </Card>
       )}
@@ -115,6 +130,16 @@ export function LoansPageClient({ userId, initialLoans, accounts }: Props) {
           accounts={accounts}
           loan={editingLoan}
           onSuccess={() => { router.refresh(); handleEditClose() }}
+        />
+      )}
+
+      {payingLoan && (
+        <LoanPaymentForm
+          isOpen={isPaymentOpen}
+          onClose={handlePaymentClose}
+          loan={payingLoan}
+          userId={userId}
+          onSuccess={() => router.refresh()}
         />
       )}
     </Box>

--- a/components/loans/LoanPaymentForm.tsx
+++ b/components/loans/LoanPaymentForm.tsx
@@ -1,0 +1,89 @@
+'use client'
+
+import { useState } from 'react'
+import { VStack, Button, Text } from '@chakra-ui/react'
+import { FormDialog } from '@/components/ui/FormDialog'
+import { InputAmount } from '@/components/ui/InputAmount'
+import { addLoanPayment } from '@/lib/actions/loans.actions'
+import { toaster } from '@/lib/toaster'
+import { formatCurrency } from '@/lib/utils/currency'
+import type { LoanWithAccount } from '@/types/database.types'
+
+interface Props {
+  isOpen: boolean
+  onClose: () => void
+  loan: LoanWithAccount
+  userId: string
+  onSuccess: () => void
+}
+
+export function LoanPaymentForm({ isOpen, onClose, loan, userId, onSuccess }: Props) {
+  const [amount, setAmount] = useState<number | undefined>(undefined)
+  const [loading, setLoading] = useState(false)
+
+  const remaining = Number(loan.amount) - Number(loan.paid_amount ?? 0)
+  const label = loan.type === 'lent' ? 'Monto recibido' : 'Monto abonado'
+
+  const handleSubmit = async () => {
+    if (!amount || amount <= 0) {
+      toaster.create({ title: 'Ingresa un monto válido', type: 'error', duration: 3000 })
+      return
+    }
+    if (amount > remaining) {
+      toaster.create({
+        title: `El monto supera el saldo pendiente (${formatCurrency(remaining, loan.currency)})`,
+        type: 'error',
+        duration: 4000,
+      })
+      return
+    }
+
+    setLoading(true)
+    const result = await addLoanPayment(userId, loan.id, amount)
+    setLoading(false)
+
+    if (result.success) {
+      const msg = result.settled ? 'Préstamo saldado completamente' : 'Abono registrado'
+      toaster.create({ title: msg, type: 'success', duration: 3000 })
+      setAmount(undefined)
+      onClose()
+      onSuccess()
+    } else {
+      toaster.create({ title: 'Error al registrar abono', description: result.error, type: 'error', duration: 4000 })
+    }
+  }
+
+  return (
+    <FormDialog
+      isOpen={isOpen}
+      onClose={onClose}
+      title={loan.type === 'lent' ? 'Registrar cobro parcial' : 'Registrar abono'}
+    >
+      <VStack gap={4} align="stretch">
+        <Text fontSize="sm" color="#B0B0B0">
+          Saldo pendiente: <Text as="span" color="white" fontWeight="600">{formatCurrency(remaining, loan.currency)}</Text>
+        </Text>
+
+        <InputAmount
+          label={label}
+          value={amount}
+          onChange={setAmount}
+          isRequired
+        />
+
+        <Button
+          bg="#4F46E5"
+          color="white"
+          _hover={{ bg: '#4338CA' }}
+          onClick={handleSubmit}
+          loading={loading}
+          loadingText="Registrando..."
+          w="full"
+          mt={2}
+        >
+          Registrar
+        </Button>
+      </VStack>
+    </FormDialog>
+  )
+}

--- a/components/loans/LoansTable.tsx
+++ b/components/loans/LoansTable.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react'
 import { Box, VStack, HStack, Text, Badge, Button, IconButton } from '@chakra-ui/react'
-import { FiEdit2, FiTrash2, FiCheckCircle } from 'react-icons/fi'
+import { FiEdit2, FiTrash2, FiCheckCircle, FiPlusCircle } from 'react-icons/fi'
 import { formatCurrency } from '@/lib/utils/currency'
 import { DataTable, type ColumnDef } from '@/components/ui/DataTable'
 import { ConfirmDialog } from '@/components/ui/ConfirmDialog'
@@ -13,13 +13,24 @@ interface Props {
   onEdit: (loan: LoanWithAccount) => void
   onSettle: (loan: LoanWithAccount) => void
   onDelete: (loan: LoanWithAccount) => void
+  onPayment: (loan: LoanWithAccount) => void
 }
 
 function settleLabel(loan: LoanWithAccount) {
   return loan.type === 'lent' ? '¡Ya me pagaron!' : '¡Ya pagué!'
 }
 
-export function LoansTable({ loans, onEdit, onSettle, onDelete }: Props) {
+function PaidProgress({ loan }: { loan: LoanWithAccount }) {
+  const paid = Number(loan.paid_amount ?? 0)
+  if (paid <= 0) return null
+  return (
+    <Text fontSize="xs" color="#B0B0B0" mt={1}>
+      Abonado: {formatCurrency(paid, loan.currency)} / {formatCurrency(Number(loan.amount), loan.currency)}
+    </Text>
+  )
+}
+
+export function LoansTable({ loans, onEdit, onSettle, onDelete, onPayment }: Props) {
   const [confirmLoan, setConfirmLoan] = useState<LoanWithAccount | null>(null)
 
   if (loans.length === 0) {
@@ -34,7 +45,12 @@ export function LoansTable({ loans, onEdit, onSettle, onDelete }: Props) {
     {
       key: 'person_name',
       header: 'Persona',
-      render: (l) => <Text fontWeight="500">{l.person_name}</Text>,
+      render: (l) => (
+        <Box>
+          <Text fontWeight="500">{l.person_name}</Text>
+          <PaidProgress loan={l} />
+        </Box>
+      ),
     },
     {
       key: 'type',
@@ -78,6 +94,17 @@ export function LoansTable({ loans, onEdit, onSettle, onDelete }: Props) {
         <HStack gap={1}>
           {l.status === 'active' && (
             <>
+              <Button
+                size="xs"
+                bg="#F97316"
+                color="white"
+                _hover={{ bg: '#EA580C' }}
+                onClick={() => onPayment(l)}
+                title="Registrar abono"
+              >
+                <FiPlusCircle />
+                <Text display={{ base: 'none', lg: 'inline' }} ml={1}>Abono</Text>
+              </Button>
               <Button
                 size="xs"
                 bg="#4F46E5"
@@ -138,7 +165,7 @@ export function LoansTable({ loans, onEdit, onSettle, onDelete }: Props) {
                 {formatCurrency(Number(loan.amount), loan.currency)}
               </Text>
             </HStack>
-            <HStack gap={2} mb={3} flexWrap="wrap">
+            <HStack gap={2} mb={1} flexWrap="wrap">
               <Badge colorPalette={loan.type === 'lent' ? 'blue' : 'orange'} fontSize="xs">
                 {loan.type === 'lent' ? 'Presté' : 'Me prestaron'}
               </Badge>
@@ -151,9 +178,21 @@ export function LoansTable({ loans, onEdit, onSettle, onDelete }: Props) {
                 <Text fontSize="xs" color="#808080">{loan.notes}</Text>
               )}
             </HStack>
-            <HStack gap={2}>
+            <PaidProgress loan={loan} />
+            <HStack gap={2} mt={3}>
               {loan.status === 'active' && (
                 <>
+                  <Button
+                    size="sm"
+                    bg="#F97316"
+                    color="white"
+                    _hover={{ bg: '#EA580C' }}
+                    flex={1}
+                    onClick={() => onPayment(loan)}
+                  >
+                    <FiPlusCircle />
+                    Abono
+                  </Button>
                   <Button
                     size="sm"
                     bg="#4F46E5"

--- a/lib/actions/loans.actions.ts
+++ b/lib/actions/loans.actions.ts
@@ -122,6 +122,68 @@ export async function deleteLoan(userId: string, loanId: string) {
   return { success: true }
 }
 
+export async function addLoanPayment(
+  userId: string,
+  loanId: string,
+  paymentAmount: number
+) {
+  const { data: loan, error: fetchErr } = await insforgeAdmin.database
+    .from('loans')
+    .select('*')
+    .eq('id', loanId)
+    .eq('user_id', userId)
+    .single()
+
+  if (fetchErr || !loan) return { success: false, error: 'Préstamo no encontrado' }
+  if (loan.status === 'settled') return { success: false, error: 'El préstamo ya está saldado' }
+
+  const currentPaid = Number(loan.paid_amount ?? 0)
+  const newPaid = currentPaid + paymentAmount
+  const loanAmount = Number(loan.amount)
+
+  // Apply balance delta: lent = I got partial payment back (add); borrowed = I paid partial (subtract)
+  if (loan.account_id) {
+    await applyBalanceDelta(
+      loan.account_id,
+      paymentAmount,
+      loan.currency,
+      loan.type === 'lent' ? 'add' : 'subtract'
+    )
+  }
+
+  if (newPaid >= loanAmount) {
+    // Fully settled via partial payments
+    const { error } = await insforgeAdmin.database
+      .from('loans')
+      .update({
+        paid_amount: loanAmount,
+        status: 'settled',
+        settled_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      })
+      .eq('id', loanId)
+      .eq('user_id', userId)
+
+    if (error) return { success: false, error: error.message }
+  } else {
+    const { error } = await insforgeAdmin.database
+      .from('loans')
+      .update({
+        paid_amount: newPaid,
+        updated_at: new Date().toISOString(),
+      })
+      .eq('id', loanId)
+      .eq('user_id', userId)
+
+    if (error) return { success: false, error: error.message }
+  }
+
+  revalidatePath('/loans')
+  revalidatePath('/movimientos')
+  revalidatePath('/dashboard')
+  return { success: true, settled: newPaid >= loanAmount }
+}
+
 export async function settleLoan(userId: string, loanId: string) {
   const { data: loan, error: fetchErr } = await insforgeAdmin.database
     .from('loans')

--- a/supabase/seeds/loans-paid-amount-v1.5.sql
+++ b/supabase/seeds/loans-paid-amount-v1.5.sql
@@ -1,0 +1,5 @@
+-- Agregar columna paid_amount a la tabla loans para soporte de abonos parciales
+-- Ejecutar en Supabase → SQL Editor antes de hacer deploy de v1.5
+-- v1.5.0 — 2026-04-24
+
+ALTER TABLE loans ADD COLUMN IF NOT EXISTS paid_amount numeric DEFAULT 0;

--- a/types/database.types.ts
+++ b/types/database.types.ts
@@ -164,6 +164,7 @@ export interface Loan {
   user_id: string
   person_name: string
   amount: number
+  paid_amount: number
   currency: Currency
   account_id: string | null
   type: LoanType


### PR DESCRIPTION
## Cambios
- `Loan.paid_amount` agregado al tipo TypeScript
- `addLoanPayment()`: nueva server action para abonos parciales
- `LoanPaymentForm`: modal con validación de saldo pendiente
- `LoansTable`: botón 'Abono' (naranja) + badge de progreso abonado/total
- `LoansPageClient`: conecta el modal de abono

## SQL a ejecutar en Supabase antes del deploy
Ver `supabase/seeds/loans-paid-amount-v1.5.sql`:
```sql
ALTER TABLE loans ADD COLUMN IF NOT EXISTS paid_amount numeric DEFAULT 0;
```

Closes #234