### PR TITLE
fix: spinner en tabs de Movimientos visible en mobile

### DIFF
--- a/app/(dashboard)/movimientos/MovimientosPageClient.tsx
+++ b/app/(dashboard)/movimientos/MovimientosPageClient.tsx
@@ -53,9 +53,17 @@ export function MovimientosPageClient({
 
   const tabIcon = (tab: string, IconComponent: React.ElementType) =>
     pendingTab === tab && isPending ? (
-      <Spinner size="xs" borderColor="whiteAlpha.300" borderTopColor="white" animationDuration="0.65s" />
+      <Spinner
+        w={4}
+        h={4}
+        borderWidth="2px"
+        borderColor="rgba(255,255,255,0.3)"
+        borderTopColor="white"
+        animationDuration="0.65s"
+        flexShrink={0}
+      />
     ) : (
-      <Icon as={IconComponent} boxSize={4} />
+      <Icon as={IconComponent} boxSize={4} flexShrink={0} />
     )
 
   return (


### PR DESCRIPTION
## Problema
El spinner usaba size='xs' (12px) mientras el icono reemplazado es 16px (boxSize={4}), causando tamaño inconsistente y posible layout shift en mobile. Además el token 'whiteAlpha.300' puede no resolver en todos los contextos.

## Cambios
- Cambiado a w={4} h={4} para igualar tamaño al icono (16px)
- borderWidth='2px' para visibilidad correcta en el nuevo tamaño
- 'whiteAlpha.300' → 'rgba(255,255,255,0.3)' (CSS explícito)
- flexShrink={0} en spinner e icono para evitar compresión en flex

## Testing
- ✅ Probado en mobile (390px via DevTools)
- ✅ Sin errores de TypeScript

Closes #283
Related to #280