### PR TITLE
fix: agregar safe area inset top en modales para iPhone

### DIFF
--- a/components/calendar/TransactionCalendar.tsx
+++ b/components/calendar/TransactionCalendar.tsx
@@ -163,7 +163,7 @@ export function TransactionCalendar({ initialTransactions }: Props) {
       <DialogRoot open={selectedDay !== null} onOpenChange={details => !details.open && setSelectedDay(null)} size="md" placement="center" lazyMount unmountOnExit closeOnInteractOutside={false}>
         <DialogBackdrop />
         <DialogPositioner>
-          <DialogContent tabIndex={-1} mx={{ base: 3, md: 0 }}>
+          <DialogContent tabIndex={-1} mx={{ base: 3, md: 0 }} style={{ marginTop: 'max(16px, env(safe-area-inset-top))' }}>
             <DialogHeader borderBottomWidth="1px" borderColor="#2d2d35" py={4}>
               <HStack justify="space-between" align="center">
                 <DialogTitle color="white">Transacciones del {selectedDay?.[0] && new Date(selectedDay[0].date).toLocaleDateString('es-ES')}</DialogTitle>

--- a/components/ui/FormDialog.tsx
+++ b/components/ui/FormDialog.tsx
@@ -36,7 +36,7 @@ export function FormDialog({ isOpen, onClose, title, children, size = 'md' }: Pr
     >
       <DialogBackdrop />
       <DialogPositioner>
-        <DialogContent tabIndex={-1} mx={{ base: 3, md: 0 }} maxH="90vh" overflowY="auto">
+        <DialogContent tabIndex={-1} mx={{ base: 3, md: 0 }} maxH="90vh" overflowY="auto" style={{ marginTop: 'max(16px, env(safe-area-inset-top))' }}>
           <DialogHeader borderBottomWidth="1px" borderColor="#2d2d35" py={4}>
             <HStack justify="space-between" align="center">
               <DialogTitle color="white">{title}</DialogTitle>


### PR DESCRIPTION
## Cambios
- FormDialog.tsx: DialogContent ahora respeta env(safe-area-inset-top) en mobile
- TransactionCalendar.tsx: mismo fix en el modal de detalle de transacciones

## Testing
- ✅ La X del modal queda visible sobre el notch en iPhone
- ✅ Sin errores de TypeScript

Closes #250
Related to #247