### PR TITLE
feat: add 'Crafted with ❤️ and Next.js by Sanghel González' footer

### DIFF
--- a/components/dashboard/CraftedByFooter.tsx
+++ b/components/dashboard/CraftedByFooter.tsx
@@ -1,0 +1,32 @@
+'use client'
+
+import { Flex, Text, Icon } from '@chakra-ui/react'
+import { FiHeart } from 'react-icons/fi'
+
+function NextJsLogo() {
+  return (
+    <svg
+      width="13"
+      height="13"
+      viewBox="0 0 180 180"
+      fill="white"
+      xmlns="http://www.w3.org/2000/svg"
+      style={{ display: 'inline-block', verticalAlign: 'middle', opacity: 0.7 }}
+    >
+      <path d="M90 0L174.853 155.25H5.14746L90 0Z" />
+    </svg>
+  )
+}
+
+export function CraftedByFooter() {
+  return (
+    <Flex align="center" gap="4px" justify="center" flexWrap="wrap">
+      <Text fontSize="xs" color="#6B7280">Crafted with</Text>
+      <Icon as={FiHeart} color="#E53E3E" boxSize="12px" />
+      <Text fontSize="xs" color="#6B7280">and</Text>
+      <NextJsLogo />
+      <Text fontSize="xs" color="#6B7280">by</Text>
+      <Text fontSize="xs" color="#9CA3AF" fontWeight="medium">Sanghel González</Text>
+    </Flex>
+  )
+}

--- a/components/dashboard/MobileNav.tsx
+++ b/components/dashboard/MobileNav.tsx
@@ -11,7 +11,9 @@ import {
   Button,
   Icon,
   Spinner,
+  Box,
 } from '@chakra-ui/react'
+import { CraftedByFooter } from './CraftedByFooter'
 import { usePathname } from 'next/navigation'
 import {
   FiHome,
@@ -56,8 +58,8 @@ export function MobileNav({ isOpen, onClose }: Props) {
           style={{ paddingTop: 'env(safe-area-inset-top)', paddingBottom: 'env(safe-area-inset-bottom)' }}
         >
           <DrawerCloseTrigger color="white" top={3} left={3} />
-          <DrawerBody px={3} pt={12} pb={4}>
-            <VStack gap={1} align="stretch">
+          <DrawerBody px={3} pt={12} pb={4} display="flex" flexDirection="column">
+            <VStack gap={1} align="stretch" flex={1}>
               {navItems.map((item) => {
                 const isActive = pathname === item.href
                 const isLoading = loadingPath === item.href
@@ -78,6 +80,9 @@ export function MobileNav({ isOpen, onClose }: Props) {
                 )
               })}
             </VStack>
+            <Box pt={4} pb={2} borderTopWidth="1px" borderColor="#2d2d35" mt={4}>
+              <CraftedByFooter />
+            </Box>
           </DrawerBody>
         </DrawerContent>
       </DrawerPositioner>

--- a/components/dashboard/Sidebar.tsx
+++ b/components/dashboard/Sidebar.tsx
@@ -2,6 +2,7 @@
 
 import { Box, VStack, Button, Icon, Spinner } from '@chakra-ui/react'
 import { usePathname } from 'next/navigation'
+import { CraftedByFooter } from './CraftedByFooter'
 import {
   FiHome,
   FiBarChart2,
@@ -38,10 +39,11 @@ export function Sidebar() {
       h="full"
       p={4}
       flexShrink={0}
-      display={{ base: 'none', md: 'block' }}
+      display={{ base: 'none', md: 'flex' }}
+      flexDirection="column"
       overflowY="auto"
     >
-      <VStack gap={2} align="stretch">
+      <VStack gap={2} align="stretch" flex={1}>
         {navItems.map((item) => {
           const isActive = pathname === item.href
           const isLoading = loadingPath === item.href
@@ -62,6 +64,9 @@ export function Sidebar() {
           )
         })}
       </VStack>
+      <Box pt={4} pb={2} borderTopWidth="1px" borderColor="#2d2d35" mt={4}>
+        <CraftedByFooter />
+      </Box>
     </Box>
   )
 }


### PR DESCRIPTION
## Cambios
- Nuevo componente `components/dashboard/CraftedByFooter.tsx` con el mensaje de atribución y el logo SVG oficial de Next.js (triángulo ▲)
- `Sidebar.tsx`: ahora usa `display: flex, flexDirection: column` para empujar el footer al fondo; el footer aparece separado por un borde superior
- `MobileNav.tsx`: el `DrawerBody` también usa flex column, con el footer al pie del drawer

## Visual
```
Crafted with ❤️ and ▲ by Sanghel González
```
Visible en la parte inferior del sidebar (desktop) y del drawer de navegación (mobile)

## Testing
- ✅ Build exitoso sin errores TypeScript
- ✅ Probado en desktop y mobile

Closes #244
Related to #241