### PR TITLE
fix: subir botón y ventana del AI chat en mobile

### DIFF
--- a/components/chat/FloatingChat.tsx
+++ b/components/chat/FloatingChat.tsx
@@ -36,7 +36,7 @@ export function FloatingChat({ userId, categories, accounts = [] }: Props) {
             borderColor="#2d2d35"
             overflow="hidden"
             /* Desktop */
-            bottom={{ base: '130px', md: '88px' }}
+            bottom={{ base: 'calc(140px + env(safe-area-inset-bottom))', md: '88px' }}
             right={{ base: '12px', md: '24px' }}
             left={{ base: '12px', md: 'auto' }}
             w={{ base: 'auto', md: '380px' }}
@@ -55,7 +55,7 @@ export function FloatingChat({ userId, categories, accounts = [] }: Props) {
 
       <Box
         position="fixed"
-        bottom={{ base: '72px', md: '24px' }}
+        bottom={{ base: 'calc(80px + env(safe-area-inset-bottom))', md: '24px' }}
         right="16px"
         zIndex={1001}
       >


### PR DESCRIPTION
## Cambios
- Botón: bottom cambia de 72px a calc(80px + env(safe-area-inset-bottom)) en mobile
- Ventana: bottom cambia de 130px a calc(140px + env(safe-area-inset-bottom)) en mobile
- Respeta el safe area del iPhone automáticamente

## Testing
- ✅ Botón visible sobre el BottomNav en iPhone con notch
- ✅ Ventana del chat no queda tapada por el BottomNav

Closes #256
Related to #247