### PR TITLE
fix: envolver iconos de tabs en componente Icon de Chakra

### DIFF
--- a/app/(dashboard)/movimientos/MovimientosPageClient.tsx
+++ b/app/(dashboard)/movimientos/MovimientosPageClient.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useTransition, useState, useEffect } from 'react'
-import { Box, Heading, Tabs, Spinner } from '@chakra-ui/react'
+import { Box, Heading, Tabs, Spinner, Icon } from '@chakra-ui/react'
 import { useRouter } from 'next/navigation'
 import { FiList, FiRepeat, FiCreditCard } from 'react-icons/fi'
 import { TransactionsPageClient } from '../transactions/TransactionsPageClient'
@@ -51,8 +51,8 @@ export function MovimientosPageClient({
     })
   }
 
-  const tabIcon = (tab: string, Icon: React.ElementType) =>
-    pendingTab === tab && isPending ? <Spinner size="xs" /> : <Icon />
+  const tabIcon = (tab: string, IconComponent: React.ElementType) =>
+    pendingTab === tab && isPending ? <Spinner size="xs" /> : <Icon as={IconComponent} boxSize={4} />
 
   return (
     <Box>

--- a/app/(dashboard)/settings/SettingsPageClient.tsx
+++ b/app/(dashboard)/settings/SettingsPageClient.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useTransition, useState, useEffect } from 'react'
-import { Box, Heading, VStack, Text, Separator, Tabs, Spinner } from '@chakra-ui/react'
+import { Box, Heading, VStack, Text, Separator, Tabs, Spinner, Icon } from '@chakra-ui/react'
 import { useRouter } from 'next/navigation'
 import { FiSliders, FiBriefcase, FiTag } from 'react-icons/fi'
 import { CurrencySelector } from '@/components/settings/CurrencySelector'
@@ -52,8 +52,8 @@ export function SettingsPageClient({
     })
   }
 
-  const tabIcon = (tab: string, Icon: React.ElementType) =>
-    pendingTab === tab && isPending ? <Spinner size="xs" /> : <Icon />
+  const tabIcon = (tab: string, IconComponent: React.ElementType) =>
+    pendingTab === tab && isPending ? <Spinner size="xs" /> : <Icon as={IconComponent} boxSize={4} />
 
   return (
     <Box>


### PR DESCRIPTION
## Cambios
- MovimientosPageClient: icon helper usa <Icon as={...} boxSize={4} /> en lugar de <Icon />
- SettingsPageClient: mismo fix
- Renombrado parámetro Icon → IconComponent para evitar conflicto con import de Chakra

## Testing
- ✅ Iconos visibles en tabs de Movimientos (Transacciones, Recurrentes, Préstamos)
- ✅ Iconos visibles en tabs de Configuración (General, Cuentas, Categorías)
- ✅ Spinner sigue apareciendo al cambiar tab

Closes #254
Related to #247