### PR TITLE
FASE 7: Ajustes Visuales y UX Mobile (v1.7.0)

### DIFF
--- a/app/(dashboard)/movimientos/MovimientosPageClient.tsx
+++ b/app/(dashboard)/movimientos/MovimientosPageClient.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useTransition, useState, useEffect } from 'react'
-import { Box, Heading, Tabs, Spinner } from '@chakra-ui/react'
+import { Box, Heading, Tabs, Spinner, Icon } from '@chakra-ui/react'
 import { useRouter } from 'next/navigation'
 import { FiList, FiRepeat, FiCreditCard } from 'react-icons/fi'
 import { TransactionsPageClient } from '../transactions/TransactionsPageClient'
@@ -51,8 +51,8 @@ export function MovimientosPageClient({
     })
   }
 
-  const tabIcon = (tab: string, Icon: React.ElementType) =>
-    pendingTab === tab && isPending ? <Spinner size="xs" /> : <Icon />
+  const tabIcon = (tab: string, IconComponent: React.ElementType) =>
+    pendingTab === tab && isPending ? <Spinner size="xs" /> : <Icon as={IconComponent} boxSize={4} />
 
   return (
     <Box>

--- a/app/(dashboard)/movimientos/MovimientosPageClient.tsx
+++ b/app/(dashboard)/movimientos/MovimientosPageClient.tsx
@@ -55,7 +55,7 @@ export function MovimientosPageClient({
     pendingTab === tab && isPending ? <Spinner size="xs" /> : <Icon />
 
   return (
-    <Box p={{ base: 4, md: 6 }}>
+    <Box>
       <Heading size="lg" mb={6} color="white">
         Movimientos
       </Heading>

--- a/app/(dashboard)/planificacion/PlanificacionPageClient.tsx
+++ b/app/(dashboard)/planificacion/PlanificacionPageClient.tsx
@@ -46,7 +46,7 @@ export function PlanificacionPageClient({
     pendingTab === tab && isPending ? <Spinner size="xs" /> : <Icon />
 
   return (
-    <Box p={{ base: 4, md: 6 }}>
+    <Box>
       <Heading size="lg" mb={6} color="white">
         Planificación
       </Heading>

--- a/app/(dashboard)/settings/SettingsPageClient.tsx
+++ b/app/(dashboard)/settings/SettingsPageClient.tsx
@@ -56,7 +56,7 @@ export function SettingsPageClient({
     pendingTab === tab && isPending ? <Spinner size="xs" /> : <Icon />
 
   return (
-    <Box p={6}>
+    <Box>
       <Heading size="lg" mb={8} color="white">
         Configuración
       </Heading>

--- a/app/(dashboard)/settings/SettingsPageClient.tsx
+++ b/app/(dashboard)/settings/SettingsPageClient.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useTransition, useState, useEffect } from 'react'
-import { Box, Heading, VStack, Text, Separator, Tabs, Spinner } from '@chakra-ui/react'
+import { Box, Heading, VStack, Text, Separator, Tabs, Spinner, Icon } from '@chakra-ui/react'
 import { useRouter } from 'next/navigation'
 import { FiSliders, FiBriefcase, FiTag } from 'react-icons/fi'
 import { CurrencySelector } from '@/components/settings/CurrencySelector'
@@ -52,8 +52,8 @@ export function SettingsPageClient({
     })
   }
 
-  const tabIcon = (tab: string, Icon: React.ElementType) =>
-    pendingTab === tab && isPending ? <Spinner size="xs" /> : <Icon />
+  const tabIcon = (tab: string, IconComponent: React.ElementType) =>
+    pendingTab === tab && isPending ? <Spinner size="xs" /> : <Icon as={IconComponent} boxSize={4} />
 
   return (
     <Box>

--- a/components/calendar/TransactionCalendar.tsx
+++ b/components/calendar/TransactionCalendar.tsx
@@ -18,8 +18,9 @@ import {
   DialogCloseTrigger,
   IconButton,
   Icon,
+  useBreakpointValue,
 } from '@chakra-ui/react'
-import { FiX } from 'react-icons/fi'
+import { FiX, FiChevronDown, FiChevronRight } from 'react-icons/fi'
 import { useState } from 'react'
 import type { TransactionWithCategory } from '@/types/database.types'
 import { formatCurrency } from '@/lib/utils/currency'
@@ -32,11 +33,14 @@ interface Props {
 
 const WEEKDAYS = ['Dom', 'Lun', 'Mar', 'Mié', 'Jue', 'Vie', 'Sáb']
 const MONTHS = ['Enero', 'Febrero', 'Marzo', 'Abril', 'Mayo', 'Junio', 'Julio', 'Agosto', 'Septiembre', 'Octubre', 'Noviembre', 'Diciembre']
+const TYPE_LABELS: Record<string, string> = { expense: 'Gasto', income: 'Ingreso' }
 
 export function TransactionCalendar({ initialTransactions }: Props) {
   const [currentDate, setCurrentDate] = useState(new Date())
   const [transactions] = useState<TransactionWithCategory[]>(initialTransactions)
   const [selectedDay, setSelectedDay] = useState<TransactionWithCategory[] | null>(null)
+  const [expandedDays, setExpandedDays] = useState<Set<number>>(new Set())
+  const isMobile = useBreakpointValue({ base: true, md: false })
 
   const getDaysInMonth = (date: Date) => {
     return new Date(date.getFullYear(), date.getMonth() + 1, 0).getDate()
@@ -53,171 +57,284 @@ export function TransactionCalendar({ initialTransactions }: Props) {
 
   const handlePrevMonth = () => {
     setCurrentDate(new Date(currentDate.getFullYear(), currentDate.getMonth() - 1))
+    setExpandedDays(new Set())
   }
 
   const handleNextMonth = () => {
     setCurrentDate(new Date(currentDate.getFullYear(), currentDate.getMonth() + 1))
+    setExpandedDays(new Set())
   }
 
   const handleDayClick = (day: number) => {
     setSelectedDay(getTransactionsForDay(day))
   }
 
+  const toggleDayExpand = (day: number) => {
+    setExpandedDays(prev => {
+      const next = new Set(prev)
+      if (next.has(day)) next.delete(day)
+      else next.add(day)
+      return next
+    })
+  }
+
   const daysInMonth = getDaysInMonth(currentDate)
   const firstDay = getFirstDayOfMonth(currentDate)
-  const days = []
 
-  // Empty cells for days before month starts
-  for (let i = 0; i < firstDay; i++) {
-    days.push(null)
-  }
+  const monthHeader = (
+    <HStack justifyContent="space-between" alignItems="center">
+      <Button onClick={handlePrevMonth} variant="ghost" size={{ base: 'sm', md: 'md' }}>
+        ← Anterior
+      </Button>
+      <Text fontSize={{ base: 'md', md: 'lg' }} fontWeight="bold">
+        {MONTHS[currentDate.getMonth()]} {currentDate.getFullYear()}
+      </Text>
+      <Button onClick={handleNextMonth} variant="ghost" size={{ base: 'sm', md: 'md' }}>
+        Siguiente →
+      </Button>
+    </HStack>
+  )
 
-  // Days of month
-  for (let i = 1; i <= daysInMonth; i++) {
-    days.push(i)
-  }
+  // Desktop grid view
+  const desktopView = (() => {
+    const days: (number | null)[] = []
+    for (let i = 0; i < firstDay; i++) days.push(null)
+    for (let i = 1; i <= daysInMonth; i++) days.push(i)
+
+    return (
+      <>
+        <Grid templateColumns="repeat(7, 1fr)" gap="1">
+          {WEEKDAYS.map(day => (
+            <Text key={day} textAlign="center" fontWeight="bold" fontSize="sm" py="2">
+              {day}
+            </Text>
+          ))}
+        </Grid>
+        <Grid templateColumns="repeat(7, 1fr)" gap="1" autoRows="minmax(100px, 1fr)">
+          {days.map((day, idx) => {
+            if (day === null) return <Box key={`empty-${idx}`} />
+            const dayTransactions = getTransactionsForDay(day)
+            const hasTransactions = dayTransactions.length > 0
+            return (
+              <Box
+                key={day}
+                borderWidth="1px"
+                borderRadius="md"
+                p="2"
+                bg={hasTransactions ? '#1a1a27' : 'transparent'}
+                borderColor={hasTransactions ? '#4F46E5' : '#2d2d35'}
+                cursor={hasTransactions ? 'pointer' : 'default'}
+                onClick={() => hasTransactions && handleDayClick(day)}
+                _hover={hasTransactions ? { bg: '#252535' } : { bg: '#1a1a1a' }}
+                transition="background 0.2s"
+              >
+                <VStack alignItems="flex-start" gap="1" height="100%">
+                  <Text fontWeight="bold" fontSize="sm">{day}</Text>
+                  {dayTransactions.length > 0 && (
+                    <VStack alignItems="flex-start" gap="0.5" width="100%" flex="1" overflowY="auto">
+                      {dayTransactions.slice(0, 2).map(t => (
+                        <Badge
+                          key={t.id}
+                          fontSize="xs"
+                          variant="subtle"
+                          colorScheme={t.type === 'income' ? 'green' : 'red'}
+                          width="100%"
+                          justifyContent="flex-start"
+                        >
+                          {formatCurrency(Number(t.amount), t.currency)}
+                        </Badge>
+                      ))}
+                      {dayTransactions.length > 2 && (
+                        <Text fontSize="xs" color="fg.muted">+{dayTransactions.length - 2} más</Text>
+                      )}
+                    </VStack>
+                  )}
+                </VStack>
+              </Box>
+            )
+          })}
+        </Grid>
+      </>
+    )
+  })()
+
+  // Mobile list view
+  const mobileView = (() => {
+    const daysWithTxns: { day: number; weekday: string; txns: TransactionWithCategory[] }[] = []
+    for (let d = 1; d <= daysInMonth; d++) {
+      const txns = getTransactionsForDay(d)
+      if (txns.length > 0) {
+        const date = new Date(currentDate.getFullYear(), currentDate.getMonth(), d)
+        daysWithTxns.push({ day: d, weekday: WEEKDAYS[date.getDay()], txns })
+      }
+    }
+
+    if (daysWithTxns.length === 0) {
+      return (
+        <Box py={8} textAlign="center">
+          <Text color="#808080">Sin transacciones este mes</Text>
+        </Box>
+      )
+    }
+
+    return (
+      <VStack gap={2} align="stretch">
+        {daysWithTxns.map(({ day, weekday, txns }) => {
+          const isExpanded = expandedDays.has(day)
+          const income = txns.filter(t => t.type === 'income').reduce((s, t) => s + Number(t.amount), 0)
+          const expense = txns.filter(t => t.type === 'expense').reduce((s, t) => s + Number(t.amount), 0)
+          const currency = txns[0].currency
+
+          return (
+            <Box key={day} borderWidth="1px" borderRadius="lg" borderColor="#2d2d35" overflow="hidden">
+              <HStack
+                px={4}
+                py={3}
+                justify="space-between"
+                bg="#1a1a27"
+                cursor="pointer"
+                onClick={() => toggleDayExpand(day)}
+                _hover={{ bg: '#252535' }}
+              >
+                <HStack gap={3}>
+                  <Box
+                    w={9}
+                    h={9}
+                    borderRadius="full"
+                    bg="#4F46E5"
+                    display="flex"
+                    alignItems="center"
+                    justifyContent="center"
+                    flexShrink={0}
+                  >
+                    <Text fontWeight="bold" fontSize="sm" color="white">{day}</Text>
+                  </Box>
+                  <VStack align="flex-start" gap={0}>
+                    <Text fontSize="sm" fontWeight="semibold" color="white">{weekday}</Text>
+                    <Text fontSize="xs" color="#808080">{txns.length} transacción{txns.length !== 1 ? 'es' : ''}</Text>
+                  </VStack>
+                </HStack>
+                <HStack gap={3}>
+                  {income > 0 && (
+                    <Text fontSize="xs" color="#10B981" fontWeight="semibold">
+                      +{formatCurrency(income, currency)}
+                    </Text>
+                  )}
+                  {expense > 0 && (
+                    <Text fontSize="xs" color="#F43F5E" fontWeight="semibold">
+                      -{formatCurrency(expense, currency)}
+                    </Text>
+                  )}
+                  <Icon as={isExpanded ? FiChevronDown : FiChevronRight} color="#808080" boxSize={4} />
+                </HStack>
+              </HStack>
+
+              {isExpanded && (
+                <VStack gap={0} align="stretch" px={4} py={2} bg="#18181d">
+                  {txns.map((t, idx) => (
+                    <HStack
+                      key={t.id}
+                      justify="space-between"
+                      py={2}
+                      borderTopWidth={idx > 0 ? '1px' : '0'}
+                      borderColor="#2d2d35"
+                    >
+                      <VStack align="flex-start" gap={0}>
+                        <Text fontSize="sm" color="white">{t.description}</Text>
+                        <HStack gap={1}>
+                          <Text fontSize="xs" color="#808080">{t.category.name}</Text>
+                          <Text fontSize="xs" color="#808080">·</Text>
+                          <Text fontSize="xs" color="#808080">{TYPE_LABELS[t.type] ?? t.type}</Text>
+                        </HStack>
+                      </VStack>
+                      <Text
+                        fontSize="sm"
+                        fontWeight="semibold"
+                        color={t.type === 'income' ? '#10B981' : '#F43F5E'}
+                      >
+                        {t.type === 'income' ? '+' : '-'}{formatCurrency(Number(t.amount), t.currency)}
+                      </Text>
+                    </HStack>
+                  ))}
+                </VStack>
+              )}
+            </Box>
+          )
+        })}
+      </VStack>
+    )
+  })()
 
   return (
     <>
-      <Box borderWidth="1px" borderRadius="lg" p="6" bg="bg.surface" width="100%">
+      <Box borderWidth="1px" borderRadius="lg" p={{ base: 4, md: 6 }} bg="bg.surface" width="100%">
         <VStack gap="4" alignItems="stretch">
-          {/* Header */}
-          <HStack justifyContent="space-between" alignItems="center">
-            <Button onClick={handlePrevMonth} variant="ghost">
-              ← Anterior
-            </Button>
-            <Text fontSize="lg" fontWeight="bold">
-              {MONTHS[currentDate.getMonth()]} {currentDate.getFullYear()}
-            </Text>
-            <Button onClick={handleNextMonth} variant="ghost">
-              Siguiente →
-            </Button>
-          </HStack>
-
-          {/* Weekday headers */}
-          <Grid templateColumns="repeat(7, 1fr)" gap="1">
-            {WEEKDAYS.map(day => (
-              <Text key={day} textAlign="center" fontWeight="bold" fontSize="sm" py="2">
-                {day}
-              </Text>
-            ))}
-          </Grid>
-
-          {/* Calendar days */}
-          <Grid templateColumns="repeat(7, 1fr)" gap="1" autoRows="minmax(100px, 1fr)">
-            {days.map((day, idx) => {
-              if (day === null) {
-                return <Box key={`empty-${idx}`} />
-              }
-
-              const dayTransactions = getTransactionsForDay(day)
-              const hasTransactions = dayTransactions.length > 0
-
-              return (
-                <Box
-                  key={day}
-                  borderWidth="1px"
-                  borderRadius="md"
-                  p="2"
-                  bg={hasTransactions ? '#1a1a27' : 'transparent'}
-                  borderColor={hasTransactions ? '#4F46E5' : '#2d2d35'}
-                  cursor={hasTransactions ? 'pointer' : 'default'}
-                  onClick={() => hasTransactions && handleDayClick(day)}
-                  _hover={hasTransactions ? { bg: '#252535' } : { bg: '#1a1a1a' }}
-                  transition="background 0.2s"
-                >
-                  <VStack alignItems="flex-start" gap="1" height="100%">
-                    <Text fontWeight="bold" fontSize="sm">
-                      {day}
-                    </Text>
-                    {dayTransactions.length > 0 && (
-                      <VStack alignItems="flex-start" gap="0.5" width="100%" flex="1" overflowY="auto">
-                        {dayTransactions.slice(0, 2).map(t => (
-                          <Badge
-                            key={t.id}
-                            fontSize="xs"
-                            variant="subtle"
-                            colorScheme={t.type === 'income' ? 'green' : 'red'}
-                            width="100%"
-                            justifyContent="flex-start"
-                          >
-                            {formatCurrency(Number(t.amount), t.currency)}
-                          </Badge>
-                        ))}
-                        {dayTransactions.length > 2 && (
-                          <Text fontSize="xs" color="fg.muted">
-                            +{dayTransactions.length - 2} más
-                          </Text>
-                        )}
-                      </VStack>
-                    )}
-                  </VStack>
-                </Box>
-              )
-            })}
-          </Grid>
+          {monthHeader}
+          {isMobile ? mobileView : desktopView}
         </VStack>
       </Box>
 
-      {/* Day details dialog */}
-      <DialogRoot open={selectedDay !== null} onOpenChange={details => !details.open && setSelectedDay(null)} size="md" placement="center" lazyMount unmountOnExit closeOnInteractOutside={false}>
-        <DialogBackdrop />
-        <DialogPositioner>
-          <DialogContent tabIndex={-1} mx={{ base: 3, md: 0 }} style={{ marginTop: 'max(16px, env(safe-area-inset-top))' }}>
-            <DialogHeader borderBottomWidth="1px" borderColor="#2d2d35" py={4}>
-              <HStack justify="space-between" align="center">
-                <DialogTitle color="white">Transacciones del {selectedDay?.[0] && new Date(selectedDay[0].date).toLocaleDateString('es-ES')}</DialogTitle>
-                <DialogCloseTrigger asChild>
-                  <IconButton
-                    aria-label="Cerrar"
-                    size="sm"
-                    variant="ghost"
-                    color="#B0B0B0"
-                    _hover={{ color: 'white', bg: '#2d2d35' }}
-                    onClick={() => setSelectedDay(null)}
-                  >
-                    <Icon as={FiX} />
-                  </IconButton>
-                </DialogCloseTrigger>
-              </HStack>
-            </DialogHeader>
-            <DialogBody>
-              <VStack alignItems="flex-start" gap="2">
-                {selectedDay && selectedDay.length > 0 ? (
-                  selectedDay.map(txn => (
-                    <Box
-                      key={txn.id}
-                      width="100%"
-                      p="3"
-                      borderWidth="1px"
-                      borderRadius="md"
-                      bg="bg.muted"
+      {/* Day details dialog (desktop only — mobile uses inline expand) */}
+      {!isMobile && (
+        <DialogRoot open={selectedDay !== null} onOpenChange={details => !details.open && setSelectedDay(null)} size="md" placement="center" lazyMount unmountOnExit closeOnInteractOutside={false}>
+          <DialogBackdrop />
+          <DialogPositioner>
+            <DialogContent tabIndex={-1} mx={{ base: 3, md: 0 }} style={{ marginTop: 'max(16px, env(safe-area-inset-top))' }}>
+              <DialogHeader borderBottomWidth="1px" borderColor="#2d2d35" py={4}>
+                <HStack justify="space-between" align="center">
+                  <DialogTitle color="white">Transacciones del {selectedDay?.[0] && new Date(selectedDay[0].date).toLocaleDateString('es-ES')}</DialogTitle>
+                  <DialogCloseTrigger asChild>
+                    <IconButton
+                      aria-label="Cerrar"
+                      size="sm"
+                      variant="ghost"
+                      color="#B0B0B0"
+                      _hover={{ color: 'white', bg: '#2d2d35' }}
+                      onClick={() => setSelectedDay(null)}
                     >
-                      <HStack justifyContent="space-between" mb="1">
-                        <Text fontWeight="bold">{txn.description}</Text>
-                        <Text fontWeight="bold" color={txn.type === 'income' ? '#10B981' : '#F43F5E'}>
-                          {txn.type === 'income' ? '+' : '-'}{formatCurrency(Number(txn.amount), txn.currency)}
-                        </Text>
-                      </HStack>
-                      <HStack justifyContent="space-between" fontSize="sm" color="fg.muted">
-                        <Text>{txn.category.name}</Text>
-                        <Text>{{ expense: 'Gasto', income: 'Ingreso' }[txn.type] ?? txn.type}</Text>
-                      </HStack>
-                      {txn.notes && (
-                        <Text fontSize="sm" mt="2" color="fg.muted">
-                          {txn.notes}
-                        </Text>
-                      )}
-                    </Box>
-                  ))
-                ) : (
-                  <Text color="fg.muted">Sin transacciones</Text>
-                )}
-              </VStack>
-            </DialogBody>
-          </DialogContent>
-        </DialogPositioner>
-      </DialogRoot>
+                      <Icon as={FiX} />
+                    </IconButton>
+                  </DialogCloseTrigger>
+                </HStack>
+              </DialogHeader>
+              <DialogBody>
+                <VStack alignItems="flex-start" gap="2">
+                  {selectedDay && selectedDay.length > 0 ? (
+                    selectedDay.map(txn => (
+                      <Box
+                        key={txn.id}
+                        width="100%"
+                        p="3"
+                        borderWidth="1px"
+                        borderRadius="md"
+                        bg="bg.muted"
+                      >
+                        <HStack justifyContent="space-between" mb="1">
+                          <Text fontWeight="bold">{txn.description}</Text>
+                          <Text fontWeight="bold" color={txn.type === 'income' ? '#10B981' : '#F43F5E'}>
+                            {txn.type === 'income' ? '+' : '-'}{formatCurrency(Number(txn.amount), txn.currency)}
+                          </Text>
+                        </HStack>
+                        <HStack justifyContent="space-between" fontSize="sm" color="fg.muted">
+                          <Text>{txn.category.name}</Text>
+                          <Text>{TYPE_LABELS[txn.type] ?? txn.type}</Text>
+                        </HStack>
+                        {txn.notes && (
+                          <Text fontSize="sm" mt="2" color="fg.muted">
+                            {txn.notes}
+                          </Text>
+                        )}
+                      </Box>
+                    ))
+                  ) : (
+                    <Text color="fg.muted">Sin transacciones</Text>
+                  )}
+                </VStack>
+              </DialogBody>
+            </DialogContent>
+          </DialogPositioner>
+        </DialogRoot>
+      )}
     </>
   )
 }

--- a/components/calendar/TransactionCalendar.tsx
+++ b/components/calendar/TransactionCalendar.tsx
@@ -163,7 +163,7 @@ export function TransactionCalendar({ initialTransactions }: Props) {
       <DialogRoot open={selectedDay !== null} onOpenChange={details => !details.open && setSelectedDay(null)} size="md" placement="center" lazyMount unmountOnExit closeOnInteractOutside={false}>
         <DialogBackdrop />
         <DialogPositioner>
-          <DialogContent tabIndex={-1} mx={{ base: 3, md: 0 }}>
+          <DialogContent tabIndex={-1} mx={{ base: 3, md: 0 }} style={{ marginTop: 'max(16px, env(safe-area-inset-top))' }}>
             <DialogHeader borderBottomWidth="1px" borderColor="#2d2d35" py={4}>
               <HStack justify="space-between" align="center">
                 <DialogTitle color="white">Transacciones del {selectedDay?.[0] && new Date(selectedDay[0].date).toLocaleDateString('es-ES')}</DialogTitle>

--- a/components/calendar/TransactionCalendar.tsx
+++ b/components/calendar/TransactionCalendar.tsx
@@ -201,7 +201,7 @@ export function TransactionCalendar({ initialTransactions }: Props) {
                       </HStack>
                       <HStack justifyContent="space-between" fontSize="sm" color="fg.muted">
                         <Text>{txn.category.name}</Text>
-                        <Text>{txn.type}</Text>
+                        <Text>{{ expense: 'Gasto', income: 'Ingreso' }[txn.type] ?? txn.type}</Text>
                       </HStack>
                       {txn.notes && (
                         <Text fontSize="sm" mt="2" color="fg.muted">

--- a/components/chat/FloatingChat.tsx
+++ b/components/chat/FloatingChat.tsx
@@ -36,7 +36,7 @@ export function FloatingChat({ userId, categories, accounts = [] }: Props) {
             borderColor="#2d2d35"
             overflow="hidden"
             /* Desktop */
-            bottom={{ base: '130px', md: '88px' }}
+            bottom={{ base: 'calc(140px + env(safe-area-inset-bottom))', md: '88px' }}
             right={{ base: '12px', md: '24px' }}
             left={{ base: '12px', md: 'auto' }}
             w={{ base: 'auto', md: '380px' }}
@@ -55,7 +55,7 @@ export function FloatingChat({ userId, categories, accounts = [] }: Props) {
 
       <Box
         position="fixed"
-        bottom={{ base: '72px', md: '24px' }}
+        bottom={{ base: 'calc(80px + env(safe-area-inset-bottom))', md: '24px' }}
         right="16px"
         zIndex={1001}
       >

--- a/components/dashboard/BottomNav.tsx
+++ b/components/dashboard/BottomNav.tsx
@@ -6,7 +6,7 @@ import {
   FiHome,
   FiLayers,
   FiTarget,
-  FiBarChart2,
+  FiCalendar,
   FiMoreHorizontal,
 } from 'react-icons/fi'
 import { IconType } from 'react-icons'
@@ -16,7 +16,7 @@ const primaryItems: { href: string; label: string; icon: IconType }[] = [
   { href: '/dashboard', label: 'Dashboard', icon: FiHome },
   { href: '/movimientos', label: 'Movimientos', icon: FiLayers },
   { href: '/planificacion', label: 'Planificación', icon: FiTarget },
-  { href: '/reports', label: 'Reportes', icon: FiBarChart2 },
+  { href: '/calendar', label: 'Calendario', icon: FiCalendar },
 ]
 
 interface Props {

--- a/components/dashboard/MobileNav.tsx
+++ b/components/dashboard/MobileNav.tsx
@@ -58,8 +58,8 @@ export function MobileNav({ isOpen, onClose }: Props) {
           style={{ paddingTop: 'env(safe-area-inset-top)', paddingBottom: 'env(safe-area-inset-bottom)' }}
         >
           <DrawerCloseTrigger color="white" top={3} left={3} />
-          <DrawerBody px={3} pt={12} pb={4} display="flex" flexDirection="column">
-            <VStack gap={1} align="stretch" flex={1}>
+          <DrawerBody px={3} pt={12} pb={4} display="flex" flexDirection="column" h="100%">
+            <VStack gap={1} align="stretch">
               {navItems.map((item) => {
                 const isActive = pathname === item.href
                 const isLoading = loadingPath === item.href
@@ -80,7 +80,7 @@ export function MobileNav({ isOpen, onClose }: Props) {
                 )
               })}
             </VStack>
-            <Box pt={4} pb={2} borderTopWidth="1px" borderColor="#2d2d35" mt={4}>
+            <Box pt={4} pb={2} borderTopWidth="1px" borderColor="#2d2d35" mt="auto">
               <CraftedByFooter />
             </Box>
           </DrawerBody>

--- a/components/loans/LoansTable.tsx
+++ b/components/loans/LoansTable.tsx
@@ -199,6 +199,8 @@ export function LoansTable({ loans, onEdit, onSettle, onDelete, onPayment }: Pro
                     color="white"
                     _hover={{ bg: '#4338CA' }}
                     flex={1}
+                    minW={0}
+                    fontSize="xs"
                     onClick={() => onSettle(loan)}
                   >
                     <FiCheckCircle />

--- a/components/recurring/RecurringTransactionsList.tsx
+++ b/components/recurring/RecurringTransactionsList.tsx
@@ -10,11 +10,18 @@ import { DataTable, type ColumnDef } from '@/components/ui/DataTable'
 import { ConfirmDialog } from '@/components/ui/ConfirmDialog'
 import type { RecurringTransactionWithCategory } from '@/types/database.types'
 
-const FREQUENCY_LABELS: Record<string, string> = {
-  daily: 'Diario',
-  weekly: 'Semanal',
-  monthly: 'Mensual',
-  yearly: 'Anual',
+const WEEKDAY_NAMES = ['domingo', 'lunes', 'martes', 'miércoles', 'jueves', 'viernes', 'sábado']
+const MONTH_NAMES = ['enero', 'febrero', 'marzo', 'abril', 'mayo', 'junio', 'julio', 'agosto', 'septiembre', 'octubre', 'noviembre', 'diciembre']
+
+function frequencyLabel(frequency: string, startDate: string): string {
+  const date = new Date(startDate + 'T12:00:00')
+  switch (frequency) {
+    case 'daily': return 'Diario'
+    case 'weekly': return `Semanal · cada ${WEEKDAY_NAMES[date.getDay()]}`
+    case 'monthly': return `Mensual · el ${date.getDate()} de cada mes`
+    case 'yearly': return `Anual · el ${date.getDate()} de ${MONTH_NAMES[date.getMonth()]}`
+    default: return frequency
+  }
 }
 
 interface Props {
@@ -65,7 +72,7 @@ export function RecurringTransactionsList({ userId, transactions, onEdit }: Prop
       ),
     },
     { key: 'amount', header: 'Monto', render: (t) => `${t.amount.toLocaleString()} ${t.currency}` },
-    { key: 'frequency', header: 'Frecuencia', render: (t) => FREQUENCY_LABELS[t.frequency] ?? t.frequency },
+    { key: 'frequency', header: 'Frecuencia', render: (t) => frequencyLabel(t.frequency, t.start_date) },
     {
       key: 'status',
       header: 'Estado',
@@ -110,7 +117,7 @@ export function RecurringTransactionsList({ userId, transactions, onEdit }: Prop
                     <HStack gap={2} flexWrap="wrap">
                       <Text fontSize="xs" color="#6b7280">{t.category.icon ?? '🏷️'} {t.category.name}</Text>
                       <Text fontSize="xs" color="#4b5563">·</Text>
-                      <Text fontSize="xs" color="#6b7280">{FREQUENCY_LABELS[t.frequency] ?? t.frequency}</Text>
+                      <Text fontSize="xs" color="#6b7280">{frequencyLabel(t.frequency, t.start_date)}</Text>
                     </HStack>
                     <HStack gap={2} mt={1}>
                       <Badge colorPalette={t.is_active ? 'green' : 'yellow'} variant="solid" fontSize="10px">

--- a/components/ui/FormDialog.tsx
+++ b/components/ui/FormDialog.tsx
@@ -36,7 +36,7 @@ export function FormDialog({ isOpen, onClose, title, children, size = 'md' }: Pr
     >
       <DialogBackdrop />
       <DialogPositioner>
-        <DialogContent tabIndex={-1} mx={{ base: 3, md: 0 }} maxH="90vh" overflowY="auto">
+        <DialogContent tabIndex={-1} mx={{ base: 3, md: 0 }} maxH="90vh" overflowY="auto" style={{ marginTop: 'max(16px, env(safe-area-inset-top))' }}>
           <DialogHeader borderBottomWidth="1px" borderColor="#2d2d35" py={4}>
             <HStack justify="space-between" align="center">
               <DialogTitle color="white">{title}</DialogTitle>


### PR DESCRIPTION
## Resumen
Correcciones visuales y mejoras de UX, con foco en la experiencia mobile (iPhone).

## Tareas Completadas
- [x] fix: traducir 'expense'/'income' a español en modal del calendario (#248 → #249)
- [x] fix: safe area inset top en modales para iPhone (#250 → #251)
- [x] fix: eliminar padding duplicado en páginas mobile (#252 → #253)
- [x] fix: iconos de tabs en Movimientos y Configuración (#254 → #255)
- [x] fix: subir botón y ventana del AI chat en mobile (#256 → #257)
- [x] fix: footer del drawer siempre al fondo (#258 → #259)
- [x] feat: vista mobile vertical del calendario + Calendario en BottomNav (#260 → #261)
- [x] fix: overflow del botón '¡Ya me pagaron!' en Préstamos (#262 → #263)
- [x] feat: día de frecuencia en gastos recurrentes (#264 → #265)

## Testing
- ✅ Build exitoso
- ✅ Sin errores de TypeScript
- ✅ Probado en desarrollo local

## Next Steps
Bump de versión a v1.7.0, tag y release en GitHub.

Closes #247