### PR TITLE
fix: traducir tipo de transacción a español en modal del calendario

### DIFF
--- a/components/calendar/TransactionCalendar.tsx
+++ b/components/calendar/TransactionCalendar.tsx
@@ -201,7 +201,7 @@ export function TransactionCalendar({ initialTransactions }: Props) {
                       </HStack>
                       <HStack justifyContent="space-between" fontSize="sm" color="fg.muted">
                         <Text>{txn.category.name}</Text>
-                        <Text>{txn.type}</Text>
+                        <Text>{{ expense: 'Gasto', income: 'Ingreso' }[txn.type] ?? txn.type}</Text>
                       </HStack>
                       {txn.notes && (
                         <Text fontSize="sm" mt="2" color="fg.muted">


### PR DESCRIPTION
## Cambios
- Modal del calendario ahora muestra 'Gasto'/'Ingreso' en lugar de 'expense'/'income'

## Testing
- ✅ Sin errores de TypeScript

Closes #248
Related to #247