### PR TITLE
feat: DateInput (con X), AccountSelect y FrequencySelect globales (#290)

### DIFF
--- a/components/ReportFilters.tsx
+++ b/components/ReportFilters.tsx
@@ -2,17 +2,18 @@
 
 import {
   Button,
+  Box,
   HStack,
   VStack,
   FieldRoot,
   FieldLabel,
-  Input,
   NativeSelectRoot,
   NativeSelectField,
   Text,
 } from '@chakra-ui/react'
 import { useEffect, useState } from 'react'
 import { getCategories } from '@/lib/actions/categories.actions'
+import { DateInput } from '@/components/ui/DateInput'
 import type { Category } from '@/types/database.types'
 
 export interface ReportFiltersState {
@@ -143,25 +144,21 @@ export function ReportFilters({ userId, onFilterChange }: Props) {
           </FieldRoot>
         )}
 
-        <FieldRoot w={{ base: 'full', sm: 'auto', md: '120px' }}>
-          <FieldLabel fontSize="sm">Desde</FieldLabel>
-          <Input
-            type="date"
+        <Box w={{ base: 'full', sm: 'auto', md: '140px' }}>
+          <DateInput
+            label="Desde"
             value={filters.startDate}
-            onChange={(e) => handleStartDateChange(e.target.value)}
-            size="sm"
+            onChange={handleStartDateChange}
           />
-        </FieldRoot>
+        </Box>
 
-        <FieldRoot w={{ base: 'full', sm: 'auto', md: '120px' }}>
-          <FieldLabel fontSize="sm">Hasta</FieldLabel>
-          <Input
-            type="date"
+        <Box w={{ base: 'full', sm: 'auto', md: '140px' }}>
+          <DateInput
+            label="Hasta"
             value={filters.endDate}
-            onChange={(e) => handleEndDateChange(e.target.value)}
-            size="sm"
+            onChange={handleEndDateChange}
           />
-        </FieldRoot>
+        </Box>
 
         <Button onClick={handleReset} size="sm" variant="ghost">
           Limpiar

--- a/components/budgets/BudgetForm.tsx
+++ b/components/budgets/BudgetForm.tsx
@@ -5,7 +5,7 @@ import { useState, useEffect } from 'react'
 import { createBudget, updateBudget } from '@/lib/actions/budgets.actions'
 import { toaster } from '@/lib/toaster'
 import { FormDialog } from '@/components/ui/FormDialog'
-import { FormInput } from '@/components/ui/FormInput'
+import { DateInput } from '@/components/ui/DateInput'
 import { InputAmount } from '@/components/ui/InputAmount'
 import { RadioSelect } from '@/components/ui/RadioSelect'
 import { CurrencySelect } from '@/components/ui/CurrencySelect'
@@ -157,11 +157,10 @@ export function BudgetForm({ isOpen, onClose, userId, categories, onSuccess, edi
             required
           />
 
-          <FormInput
+          <DateInput
             label="Fecha de Inicio"
             value={formData.start_date}
             onChange={(v) => setFormData({ ...formData, start_date: v })}
-            type="date"
             required
           />
 

--- a/components/loans/LoanForm.tsx
+++ b/components/loans/LoanForm.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { VStack, FieldRoot, FieldLabel, NativeSelectRoot, NativeSelectField } from '@chakra-ui/react'
+import { VStack } from '@chakra-ui/react'
 import { useState } from 'react'
 import { createLoan, updateLoan } from '@/lib/actions/loans.actions'
 import { toaster } from '@/lib/toaster'
@@ -9,6 +9,7 @@ import { FormInput } from '@/components/ui/FormInput'
 import { InputAmount } from '@/components/ui/InputAmount'
 import { RadioSelect } from '@/components/ui/RadioSelect'
 import { CurrencySelect } from '@/components/ui/CurrencySelect'
+import { AccountSelect } from '@/components/ui/AccountSelect'
 import { PrimaryButton } from '@/components/ui/PrimaryButton'
 import type { Account, Currency, LoanWithAccount } from '@/types/database.types'
 
@@ -96,22 +97,12 @@ export function LoanForm({ isOpen, onClose, userId, accounts, onSuccess, loan }:
             onChange={(v) => setFormData((p) => ({ ...p, currency: v }))}
           />
           {accounts.length > 0 && (
-            <FieldRoot>
-              <FieldLabel>Cuenta</FieldLabel>
-              <NativeSelectRoot>
-                <NativeSelectField
-                  value={formData.account_id}
-                  onChange={(e) => setFormData((p) => ({ ...p, account_id: e.target.value }))}
-                >
-                  <option value="">Sin cuenta</option>
-                  {accounts.map((a) => (
-                    <option key={a.id} value={a.id}>
-                      {a.icon} {a.name} ({a.currency})
-                    </option>
-                  ))}
-                </NativeSelectField>
-              </NativeSelectRoot>
-            </FieldRoot>
+            <AccountSelect
+              value={formData.account_id}
+              onChange={(v) => setFormData((p) => ({ ...p, account_id: v }))}
+              accounts={accounts}
+              optional
+            />
           )}
           <FormInput
             label="Notas (opcional)"

--- a/components/recurring/RecurringTransactionForm.tsx
+++ b/components/recurring/RecurringTransactionForm.tsx
@@ -1,15 +1,18 @@
 'use client'
 
-import { VStack, FieldRoot, FieldLabel, NativeSelectRoot, NativeSelectField } from '@chakra-ui/react'
+import { VStack } from '@chakra-ui/react'
 import { useState, useEffect } from 'react'
 import { createRecurringTransaction, updateRecurringTransaction } from '@/lib/actions/recurring.actions'
 import { toaster } from '@/lib/toaster'
 import { FormDialog } from '@/components/ui/FormDialog'
 import { FormInput } from '@/components/ui/FormInput'
+import { DateInput } from '@/components/ui/DateInput'
 import { InputAmount } from '@/components/ui/InputAmount'
 import { RadioSelect } from '@/components/ui/RadioSelect'
 import { CurrencySelect } from '@/components/ui/CurrencySelect'
 import { CategorySelect } from '@/components/ui/CategorySelect'
+import { AccountSelect } from '@/components/ui/AccountSelect'
+import { FrequencySelect } from '@/components/ui/FrequencySelect'
 import { PrimaryButton } from '@/components/ui/PrimaryButton'
 import type { Account, Category, Currency, RecurringTransactionWithCategory } from '@/types/database.types'
 import { getLocalDateString } from '@/lib/utils/dates'
@@ -157,52 +160,33 @@ export function RecurringTransactionForm({
           />
 
           {accounts.length > 0 && (
-            <FieldRoot>
-              <FieldLabel>Cuenta asociada <span style={{ color: '#B0B0B0', fontSize: '0.85em' }}>(opcional)</span></FieldLabel>
-              <NativeSelectRoot>
-                <NativeSelectField
-                  value={form.account_id}
-                  onChange={(e) => setForm({ ...form, account_id: e.target.value })}
-                >
-                  <option value="">Sin cuenta</option>
-                  {accounts.map((acc) => (
-                    <option key={acc.id} value={acc.id}>
-                      {acc.name} ({acc.currency})
-                    </option>
-                  ))}
-                </NativeSelectField>
-              </NativeSelectRoot>
-            </FieldRoot>
+            <AccountSelect
+              value={form.account_id}
+              onChange={(v) => setForm({ ...form, account_id: v })}
+              accounts={accounts}
+              label="Cuenta asociada"
+              optional
+            />
           )}
 
-          <FieldRoot required>
-            <FieldLabel>Frecuencia</FieldLabel>
-            <NativeSelectRoot>
-              <NativeSelectField
-                value={form.frequency}
-                onChange={(e) => setForm({ ...form, frequency: e.target.value as typeof form.frequency })}
-              >
-                <option value="daily">Diario</option>
-                <option value="weekly">Semanal</option>
-                <option value="monthly">Mensual</option>
-                <option value="yearly">Anual</option>
-              </NativeSelectField>
-            </NativeSelectRoot>
-          </FieldRoot>
-
-          <FormInput
-            label="Fecha de Inicio"
-            value={form.start_date}
-            onChange={(v) => setForm({ ...form, start_date: v })}
-            type="date"
+          <FrequencySelect
+            value={form.frequency}
+            onChange={(v) => setForm({ ...form, frequency: v })}
             required
           />
 
-          <FormInput
-            label="Fecha de Fin (Opcional)"
+          <DateInput
+            label="Fecha de Inicio"
+            value={form.start_date}
+            onChange={(v) => setForm({ ...form, start_date: v })}
+            required
+          />
+
+          <DateInput
+            label="Fecha de Fin"
             value={form.end_date}
             onChange={(v) => setForm({ ...form, end_date: v })}
-            type="date"
+            optional
           />
 
           <PrimaryButton type="submit" width="full" loading={loading}>

--- a/components/savings/AddFundsForm.tsx
+++ b/components/savings/AddFundsForm.tsx
@@ -1,10 +1,11 @@
 'use client'
 
 import { useState } from 'react'
-import { VStack, Button, Text, FieldRoot, FieldLabel, NativeSelectRoot, NativeSelectField } from '@chakra-ui/react'
+import { VStack, Button, Text } from '@chakra-ui/react'
 import { FormDialog } from '@/components/ui/FormDialog'
 import { InputAmount } from '@/components/ui/InputAmount'
 import { CurrencySelect } from '@/components/ui/CurrencySelect'
+import { AccountSelect } from '@/components/ui/AccountSelect'
 import { addFundsToGoal } from '@/lib/actions/savings.actions'
 import { toaster } from '@/lib/toaster'
 import type { Account, Currency, SavingsGoal } from '@/types/database.types'
@@ -76,22 +77,13 @@ export function AddFundsForm({ isOpen, onClose, goal, userId, accounts, onSucces
         </Text>
 
         {activeAccounts.length > 0 && (
-          <FieldRoot>
-            <FieldLabel>Cuenta de origen <Text as="span" color="#B0B0B0" fontSize="xs">(opcional)</Text></FieldLabel>
-            <NativeSelectRoot>
-              <NativeSelectField
-                value={accountId}
-                onChange={(e) => handleAccountChange(e.target.value)}
-              >
-                <option value="">Sin cuenta</option>
-                {activeAccounts.map((a) => (
-                  <option key={a.id} value={a.id}>
-                    {a.icon ?? ''} {a.name} — {a.currency}
-                  </option>
-                ))}
-              </NativeSelectField>
-            </NativeSelectRoot>
-          </FieldRoot>
+          <AccountSelect
+            value={accountId}
+            onChange={handleAccountChange}
+            accounts={activeAccounts}
+            label="Cuenta de origen"
+            optional
+          />
         )}
 
         <CurrencySelect

--- a/components/savings/SavingsGoalForm.tsx
+++ b/components/savings/SavingsGoalForm.tsx
@@ -6,6 +6,7 @@ import { createSavingsGoal, updateSavingsGoal } from '@/lib/actions/savings.acti
 import { toaster } from '@/lib/toaster'
 import { FormDialog } from '@/components/ui/FormDialog'
 import { FormInput } from '@/components/ui/FormInput'
+import { DateInput } from '@/components/ui/DateInput'
 import { InputAmount } from '@/components/ui/InputAmount'
 import { CurrencySelect } from '@/components/ui/CurrencySelect'
 import { PrimaryButton } from '@/components/ui/PrimaryButton'
@@ -106,11 +107,11 @@ export function SavingsGoalForm({ isOpen, onClose, userId, onSuccess, initialDat
             onChange={(v) => setForm({ ...form, currency: v })}
           />
 
-          <FormInput
-            label="Fecha Límite (Opcional)"
+          <DateInput
+            label="Fecha Límite"
             value={form.deadline}
             onChange={(v) => setForm({ ...form, deadline: v })}
-            type="date"
+            optional
           />
 
           <PrimaryButton type="submit" width="full" loading={loading}>

--- a/components/settings/AccountMovementForm.tsx
+++ b/components/settings/AccountMovementForm.tsx
@@ -1,17 +1,15 @@
 'use client'
 
-import { VStack, FieldRoot, FieldLabel, NativeSelectRoot, NativeSelectField } from '@chakra-ui/react'
+import { VStack } from '@chakra-ui/react'
 import { useState } from 'react'
 import { createAccountMovement } from '@/lib/actions/account_movements.actions'
 import { toaster } from '@/lib/toaster'
 import { FormDialog } from '@/components/ui/FormDialog'
 import { FormInput } from '@/components/ui/FormInput'
+import { DateInput } from '@/components/ui/DateInput'
 import { InputAmount } from '@/components/ui/InputAmount'
-const CURRENCY_OPTIONS: { value: string; label: string }[] = [
-  { value: 'COP', label: 'COP - Peso Colombiano' },
-  { value: 'USD', label: 'USD - Dólar' },
-  { value: 'VES', label: 'VES - Bolívar (Bs)' },
-]
+import { AccountSelect } from '@/components/ui/AccountSelect'
+import { CurrencySelect } from '@/components/ui/CurrencySelect'
 import { PrimaryButton } from '@/components/ui/PrimaryButton'
 import type { Account, Currency } from '@/types/database.types'
 import { getLocalDateString } from '@/lib/utils/dates'
@@ -69,22 +67,14 @@ export function AccountMovementForm({ isOpen, onClose, userId, accounts, onSucce
     <FormDialog isOpen={isOpen} onClose={onClose} title="Nuevo Movimiento entre Cuentas">
       <form onSubmit={handleSubmit}>
         <VStack gap={4}>
-          <FieldRoot required>
-            <FieldLabel>Cuenta origen</FieldLabel>
-            <NativeSelectRoot>
-              <NativeSelectField
-                value={formData.from_account_id}
-                onChange={(e) => setFormData({ ...formData, from_account_id: e.target.value })}
-              >
-                <option value="">Seleccionar...</option>
-                {accounts.map((acc) => (
-                  <option key={acc.id} value={acc.id}>
-                    {acc.icon ?? '💳'} {acc.name} ({acc.currency})
-                  </option>
-                ))}
-              </NativeSelectField>
-            </NativeSelectRoot>
-          </FieldRoot>
+          <AccountSelect
+            value={formData.from_account_id}
+            onChange={(v) => setFormData({ ...formData, from_account_id: v })}
+            accounts={accounts}
+            label="Cuenta origen"
+            required
+            placeholder="Seleccionar..."
+          />
 
           <InputAmount
             label="Monto enviado"
@@ -93,38 +83,22 @@ export function AccountMovementForm({ isOpen, onClose, userId, accounts, onSucce
             isRequired
           />
 
-          <FieldRoot required>
-            <FieldLabel>Moneda origen</FieldLabel>
-            <NativeSelectRoot>
-              <NativeSelectField
-                value={formData.from_currency}
-                onChange={(e) => setFormData({ ...formData, from_currency: e.target.value as Currency })}
-              >
-                {CURRENCY_OPTIONS.map((c) => (
-                  <option key={c.value} value={c.value}>{c.label}</option>
-                ))}
-              </NativeSelectField>
-            </NativeSelectRoot>
-          </FieldRoot>
+          <CurrencySelect
+            value={formData.from_currency}
+            onChange={(v) => setFormData({ ...formData, from_currency: v })}
+            showFullLabel
+            required
+          />
 
-          <FieldRoot required>
-            <FieldLabel>Cuenta destino</FieldLabel>
-            <NativeSelectRoot>
-              <NativeSelectField
-                value={formData.to_account_id}
-                onChange={(e) => setFormData({ ...formData, to_account_id: e.target.value })}
-              >
-                <option value="">Seleccionar...</option>
-                {accounts
-                  .filter((acc) => acc.id !== formData.from_account_id)
-                  .map((acc) => (
-                    <option key={acc.id} value={acc.id}>
-                      {acc.icon ?? '💳'} {acc.name} ({acc.currency})
-                    </option>
-                  ))}
-              </NativeSelectField>
-            </NativeSelectRoot>
-          </FieldRoot>
+          <AccountSelect
+            value={formData.to_account_id}
+            onChange={(v) => setFormData({ ...formData, to_account_id: v })}
+            accounts={accounts}
+            label="Cuenta destino"
+            required
+            placeholder="Seleccionar..."
+            excludeId={formData.from_account_id}
+          />
 
           <InputAmount
             label="Monto recibido"
@@ -133,19 +107,12 @@ export function AccountMovementForm({ isOpen, onClose, userId, accounts, onSucce
             isRequired
           />
 
-          <FieldRoot required>
-            <FieldLabel>Moneda destino</FieldLabel>
-            <NativeSelectRoot>
-              <NativeSelectField
-                value={formData.to_currency}
-                onChange={(e) => setFormData({ ...formData, to_currency: e.target.value as Currency })}
-              >
-                {CURRENCY_OPTIONS.map((c) => (
-                  <option key={c.value} value={c.value}>{c.label}</option>
-                ))}
-              </NativeSelectField>
-            </NativeSelectRoot>
-          </FieldRoot>
+          <CurrencySelect
+            value={formData.to_currency}
+            onChange={(v) => setFormData({ ...formData, to_currency: v })}
+            showFullLabel
+            required
+          />
 
           <FormInput
             label="Descripción (opcional)"
@@ -154,11 +121,10 @@ export function AccountMovementForm({ isOpen, onClose, userId, accounts, onSucce
             placeholder="Ej: Cambio de dólares"
           />
 
-          <FormInput
+          <DateInput
             label="Fecha"
             value={formData.date}
             onChange={(v) => setFormData({ ...formData, date: v })}
-            type="date"
             required
           />
 

--- a/components/transactions/TransactionEditForm.tsx
+++ b/components/transactions/TransactionEditForm.tsx
@@ -1,16 +1,18 @@
 'use client'
 
-import { VStack, Box, SimpleGrid, FieldRoot, FieldLabel, NativeSelectRoot, NativeSelectField } from '@chakra-ui/react'
+import { VStack, Box, SimpleGrid } from '@chakra-ui/react'
 import { useState, useEffect } from 'react'
 import { updateTransaction } from '@/lib/actions/transactions.actions'
 import { toaster } from '@/lib/toaster'
 import { FormDialog } from '@/components/ui/FormDialog'
 import { FormInput } from '@/components/ui/FormInput'
+import { DateInput } from '@/components/ui/DateInput'
 import { InputAmount } from '@/components/ui/InputAmount'
 import { FormTextarea } from '@/components/ui/FormTextarea'
 import { RadioSelect } from '@/components/ui/RadioSelect'
 import { CurrencySelect } from '@/components/ui/CurrencySelect'
 import { CategorySelect } from '@/components/ui/CategorySelect'
+import { AccountSelect } from '@/components/ui/AccountSelect'
 import { PrimaryButton } from '@/components/ui/PrimaryButton'
 import { CurrencyPreview } from './CurrencyPreview'
 import type { Account, Category, Currency, TransactionWithCategory } from '@/types/database.types'
@@ -112,22 +114,14 @@ export function TransactionEditForm({ isOpen, onClose, userId, categories, accou
           />
 
           {accounts.length > 0 && (
-            <FieldRoot>
-              <FieldLabel>Cuenta (opcional)</FieldLabel>
-              <NativeSelectRoot>
-                <NativeSelectField
-                  value={formData.account_id}
-                  onChange={(e) => setFormData({ ...formData, account_id: e.target.value })}
-                >
-                  <option value="">Sin cuenta específica</option>
-                  {accounts.map((acc) => (
-                    <option key={acc.id} value={acc.id}>
-                      {acc.icon ?? '💳'} {acc.name} ({acc.currency})
-                    </option>
-                  ))}
-                </NativeSelectField>
-              </NativeSelectRoot>
-            </FieldRoot>
+            <AccountSelect
+              value={formData.account_id}
+              onChange={(v) => setFormData({ ...formData, account_id: v })}
+              accounts={accounts}
+              label="Cuenta"
+              optional
+              placeholder="Sin cuenta específica"
+            />
           )}
 
           <Box w="full" minH="10">
@@ -144,11 +138,10 @@ export function TransactionEditForm({ isOpen, onClose, userId, categories, accou
               onChange={(v) => setFormData({ ...formData, description: v })}
               required
             />
-            <FormInput
+            <DateInput
               label="Fecha"
               value={formData.date}
               onChange={(v) => setFormData({ ...formData, date: v })}
-              type="date"
               required
             />
           </SimpleGrid>

--- a/components/transactions/TransactionForm.tsx
+++ b/components/transactions/TransactionForm.tsx
@@ -1,16 +1,18 @@
 'use client'
 
-import { VStack, Box, SimpleGrid, FieldRoot, FieldLabel, NativeSelectRoot, NativeSelectField } from '@chakra-ui/react'
+import { VStack, Box, SimpleGrid } from '@chakra-ui/react'
 import { useState, useEffect } from 'react'
 import { createTransaction } from '@/lib/actions/transactions.actions'
 import { toaster } from '@/lib/toaster'
 import { FormDialog } from '@/components/ui/FormDialog'
 import { FormInput } from '@/components/ui/FormInput'
+import { DateInput } from '@/components/ui/DateInput'
 import { InputAmount } from '@/components/ui/InputAmount'
 import { FormTextarea } from '@/components/ui/FormTextarea'
 import { RadioSelect } from '@/components/ui/RadioSelect'
 import { CurrencySelect } from '@/components/ui/CurrencySelect'
 import { CategorySelect } from '@/components/ui/CategorySelect'
+import { AccountSelect } from '@/components/ui/AccountSelect'
 import { PrimaryButton } from '@/components/ui/PrimaryButton'
 import { CurrencyPreview } from './CurrencyPreview'
 import type { Account, Category, Currency } from '@/types/database.types'
@@ -110,22 +112,14 @@ export function TransactionForm({ isOpen, onClose, userId, categories, accounts 
           />
 
           {accounts.length > 0 && (
-            <FieldRoot>
-              <FieldLabel>Cuenta (opcional)</FieldLabel>
-              <NativeSelectRoot>
-                <NativeSelectField
-                  value={formData.account_id}
-                  onChange={(e) => setFormData({ ...formData, account_id: e.target.value })}
-                >
-                  <option value="">Sin cuenta específica</option>
-                  {accounts.map((acc) => (
-                    <option key={acc.id} value={acc.id}>
-                      {acc.icon ?? '💳'} {acc.name} ({acc.currency})
-                    </option>
-                  ))}
-                </NativeSelectField>
-              </NativeSelectRoot>
-            </FieldRoot>
+            <AccountSelect
+              value={formData.account_id}
+              onChange={(v) => setFormData({ ...formData, account_id: v })}
+              accounts={accounts}
+              label="Cuenta"
+              optional
+              placeholder="Sin cuenta específica"
+            />
           )}
 
           <Box w="full" minH="10">
@@ -143,11 +137,10 @@ export function TransactionForm({ isOpen, onClose, userId, categories, accounts 
               placeholder="Ej: Compra en supermercado"
               required
             />
-            <FormInput
+            <DateInput
               label="Fecha"
               value={formData.date}
               onChange={(v) => setFormData({ ...formData, date: v })}
-              type="date"
               required
               disabled={lockedDate}
             />

--- a/components/ui/AccountSelect.tsx
+++ b/components/ui/AccountSelect.tsx
@@ -1,0 +1,47 @@
+'use client'
+
+import { FieldRoot, FieldLabel, NativeSelectRoot, NativeSelectField } from '@chakra-ui/react'
+import type { Account } from '@/types/database.types'
+
+interface Props {
+  value: string
+  onChange: (value: string) => void
+  accounts: Account[]
+  label?: string
+  optional?: boolean
+  required?: boolean
+  placeholder?: string
+  excludeId?: string
+}
+
+export function AccountSelect({
+  value,
+  onChange,
+  accounts,
+  label = 'Cuenta',
+  optional,
+  required,
+  placeholder = 'Sin cuenta',
+  excludeId,
+}: Props) {
+  const filtered = excludeId ? accounts.filter((a) => a.id !== excludeId) : accounts
+
+  return (
+    <FieldRoot required={required} w="full">
+      <FieldLabel>
+        {label}
+        {optional && <span style={{ color: '#B0B0B0', fontSize: '0.85em', marginLeft: '4px' }}>(opcional)</span>}
+      </FieldLabel>
+      <NativeSelectRoot>
+        <NativeSelectField value={value} onChange={(e) => onChange(e.target.value)}>
+          <option value="">{placeholder}</option>
+          {filtered.map((acc) => (
+            <option key={acc.id} value={acc.id}>
+              {acc.icon ?? '💳'} {acc.name} ({acc.currency})
+            </option>
+          ))}
+        </NativeSelectField>
+      </NativeSelectRoot>
+    </FieldRoot>
+  )
+}

--- a/components/ui/DateInput.tsx
+++ b/components/ui/DateInput.tsx
@@ -1,0 +1,48 @@
+'use client'
+
+import { FieldRoot, FieldLabel, Input, Flex, IconButton } from '@chakra-ui/react'
+import { FiX } from 'react-icons/fi'
+
+interface Props {
+  label: string
+  value: string
+  onChange: (value: string) => void
+  required?: boolean
+  disabled?: boolean
+  optional?: boolean
+}
+
+export function DateInput({ label, value, onChange, required, disabled, optional }: Props) {
+  return (
+    <FieldRoot required={required} w="full">
+      <FieldLabel>
+        {label}
+        {optional && <span style={{ color: '#B0B0B0', fontSize: '0.85em', marginLeft: '4px' }}>(opcional)</span>}
+      </FieldLabel>
+      <Flex gap={1} w="full">
+        <Input
+          type="date"
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          disabled={disabled}
+          opacity={disabled ? 0.6 : 1}
+          cursor={disabled ? 'not-allowed' : undefined}
+          flex={1}
+        />
+        {value && !disabled && (
+          <IconButton
+            aria-label="Limpiar fecha"
+            variant="ghost"
+            size="sm"
+            color="#B0B0B0"
+            _hover={{ color: 'white', bg: '#26262f' }}
+            onClick={() => onChange('')}
+            flexShrink={0}
+          >
+            <FiX />
+          </IconButton>
+        )}
+      </Flex>
+    </FieldRoot>
+  )
+}

--- a/components/ui/FrequencySelect.tsx
+++ b/components/ui/FrequencySelect.tsx
@@ -1,0 +1,30 @@
+'use client'
+
+import { FieldRoot, FieldLabel, NativeSelectRoot, NativeSelectField } from '@chakra-ui/react'
+
+type Frequency = 'daily' | 'weekly' | 'monthly' | 'yearly'
+
+interface Props {
+  value: Frequency
+  onChange: (value: Frequency) => void
+  required?: boolean
+}
+
+export function FrequencySelect({ value, onChange, required }: Props) {
+  return (
+    <FieldRoot required={required} w="full">
+      <FieldLabel>Frecuencia</FieldLabel>
+      <NativeSelectRoot>
+        <NativeSelectField
+          value={value}
+          onChange={(e) => onChange(e.target.value as Frequency)}
+        >
+          <option value="daily">Diario</option>
+          <option value="weekly">Semanal</option>
+          <option value="monthly">Mensual</option>
+          <option value="yearly">Anual</option>
+        </NativeSelectField>
+      </NativeSelectRoot>
+    </FieldRoot>
+  )
+}


### PR DESCRIPTION
## Cambios

### Nuevos componentes en `components/ui/`
- **`DateInput`**: wrapper sobre Input type=date con botón X para limpiar el campo (esencial en mobile sin teclado). Soporta `required`, `disabled`, `optional`.
- **`AccountSelect`**: select de cuentas reutilizable con soporte de `excludeId` (para excluir cuenta origen en transferencias), `optional`, `placeholder` personalizable.
- **`FrequencySelect`**: select de frecuencia con opciones fijas (diario/semanal/mensual/anual).

### Archivos actualizados (reemplazo de código inline duplicado)
- `TransactionForm` y `TransactionEditForm` → DateInput + AccountSelect
- `RecurringTransactionForm` → DateInput + AccountSelect + FrequencySelect
- `AccountMovementForm` → AccountSelect (×2) + CurrencySelect + DateInput
- `LoanForm` → AccountSelect
- `AddFundsForm` → AccountSelect
- `SavingsGoalForm` → DateInput (optional)
- `BudgetForm` → DateInput
- `ReportFilters` → DateInput (×2)

## Testing
- ✅ Sin errores TypeScript
- ✅ `DateInput` muestra botón X cuando hay valor, limpia al click
- ✅ `AccountSelect` respeta `excludeId` en movimientos entre cuentas
- ✅ `FrequencySelect` funciona en RecurringTransactionForm

Closes #290