### PR TITLE
fix: footer del drawer siempre pegado al fondo en mobile

### DIFF
--- a/components/dashboard/MobileNav.tsx
+++ b/components/dashboard/MobileNav.tsx
@@ -58,8 +58,8 @@ export function MobileNav({ isOpen, onClose }: Props) {
           style={{ paddingTop: 'env(safe-area-inset-top)', paddingBottom: 'env(safe-area-inset-bottom)' }}
         >
           <DrawerCloseTrigger color="white" top={3} left={3} />
-          <DrawerBody px={3} pt={12} pb={4} display="flex" flexDirection="column">
-            <VStack gap={1} align="stretch" flex={1}>
+          <DrawerBody px={3} pt={12} pb={4} display="flex" flexDirection="column" h="100%">
+            <VStack gap={1} align="stretch">
               {navItems.map((item) => {
                 const isActive = pathname === item.href
                 const isLoading = loadingPath === item.href
@@ -80,7 +80,7 @@ export function MobileNav({ isOpen, onClose }: Props) {
                 )
               })}
             </VStack>
-            <Box pt={4} pb={2} borderTopWidth="1px" borderColor="#2d2d35" mt={4}>
+            <Box pt={4} pb={2} borderTopWidth="1px" borderColor="#2d2d35" mt="auto">
               <CraftedByFooter />
             </Box>
           </DrawerBody>


### PR DESCRIPTION
## Cambios
- DrawerBody: agregado h="100%" para ocupar toda la altura disponible
- VStack: removido flex={1} (el footer lo controlaba)
- Footer Box: cambiado mt={4} → mt="auto" para empujarlo siempre al fondo

## Testing
- ✅ Footer visible al fondo al abrir el drawer
- ✅ No hay espacio vacío entre footer y borde inferior

Closes #258
Related to #247