### PR TITLE
fix: prevenir overflow del botón '¡Ya me pagaron!' en mobile

### DIFF
--- a/components/loans/LoansTable.tsx
+++ b/components/loans/LoansTable.tsx
@@ -199,6 +199,8 @@ export function LoansTable({ loans, onEdit, onSettle, onDelete, onPayment }: Pro
                     color="white"
                     _hover={{ bg: '#4338CA' }}
                     flex={1}
+                    minW={0}
+                    fontSize="xs"
                     onClick={() => onSettle(loan)}
                   >
                     <FiCheckCircle />


### PR DESCRIPTION
## Cambios
- Botón de liquidar: agrega minW={0} para permitir que se encoja con flex={1}
- Botón de liquidar: fontSize="xs" para que el texto largo quepa en el espacio disponible

## Testing
- ✅ Texto '¡Ya me pagaron!' cabe sin desbordarse en mobile
- ✅ Botón 'Abono' no afectado

Closes #262
Related to #247