### PR TITLE
fix: hacer visible el spinner en tabs de Movimientos en fondo oscuro

### DIFF
--- a/app/(dashboard)/movimientos/MovimientosPageClient.tsx
+++ b/app/(dashboard)/movimientos/MovimientosPageClient.tsx
@@ -52,7 +52,7 @@ export function MovimientosPageClient({
   }
 
   const tabIcon = (tab: string, IconComponent: React.ElementType) =>
-    pendingTab === tab && isPending ? <Spinner size="xs" /> : <Icon as={IconComponent} boxSize={4} />
+    pendingTab === tab && isPending ? <Spinner size="xs" color="white" /> : <Icon as={IconComponent} boxSize={4} />
 
   return (
     <Box>


### PR DESCRIPTION
## Cambios
- Añade `color="white"` al `Spinner` que aparece al cambiar de tab en la página de Movimientos

## Testing
- ✅ Sin errores de TypeScript
- ✅ Spinner visible al cambiar de tab en fondo oscuro

Closes #268