### PR TITLE
feat: abonos a metas de ahorro vinculados a cuenta y balance

### DIFF
--- a/app/(dashboard)/planificacion/PlanificacionPageClient.tsx
+++ b/app/(dashboard)/planificacion/PlanificacionPageClient.tsx
@@ -4,7 +4,7 @@ import { Box, Heading, Tabs } from '@chakra-ui/react'
 import { useRouter } from 'next/navigation'
 import { SavingsGoalsPageContent } from '@/components/savings/SavingsGoalsPageContent'
 import { BudgetsPageClient } from '../budgets/BudgetsPageClient'
-import type { SavingsGoal, Category } from '@/types/database.types'
+import type { Account, SavingsGoal, Category } from '@/types/database.types'
 
 type Tab = 'metas' | 'presupuestos'
 
@@ -14,6 +14,7 @@ interface Props {
   initialGoals: SavingsGoal[] | null
   initialBudgets: unknown[] | null
   categories: Category[]
+  accounts?: Account[]
 }
 
 export function PlanificacionPageClient({
@@ -22,6 +23,7 @@ export function PlanificacionPageClient({
   initialGoals,
   initialBudgets,
   categories,
+  accounts = [],
 }: Props) {
   const router = useRouter()
 
@@ -59,7 +61,7 @@ export function PlanificacionPageClient({
 
         <Tabs.Content value="metas">
           {initialGoals !== null && (
-            <SavingsGoalsPageContent userId={userId} initialGoals={initialGoals} />
+            <SavingsGoalsPageContent userId={userId} initialGoals={initialGoals} accounts={accounts} />
           )}
         </Tabs.Content>
 

--- a/app/(dashboard)/planificacion/page.tsx
+++ b/app/(dashboard)/planificacion/page.tsx
@@ -5,8 +5,9 @@ import { insforgeAdmin } from '@/lib/insforge-admin'
 import { getSavingsGoals } from '@/lib/actions/savings.actions'
 import { getCategories } from '@/lib/actions/categories.actions'
 import { getBudgets } from '@/lib/actions/budgets.actions'
+import { getAccounts } from '@/lib/actions/accounts.actions'
 import { PlanificacionPageClient } from './PlanificacionPageClient'
-import type { SavingsGoal, Category } from '@/types/database.types'
+import type { SavingsGoal, Category, Account } from '@/types/database.types'
 
 type Tab = 'metas' | 'presupuestos'
 
@@ -37,10 +38,15 @@ export default async function PlanificacionPage({
   let initialGoals: SavingsGoal[] | null = null
   let initialBudgets: unknown[] | null = null
   let categories: Category[] = []
+  let accounts: Account[] = []
 
   if (tab === 'metas') {
-    const result = await getSavingsGoals(user.id)
-    initialGoals = result.success ? (result.data ?? []) : []
+    const [goalsResult, accountsResult] = await Promise.all([
+      getSavingsGoals(user.id),
+      getAccounts(user.id),
+    ])
+    initialGoals = goalsResult.success ? (goalsResult.data ?? []) : []
+    accounts = (accountsResult.success ? accountsResult.data : []) as Account[]
   } else if (tab === 'presupuestos') {
     const [categoriesResult, budgetsResult] = await Promise.all([
       getCategories(user.id),
@@ -57,6 +63,7 @@ export default async function PlanificacionPage({
       initialGoals={initialGoals}
       initialBudgets={initialBudgets}
       categories={categories}
+      accounts={accounts}
     />
   )
 }

--- a/components/savings/AddFundsForm.tsx
+++ b/components/savings/AddFundsForm.tsx
@@ -1,0 +1,125 @@
+'use client'
+
+import { useState } from 'react'
+import { VStack, Button, Text, FieldRoot, FieldLabel, NativeSelectRoot, NativeSelectField } from '@chakra-ui/react'
+import { FormDialog } from '@/components/ui/FormDialog'
+import { InputAmount } from '@/components/ui/InputAmount'
+import { CurrencySelect } from '@/components/ui/CurrencySelect'
+import { addFundsToGoal } from '@/lib/actions/savings.actions'
+import { toaster } from '@/lib/toaster'
+import type { Account, Currency, SavingsGoal } from '@/types/database.types'
+
+interface Props {
+  isOpen: boolean
+  onClose: () => void
+  goal: SavingsGoal
+  userId: string
+  accounts: Account[]
+  onSuccess: () => void
+}
+
+export function AddFundsForm({ isOpen, onClose, goal, userId, accounts, onSuccess }: Props) {
+  const [amount, setAmount] = useState<number | undefined>(undefined)
+  const [accountId, setAccountId] = useState<string>('')
+  const [currency, setCurrency] = useState<Currency>(goal.currency)
+  const [loading, setLoading] = useState(false)
+
+  const activeAccounts = accounts.filter((a) => a.is_active)
+
+  const handleAccountChange = (id: string) => {
+    setAccountId(id)
+    if (id) {
+      const account = activeAccounts.find((a) => a.id === id)
+      if (account) setCurrency(account.currency)
+    } else {
+      setCurrency(goal.currency)
+    }
+  }
+
+  const handleSubmit = async () => {
+    if (!amount || amount <= 0) {
+      toaster.create({ title: 'Ingresa un monto válido', type: 'error', duration: 3000 })
+      return
+    }
+
+    setLoading(true)
+    const result = await addFundsToGoal(goal.id, userId, {
+      amount,
+      account_id: accountId || undefined,
+      currency,
+    })
+    setLoading(false)
+
+    if (result.success) {
+      toaster.create({ title: 'Fondos añadidos', type: 'success', duration: 3000 })
+      setAmount(undefined)
+      setAccountId('')
+      setCurrency(goal.currency)
+      onClose()
+      onSuccess()
+    } else {
+      toaster.create({ title: result.error || 'Error al añadir fondos', type: 'error', duration: 4000 })
+    }
+  }
+
+  return (
+    <FormDialog
+      isOpen={isOpen}
+      onClose={onClose}
+      title={`Añadir fondos — ${goal.name}`}
+    >
+      <VStack gap={4} align="stretch">
+        <Text fontSize="sm" color="#B0B0B0">
+          Meta: <Text as="span" color="white" fontWeight="600">
+            {goal.current_amount.toLocaleString()} / {goal.target_amount.toLocaleString()} {goal.currency}
+          </Text>
+        </Text>
+
+        {activeAccounts.length > 0 && (
+          <FieldRoot>
+            <FieldLabel>Cuenta de origen <Text as="span" color="#B0B0B0" fontSize="xs">(opcional)</Text></FieldLabel>
+            <NativeSelectRoot>
+              <NativeSelectField
+                value={accountId}
+                onChange={(e) => handleAccountChange(e.target.value)}
+              >
+                <option value="">Sin cuenta</option>
+                {activeAccounts.map((a) => (
+                  <option key={a.id} value={a.id}>
+                    {a.icon ?? ''} {a.name} — {a.currency}
+                  </option>
+                ))}
+              </NativeSelectField>
+            </NativeSelectRoot>
+          </FieldRoot>
+        )}
+
+        <CurrencySelect
+          value={currency}
+          onChange={setCurrency}
+          showFullLabel
+        />
+
+        <InputAmount
+          label="Monto"
+          value={amount}
+          onChange={setAmount}
+          isRequired
+        />
+
+        <Button
+          bg="#4F46E5"
+          color="white"
+          _hover={{ bg: '#4338CA' }}
+          onClick={handleSubmit}
+          loading={loading}
+          loadingText="Añadiendo..."
+          w="full"
+          mt={2}
+        >
+          Añadir Fondos
+        </Button>
+      </VStack>
+    </FormDialog>
+  )
+}

--- a/components/savings/SavingsGoalCard.tsx
+++ b/components/savings/SavingsGoalCard.tsx
@@ -1,20 +1,19 @@
 'use client'
 
 import { Box, VStack, HStack, Text, Button, Badge, IconButton } from '@chakra-ui/react'
-import { InputAmount } from '@/components/ui/InputAmount'
 import { FiEdit2, FiTrash2 } from 'react-icons/fi'
 import { useState } from 'react'
 import { useRouter } from 'next/navigation'
-import { addFundsToGoal, deleteSavingsGoal } from '@/lib/actions/savings.actions'
+import { deleteSavingsGoal } from '@/lib/actions/savings.actions'
 import { toaster } from '@/lib/toaster'
 import { ConfirmDialog } from '@/components/ui/ConfirmDialog'
-import { FormDialog } from '@/components/ui/FormDialog'
-import { PrimaryButton } from '@/components/ui/PrimaryButton'
-import type { SavingsGoal } from '@/types/database.types'
+import { AddFundsForm } from '@/components/savings/AddFundsForm'
+import type { Account, SavingsGoal } from '@/types/database.types'
 
 interface Props {
   goal: SavingsGoal
   userId: string
+  accounts: Account[]
   onEdit: (goal: SavingsGoal) => void
 }
 
@@ -24,34 +23,14 @@ function getStatusBadge(goal: SavingsGoal) {
   return { label: 'En Progreso', colorPalette: 'blue' }
 }
 
-export function SavingsGoalCard({ goal, userId, onEdit }: Props) {
+export function SavingsGoalCard({ goal, userId, accounts, onEdit }: Props) {
   const router = useRouter()
   const [isAddFundsOpen, setIsAddFundsOpen] = useState(false)
-  const [fundsAmount, setFundsAmount] = useState<number | undefined>(undefined)
-  const [loading, setLoading] = useState(false)
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
   const [deleteLoading, setDeleteLoading] = useState(false)
 
   const progress = (goal.current_amount / goal.target_amount) * 100
   const status = getStatusBadge(goal)
-
-  const handleAddFunds = async () => {
-    if (!fundsAmount || fundsAmount <= 0) {
-      toaster.create({ title: 'Por favor ingresa un monto', type: 'error', duration: 3000 })
-      return
-    }
-    setLoading(true)
-    const result = await addFundsToGoal(goal.id, userId, { amount: fundsAmount ?? 0 })
-    setLoading(false)
-    if (result.success) {
-      toaster.create({ title: 'Fondos añadidos', type: 'success', duration: 3000 })
-      setFundsAmount(undefined)
-      setIsAddFundsOpen(false)
-      router.refresh()
-    } else {
-      toaster.create({ title: result.error || 'Error', type: 'error', duration: 3000 })
-    }
-  }
 
   const confirmDelete = async () => {
     setDeleteLoading(true)
@@ -141,23 +120,14 @@ export function SavingsGoalCard({ goal, userId, onEdit }: Props) {
         isLoading={deleteLoading}
       />
 
-      <FormDialog
+      <AddFundsForm
         isOpen={isAddFundsOpen}
-        onClose={() => { setIsAddFundsOpen(false); setFundsAmount(undefined) }}
-        title="Añadir Fondos"
-      >
-        <VStack gap="4">
-          <InputAmount
-            label="Monto"
-            value={fundsAmount}
-            onChange={setFundsAmount}
-            isRequired
-          />
-          <PrimaryButton width="full" loading={loading} onClick={handleAddFunds}>
-            Añadir
-          </PrimaryButton>
-        </VStack>
-      </FormDialog>
+        onClose={() => setIsAddFundsOpen(false)}
+        goal={goal}
+        userId={userId}
+        accounts={accounts}
+        onSuccess={() => router.refresh()}
+      />
     </>
   )
 }

--- a/components/savings/SavingsGoalsGrid.tsx
+++ b/components/savings/SavingsGoalsGrid.tsx
@@ -2,15 +2,16 @@
 
 import { Grid, Text } from '@chakra-ui/react'
 import { SavingsGoalCard } from './SavingsGoalCard'
-import type { SavingsGoal } from '@/types/database.types'
+import type { Account, SavingsGoal } from '@/types/database.types'
 
 interface Props {
   userId: string
   goals: SavingsGoal[]
+  accounts: Account[]
   onEdit: (goal: SavingsGoal) => void
 }
 
-export function SavingsGoalsGrid({ userId, goals, onEdit }: Props) {
+export function SavingsGoalsGrid({ userId, goals, accounts, onEdit }: Props) {
   if (goals.length === 0) {
     return <Text color="fg.muted">Sin metas de ahorro. ¡Crea una para comenzar!</Text>
   }
@@ -18,7 +19,7 @@ export function SavingsGoalsGrid({ userId, goals, onEdit }: Props) {
   return (
     <Grid templateColumns={{ base: '1fr', md: 'repeat(2, 1fr)', lg: 'repeat(3, 1fr)' }} gap="4">
       {goals.map(goal => (
-        <SavingsGoalCard key={goal.id} goal={goal} userId={userId} onEdit={onEdit} />
+        <SavingsGoalCard key={goal.id} goal={goal} userId={userId} accounts={accounts} onEdit={onEdit} />
       ))}
     </Grid>
   )

--- a/components/savings/SavingsGoalsPageContent.tsx
+++ b/components/savings/SavingsGoalsPageContent.tsx
@@ -6,14 +6,15 @@ import { useRouter } from 'next/navigation'
 import { FiPlus } from 'react-icons/fi'
 import { SavingsGoalForm } from '@/components/savings/SavingsGoalForm'
 import { SavingsGoalsGrid } from '@/components/savings/SavingsGoalsGrid'
-import type { SavingsGoal } from '@/types/database.types'
+import type { Account, SavingsGoal } from '@/types/database.types'
 
 interface Props {
   userId: string
   initialGoals: SavingsGoal[]
+  accounts?: Account[]
 }
 
-export function SavingsGoalsPageContent({ userId, initialGoals }: Props) {
+export function SavingsGoalsPageContent({ userId, initialGoals, accounts = [] }: Props) {
   const [isFormOpen, setIsFormOpen] = useState(false)
   const [editingGoal, setEditingGoal] = useState<SavingsGoal | null>(null)
   const router = useRouter()
@@ -45,7 +46,7 @@ export function SavingsGoalsPageContent({ userId, initialGoals }: Props) {
         }}
       />
 
-      <SavingsGoalsGrid userId={userId} goals={initialGoals} onEdit={setEditingGoal} />
+      <SavingsGoalsGrid userId={userId} goals={initialGoals} accounts={accounts} onEdit={setEditingGoal} />
     </VStack>
   )
 }

--- a/lib/actions/savings.actions.ts
+++ b/lib/actions/savings.actions.ts
@@ -2,6 +2,7 @@
 
 import { revalidatePath } from 'next/cache'
 import { insforgeAdmin } from '@/lib/insforge-admin'
+import { applyBalanceDelta } from '@/lib/utils/balance-updater'
 import {
   createSavingsGoalSchema,
   updateSavingsGoalSchema,
@@ -10,7 +11,7 @@ import {
   type UpdateSavingsGoalInput,
   type AddFundsInput,
 } from '@/lib/validations/savings'
-import type { SavingsGoal } from '@/types/database.types'
+import type { SavingsGoal, Currency } from '@/types/database.types'
 
 export async function createSavingsGoal(userId: string, data: CreateSavingsGoalInput) {
   if (!userId) {
@@ -111,7 +112,11 @@ export async function deleteSavingsGoal(id: string, userId: string) {
   }
 }
 
-export async function addFundsToGoal(id: string, userId: string, data: AddFundsInput) {
+export async function addFundsToGoal(
+  id: string,
+  userId: string,
+  data: AddFundsInput & { account_id?: string; currency?: Currency }
+) {
   try {
     const validated = addFundsSchema.parse(data)
 
@@ -137,8 +142,26 @@ export async function addFundsToGoal(id: string, userId: string, data: AddFundsI
 
     if (updateError) throw updateError
 
+    const contributionCurrency = data.currency ?? goal.currency
+
+    // Record the contribution
+    await insforgeAdmin.database.from('savings_contributions').insert({
+      goal_id: id,
+      user_id: userId,
+      amount: validated.amount,
+      currency: contributionCurrency,
+      account_id: data.account_id ?? null,
+    })
+
+    // Deduct from account balance when an account is specified
+    if (data.account_id) {
+      await applyBalanceDelta(data.account_id, validated.amount, contributionCurrency, 'subtract')
+    }
+
     revalidatePath('/savings-goals')
     revalidatePath('/planificacion')
+    revalidatePath('/dashboard')
+    revalidatePath('/settings')
     return { success: true, data: updated as SavingsGoal }
   } catch (error) {
     console.error('Add funds to goal error:', error)

--- a/supabase/seeds/savings-contributions-v1.5.sql
+++ b/supabase/seeds/savings-contributions-v1.5.sql
@@ -1,0 +1,26 @@
+-- Tabla para registrar aportes a metas de ahorro con cuenta y moneda
+-- Ejecutar en Supabase → SQL Editor antes del deploy de v1.5
+-- v1.5.0 — 2026-04-24
+
+CREATE TABLE IF NOT EXISTS savings_contributions (
+  id uuid DEFAULT gen_random_uuid() PRIMARY KEY,
+  goal_id uuid REFERENCES savings_goals(id) ON DELETE CASCADE NOT NULL,
+  user_id text NOT NULL,
+  amount numeric NOT NULL CHECK (amount > 0),
+  currency text NOT NULL,
+  account_id uuid REFERENCES accounts(id) ON DELETE SET NULL,
+  created_at timestamptz DEFAULT now() NOT NULL
+);
+
+-- Index for querying by goal
+CREATE INDEX IF NOT EXISTS idx_savings_contributions_goal_id ON savings_contributions(goal_id);
+
+-- Enable RLS
+ALTER TABLE savings_contributions ENABLE ROW LEVEL SECURITY;
+
+-- Policy: users can only see/modify their own contributions
+CREATE POLICY "Users can manage their own savings contributions"
+  ON savings_contributions
+  FOR ALL
+  USING (user_id = auth.uid()::text)
+  WITH CHECK (user_id = auth.uid()::text);


### PR DESCRIPTION
## Cambios
- `AddFundsForm`: nuevo componente con selector de cuenta (opcional) y moneda
- `addFundsToGoal`: acepta `account_id` + `currency`, crea registro en `savings_contributions`, llama `applyBalanceDelta` para descontar de la cuenta
- `SavingsGoalCard`: usa `AddFundsForm` en lugar del dialog simple
- `SavingsGoalsGrid/PageContent`: prop `accounts` threaded
- `PlanificacionPageClient/page`: fetchea accounts cuando tab=metas

## SQL a ejecutar en Supabase antes del deploy
Ver `supabase/seeds/savings-contributions-v1.5.sql` — crea tabla `savings_contributions` con RLS.

Closes #236