### PR TITLE
fix: correcciones UI en modales (centrado, grid desktop, spinner, colorpicker)

### DIFF
--- a/app/(dashboard)/movimientos/MovimientosPageClient.tsx
+++ b/app/(dashboard)/movimientos/MovimientosPageClient.tsx
@@ -52,7 +52,11 @@ export function MovimientosPageClient({
   }
 
   const tabIcon = (tab: string, IconComponent: React.ElementType) =>
-    pendingTab === tab && isPending ? <Spinner size="xs" color="white" /> : <Icon as={IconComponent} boxSize={4} />
+    pendingTab === tab && isPending ? (
+      <Spinner size="xs" borderColor="whiteAlpha.300" borderTopColor="white" animationDuration="0.65s" />
+    ) : (
+      <Icon as={IconComponent} boxSize={4} />
+    )
 
   return (
     <Box>

--- a/components/categories/ColorPicker.tsx
+++ b/components/categories/ColorPicker.tsx
@@ -23,6 +23,8 @@ const COLORS = [
   '#a855f7',
 ]
 
+const PICKER_WIDTH = 200
+
 interface Props {
   value: string
   onChange: (color: string) => void
@@ -30,24 +32,38 @@ interface Props {
 
 export function ColorPicker({ value, onChange }: Props) {
   const [open, setOpen] = useState(false)
-  const ref = useRef<HTMLDivElement>(null)
+  const [pos, setPos] = useState({ top: 0, left: 0 })
+  const wrapperRef = useRef<HTMLDivElement>(null)
+  const pickerRef = useRef<HTMLDivElement>(null)
+
+  const handleToggle = () => {
+    if (!open && wrapperRef.current) {
+      const rect = wrapperRef.current.getBoundingClientRect()
+      const left = Math.min(rect.right - PICKER_WIDTH, window.innerWidth - PICKER_WIDTH - 8)
+      setPos({ top: rect.bottom + 4, left: Math.max(left, 8) })
+    }
+    setOpen((v) => !v)
+  }
 
   useEffect(() => {
     if (!open) return
     const handler = (e: MouseEvent) => {
-      if (ref.current && !ref.current.contains(e.target as Node)) {
-        setOpen(false)
-      }
+      const target = e.target as Element
+      if (
+        pickerRef.current?.contains(target) ||
+        wrapperRef.current?.contains(target)
+      ) return
+      setOpen(false)
     }
     document.addEventListener('mousedown', handler)
     return () => document.removeEventListener('mousedown', handler)
   }, [open])
 
   return (
-    <Box position="relative" ref={ref}>
+    <Box ref={wrapperRef} display="inline-block" position="relative">
       <StyledButton
         type="button"
-        onClick={() => setOpen((v) => !v)}
+        onClick={handleToggle}
         w="9"
         h="9"
         borderRadius="md"
@@ -61,17 +77,18 @@ export function ColorPicker({ value, onChange }: Props) {
 
       {open && (
         <Box
-          position="absolute"
-          top="calc(100% + 4px)"
-          right={0}
-          zIndex={50}
+          ref={pickerRef}
+          position="fixed"
+          top={`${pos.top}px`}
+          left={`${pos.left}px`}
+          zIndex={10000}
           bg="#1a1a23"
           borderRadius="lg"
           border="1px solid"
           borderColor="#2d2d35"
-          boxShadow="lg"
+          boxShadow="0 4px 24px rgba(0,0,0,0.6)"
           p={3}
-          w="50"
+          w={`${PICKER_WIDTH}px`}
         >
           <Box display="grid" gridTemplateColumns="repeat(5, 1fr)" gap={2}>
             {COLORS.map((color) => (

--- a/components/transactions/TransactionEditForm.tsx
+++ b/components/transactions/TransactionEditForm.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { VStack, Box, FieldRoot, FieldLabel, NativeSelectRoot, NativeSelectField } from '@chakra-ui/react'
+import { VStack, Box, SimpleGrid, FieldRoot, FieldLabel, NativeSelectRoot, NativeSelectField } from '@chakra-ui/react'
 import { useState, useEffect } from 'react'
 import { updateTransaction } from '@/lib/actions/transactions.actions'
 import { toaster } from '@/lib/toaster'
@@ -88,19 +88,20 @@ export function TransactionEditForm({ isOpen, onClose, userId, categories, accou
             required
           />
 
-          <InputAmount
-            label="Monto"
-            value={formData.amount}
-            onChange={(v) => setFormData({ ...formData, amount: v })}
-            isRequired
-          />
-
-          <CurrencySelect
-            value={formData.currency}
-            onChange={(v) => setFormData({ ...formData, currency: v })}
-            showFullLabel
-            required
-          />
+          <SimpleGrid columns={{ base: 1, md: 2 }} gap={4} w="full">
+            <InputAmount
+              label="Monto"
+              value={formData.amount}
+              onChange={(v) => setFormData({ ...formData, amount: v })}
+              isRequired
+            />
+            <CurrencySelect
+              value={formData.currency}
+              onChange={(v) => setFormData({ ...formData, currency: v })}
+              showFullLabel
+              required
+            />
+          </SimpleGrid>
 
           <CategorySelect
             value={formData.category_id}
@@ -136,20 +137,21 @@ export function TransactionEditForm({ isOpen, onClose, userId, categories, accou
             />
           </Box>
 
-          <FormInput
-            label="Descripción"
-            value={formData.description}
-            onChange={(v) => setFormData({ ...formData, description: v })}
-            required
-          />
-
-          <FormInput
-            label="Fecha"
-            value={formData.date}
-            onChange={(v) => setFormData({ ...formData, date: v })}
-            type="date"
-            required
-          />
+          <SimpleGrid columns={{ base: 1, md: 2 }} gap={4} w="full">
+            <FormInput
+              label="Descripción"
+              value={formData.description}
+              onChange={(v) => setFormData({ ...formData, description: v })}
+              required
+            />
+            <FormInput
+              label="Fecha"
+              value={formData.date}
+              onChange={(v) => setFormData({ ...formData, date: v })}
+              type="date"
+              required
+            />
+          </SimpleGrid>
 
           <FormTextarea
             label="Notas (opcional)"

--- a/components/transactions/TransactionForm.tsx
+++ b/components/transactions/TransactionForm.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { VStack, Box, FieldRoot, FieldLabel, NativeSelectRoot, NativeSelectField } from '@chakra-ui/react'
+import { VStack, Box, SimpleGrid, FieldRoot, FieldLabel, NativeSelectRoot, NativeSelectField } from '@chakra-ui/react'
 import { useState, useEffect } from 'react'
 import { createTransaction } from '@/lib/actions/transactions.actions'
 import { toaster } from '@/lib/toaster'
@@ -86,19 +86,20 @@ export function TransactionForm({ isOpen, onClose, userId, categories, accounts 
             required
           />
 
-          <InputAmount
-            label="Monto"
-            value={formData.amount}
-            onChange={(v) => setFormData({ ...formData, amount: v })}
-            isRequired
-          />
-
-          <CurrencySelect
-            value={formData.currency}
-            onChange={(v) => setFormData({ ...formData, currency: v })}
-            showFullLabel
-            required
-          />
+          <SimpleGrid columns={{ base: 1, md: 2 }} gap={4} w="full">
+            <InputAmount
+              label="Monto"
+              value={formData.amount}
+              onChange={(v) => setFormData({ ...formData, amount: v })}
+              isRequired
+            />
+            <CurrencySelect
+              value={formData.currency}
+              onChange={(v) => setFormData({ ...formData, currency: v })}
+              showFullLabel
+              required
+            />
+          </SimpleGrid>
 
           <CategorySelect
             value={formData.category_id}
@@ -134,22 +135,23 @@ export function TransactionForm({ isOpen, onClose, userId, categories, accounts 
             />
           </Box>
 
-          <FormInput
-            label="Descripción"
-            value={formData.description}
-            onChange={(v) => setFormData({ ...formData, description: v })}
-            placeholder="Ej: Compra en supermercado"
-            required
-          />
-
-          <FormInput
-            label="Fecha"
-            value={formData.date}
-            onChange={(v) => setFormData({ ...formData, date: v })}
-            type="date"
-            required
-            disabled={lockedDate}
-          />
+          <SimpleGrid columns={{ base: 1, md: 2 }} gap={4} w="full">
+            <FormInput
+              label="Descripción"
+              value={formData.description}
+              onChange={(v) => setFormData({ ...formData, description: v })}
+              placeholder="Ej: Compra en supermercado"
+              required
+            />
+            <FormInput
+              label="Fecha"
+              value={formData.date}
+              onChange={(v) => setFormData({ ...formData, date: v })}
+              type="date"
+              required
+              disabled={lockedDate}
+            />
+          </SimpleGrid>
 
           <FormTextarea
             label="Notas (opcional)"

--- a/components/ui/FormDialog.tsx
+++ b/components/ui/FormDialog.tsx
@@ -36,8 +36,14 @@ export function FormDialog({ isOpen, onClose, title, children, size = 'md' }: Pr
     >
       <DialogBackdrop />
       <DialogPositioner>
-        <DialogContent tabIndex={-1} mx={{ base: 3, md: 0 }} maxH="90vh" overflowY="auto" style={{ marginTop: 'max(16px, env(safe-area-inset-top))' }}>
-          <DialogHeader borderBottomWidth="1px" borderColor="#2d2d35" py={4}>
+        <DialogContent
+          tabIndex={-1}
+          mx={{ base: 3, md: 0 }}
+          maxH={{ base: '85vh', md: '90vh' }}
+          display="flex"
+          flexDirection="column"
+        >
+          <DialogHeader borderBottomWidth="1px" borderColor="#2d2d35" py={4} flexShrink={0}>
             <HStack justify="space-between" align="center">
               <DialogTitle color="white">{title}</DialogTitle>
               <DialogCloseTrigger asChild>
@@ -54,7 +60,7 @@ export function FormDialog({ isOpen, onClose, title, children, size = 'md' }: Pr
               </DialogCloseTrigger>
             </HStack>
           </DialogHeader>
-          <DialogBody pb={6}>
+          <DialogBody pb={6} flex="1" minH="0" overflowY="auto">
             {children}
           </DialogBody>
         </DialogContent>


### PR DESCRIPTION
## Cambios
- **Modal scroll interno**: header fijo con `flexShrink={0}`, body scrolleable con `flex="1" minH="0" overflowY="auto"`, centrado correcto en mobile (sin `marginTop` inline que rompía el centrado)
- **TransactionForm / TransactionEditForm**: grid 2 columnas en desktop (`md+`) para Monto+Moneda y Descripción+Fecha; en mobile sigue siendo columna única
- **Spinner de tabs en Movimientos**: spinner visible en fondo oscuro usando `borderColor="whiteAlpha.300"` y `borderTopColor="white"` en lugar de `color="white"` que no aplicaba al arco animado en Chakra UI v3
- **ColorPicker**: usa `position="fixed"` con `getBoundingClientRect()` igual que `IconPicker`, evitando que sea recortado por `overflow: auto` del modal

## Testing
- ✅ TypeScript sin errores (`pnpm type-check`)
- ✅ Modales: verificar centrado y scroll interno en mobile (DevTools → iPhone SE)
- ✅ TransactionForm: verificar 2 columnas en desktop (≥768px) y columna única en mobile
- ✅ Spinner: cambiar tabs en Movimientos y verificar spinner blanco visible
- ✅ ColorPicker: abrir Nueva Categoría → click en botón color → paleta flota sobre el modal

Closes #274