### PR TITLE
fix: botón toggle sidebar sticky circular + active item colapsado

### DIFF
--- a/components/dashboard/Sidebar.tsx
+++ b/components/dashboard/Sidebar.tsx
@@ -12,8 +12,8 @@ import {
   FiCalendar,
   FiDownload,
   FiLayers,
-  FiChevronLeft,
-  FiChevronRight,
+  FiChevronsLeft,
+  FiChevronsRight,
 } from 'react-icons/fi'
 import { IconType } from 'react-icons'
 import { useNavigation } from '@/hooks/useNavigation'
@@ -33,7 +33,6 @@ export function Sidebar() {
   const { navigate, loadingPath } = useNavigation()
   const [isCollapsed, setIsCollapsed] = useState(false)
 
-  // Leer preferencia guardada después del mount (evita hydration mismatch)
   useEffect(() => {
     const saved = localStorage.getItem('sidebar-collapsed')
     if (saved === 'true') setIsCollapsed(true)
@@ -50,71 +49,102 @@ export function Sidebar() {
   return (
     <Box
       as="nav"
-      w={isCollapsed ? '14' : '64'}
+      w={isCollapsed ? '16' : '64'}
       transition="width 0.2s ease"
       bg="#18181d"
       borderRightWidth="1px"
       borderColor="#2d2d35"
       h="full"
-      p={4}
       flexShrink={0}
       display={{ base: 'none', md: 'flex' }}
       flexDirection="column"
       overflowY="auto"
       overflowX="hidden"
     >
-      <VStack gap={2} align="stretch" flex={1}>
-        {navItems.map((item) => {
-          const isActive = pathname === item.href
-          const isLoading = loadingPath === item.href
-          return (
-            <Button
-              key={item.href}
-              justifyContent={isCollapsed ? 'center' : 'flex-start'}
-              gap={isCollapsed ? 0 : 2}
-              bg={isActive ? '#4F46E5' : 'transparent'}
-              color={isActive ? 'white' : '#B0B0B0'}
-              _hover={{ bg: isActive ? '#4338CA' : '#26262f' }}
-              transition="background-color 0.2s ease"
-              onClick={() => navigate(item.href)}
-              minW={0}
-              overflow="hidden"
-              px={isCollapsed ? 2 : 4}
-              title={isCollapsed ? item.label : undefined}
-            >
-              {isLoading ? (
-                <Spinner size="xs" color={isActive ? 'white' : '#B0B0B0'} />
-              ) : (
-                <Icon as={item.icon} flexShrink={0} />
-              )}
-              {!isCollapsed && (
-                <Box as="span" overflow="hidden" whiteSpace="nowrap" textOverflow="ellipsis">
-                  {item.label}
-                </Box>
-              )}
-            </Button>
-          )
-        })}
-      </VStack>
-
-      <Box pt={4} borderTopWidth="1px" borderColor="#2d2d35" mt={4}>
-        <Button
-          size="sm"
-          variant="ghost"
-          color="#B0B0B0"
-          _hover={{ bg: '#26262f', color: 'white' }}
+      {/* Sticky toggle button header */}
+      <Box
+        display="flex"
+        alignItems="center"
+        justifyContent={isCollapsed ? 'center' : 'flex-end'}
+        px={3}
+        pt={3}
+        pb={3}
+        position="sticky"
+        top={0}
+        bg="#18181d"
+        zIndex={1}
+        borderBottomWidth="1px"
+        borderColor="#2d2d35"
+        mb={2}
+      >
+        <Box
+          as="button"
           onClick={toggle}
-          w="full"
-          justifyContent={isCollapsed ? 'center' : 'flex-start'}
-          gap={2}
-          mb={isCollapsed ? 0 : 2}
-          title={isCollapsed ? 'Expandir sidebar' : undefined}
+          cursor="pointer"
+          display="flex"
+          alignItems="center"
+          justifyContent="center"
+          w="7"
+          h="7"
+          borderRadius="full"
+          bg="#1e1e27"
+          color="#B0B0B0"
+          borderWidth="1px"
+          borderColor="#2d2d35"
+          _hover={{ bg: '#26262f', color: 'white', borderColor: '#4F46E5' }}
+          transition="all 0.2s ease"
+          title={isCollapsed ? 'Expandir sidebar' : 'Colapsar sidebar'}
+          aria-label={isCollapsed ? 'Expandir sidebar' : 'Colapsar sidebar'}
         >
-          <Icon as={isCollapsed ? FiChevronRight : FiChevronLeft} />
-          {!isCollapsed && 'Colapsar'}
-        </Button>
-        {!isCollapsed && <CraftedByFooter />}
+          <Icon as={isCollapsed ? FiChevronsRight : FiChevronsLeft} boxSize="3" />
+        </Box>
       </Box>
+
+      {/* Nav items */}
+      <Box px={isCollapsed ? 2 : 3} flex={1}>
+        <VStack gap={1} align="stretch">
+          {navItems.map((item) => {
+            const isActive = pathname === item.href
+            const isLoading = loadingPath === item.href
+            return (
+              <Button
+                key={item.href}
+                justifyContent={isCollapsed ? 'center' : 'flex-start'}
+                gap={isCollapsed ? 0 : 2}
+                bg={isActive ? '#4F46E5' : 'transparent'}
+                color={isActive ? 'white' : '#B0B0B0'}
+                _hover={{ bg: isActive ? '#4338CA' : '#26262f' }}
+                transition="background-color 0.2s ease"
+                onClick={() => navigate(item.href)}
+                minW={0}
+                px={isCollapsed ? 0 : 3}
+                h="10"
+                borderRadius="lg"
+                overflow="hidden"
+                title={isCollapsed ? item.label : undefined}
+              >
+                {isLoading ? (
+                  <Spinner size="xs" color={isActive ? 'white' : '#B0B0B0'} />
+                ) : (
+                  <Icon as={item.icon} flexShrink={0} />
+                )}
+                {!isCollapsed && (
+                  <Box as="span" overflow="hidden" whiteSpace="nowrap" textOverflow="ellipsis">
+                    {item.label}
+                  </Box>
+                )}
+              </Button>
+            )
+          })}
+        </VStack>
+      </Box>
+
+      {/* Footer */}
+      {!isCollapsed && (
+        <Box px={3} pt={4} pb={4} borderTopWidth="1px" borderColor="#2d2d35" mt={4}>
+          <CraftedByFooter />
+        </Box>
+      )}
     </Box>
   )
 }


### PR DESCRIPTION
## Cambios

### Toggle button rediseñado
- Movido de la parte inferior a la parte **superior del sidebar** como botón sticky
- Pequeño círculo (28px) con fondo oscuro y borde sutil
- Alineado a la derecha cuando expandido, centrado cuando colapsado  
- Hover: borde índigo (#4F46E5) para feedback branded
- Sticky: se mantiene visible en la parte superior aunque el sidebar tenga scroll
- Separador visual (border-bottom) entre toggle y nav items

### Fix active item en modo colapsado
- `px={0}` en botones colapsados: el fondo índigo llena limpiamente el espacio disponible
- `borderRadius='lg'`: bordes redondeados en el background activo
- `h='10'` (40px): altura explícita consistente
- Sidebar collapsed width: `w='16'` (64px) → mejor espaciado para iconos
- Wrapper con `px={2}` cuando colapsado para padding apropiado

## Testing
- ✅ Sin errores TypeScript
- ✅ Toggle funcional con persistencia localStorage
- ✅ Animación suave en collapse/expand

Closes #286
Related to #280