### PR TITLE
feat: add created_at secondary sort for consistent table ordering

### DIFF
--- a/lib/actions/export.actions.ts
+++ b/lib/actions/export.actions.ts
@@ -14,6 +14,7 @@ export async function exportTransactions(userId: string, format: 'csv' | 'json')
       .select('*, category:categories(*)')
       .eq('user_id', userId)
       .order('date', { ascending: false })
+      .order('created_at', { ascending: false })
 
     if (error) throw error
 

--- a/lib/actions/recurring.actions.ts
+++ b/lib/actions/recurring.actions.ts
@@ -60,6 +60,7 @@ export async function getRecurringTransactions(userId: string, limit = 50) {
       .select('*, category:categories(*)')
       .eq('user_id', userId)
       .order('start_date', { ascending: false })
+      .order('created_at', { ascending: false })
       .limit(limit)
 
     if (error) throw error

--- a/lib/actions/transactions.actions.ts
+++ b/lib/actions/transactions.actions.ts
@@ -53,6 +53,7 @@ export async function getTransactions(userId: string, limit = 50) {
       .select('*, category:categories(*)')
       .eq('user_id', userId)
       .order('date', { ascending: false })
+      .order('created_at', { ascending: false })
       .limit(limit)
 
     if (error) throw error


### PR DESCRIPTION
## Cambios
- `transactions.actions.ts`: agrega `.order('created_at', { ascending: false })` como sort secundario tras `date DESC`
- `recurring.actions.ts`: agrega `.order('created_at', { ascending: false })` como sort secundario tras `start_date DESC`
- `export.actions.ts`: mismo patrón para exportación

## Comportamiento
- Los registros se agrupan por fecha de la transacción (día)
- Dentro del mismo día aparecen en el orden en que fueron creados
- Editar un registro (sin cambiar su fecha) **no altera su posición**

## Testing
- ✅ Sin errores de TypeScript
- ✅ account_movements ya tenía el patrón correcto (sin cambios)

Closes #242
Related to #241