### PR TITLE
fix: eliminar padding duplicado en páginas mobile

### DIFF
--- a/app/(dashboard)/movimientos/MovimientosPageClient.tsx
+++ b/app/(dashboard)/movimientos/MovimientosPageClient.tsx
@@ -55,7 +55,7 @@ export function MovimientosPageClient({
     pendingTab === tab && isPending ? <Spinner size="xs" /> : <Icon />
 
   return (
-    <Box p={{ base: 4, md: 6 }}>
+    <Box>
       <Heading size="lg" mb={6} color="white">
         Movimientos
       </Heading>

--- a/app/(dashboard)/planificacion/PlanificacionPageClient.tsx
+++ b/app/(dashboard)/planificacion/PlanificacionPageClient.tsx
@@ -46,7 +46,7 @@ export function PlanificacionPageClient({
     pendingTab === tab && isPending ? <Spinner size="xs" /> : <Icon />
 
   return (
-    <Box p={{ base: 4, md: 6 }}>
+    <Box>
       <Heading size="lg" mb={6} color="white">
         Planificación
       </Heading>

--- a/app/(dashboard)/settings/SettingsPageClient.tsx
+++ b/app/(dashboard)/settings/SettingsPageClient.tsx
@@ -56,7 +56,7 @@ export function SettingsPageClient({
     pendingTab === tab && isPending ? <Spinner size="xs" /> : <Icon />
 
   return (
-    <Box p={6}>
+    <Box>
       <Heading size="lg" mb={8} color="white">
         Configuración
       </Heading>


### PR DESCRIPTION
## Cambios
- Removido p={{ base: 4, md: 6 }} de MovimientosPageClient (duplicaba el del DashboardShell)
- Removido p={{ base: 4, md: 6 }} de PlanificacionPageClient
- Removido p={6} de SettingsPageClient

El DashboardShell ya aplica padding responsivo en el contenedor principal.

## Testing
- ✅ Padding consistente con el Dashboard en todas las páginas
- ✅ Sin errores de TypeScript

Closes #252
Related to #247