### PR TITLE
fix: prevenir overflow del texto en botón 'Ya me pagaron' en mobile

### DIFF
--- a/components/loans/LoansTable.tsx
+++ b/components/loans/LoansTable.tsx
@@ -201,10 +201,13 @@ export function LoansTable({ loans, onEdit, onSettle, onDelete, onPayment }: Pro
                     flex={1}
                     minW={0}
                     fontSize="xs"
+                    overflow="hidden"
                     onClick={() => onSettle(loan)}
                   >
-                    <FiCheckCircle />
-                    {settleLabel(loan)}
+                    <FiCheckCircle style={{ flexShrink: 0 }} />
+                    <Text overflow="hidden" textOverflow="ellipsis" whiteSpace="nowrap">
+                      {settleLabel(loan)}
+                    </Text>
                   </Button>
                   <IconButton
                     aria-label="Editar"


### PR DESCRIPTION
## Cambios
- Envuelve el texto del botón settle en un componente `Text` con `overflow hidden` y `textOverflow ellipsis`
- Añade `overflow hidden` al `Button` y `flexShrink: 0` al ícono para evitar que se comprima

## Testing
- ✅ Sin errores de TypeScript
- ✅ Botón muestra texto sin desbordamiento en móvil

Closes #267