### PR TITLE
fix: SearchableSelect dropdown absoluto — sin aumentar altura del modal

### DIFF
--- a/components/ui/SearchableSelect.tsx
+++ b/components/ui/SearchableSelect.tsx
@@ -77,40 +77,53 @@ export function SearchableSelect({
         </FieldLabel>
       )}
 
+      {/* Container is always h="10" — dropdown is absolutely positioned and never affects modal height */}
       <Box ref={containerRef} w="full" position="relative">
-        {!isOpen ? (
-          <Flex
-            as="button"
-            onClick={open}
-            w="full"
-            textAlign="left"
-            px={3}
-            h="10"
-            borderRadius="md"
-            borderWidth="1px"
-            borderColor="#2d2d35"
-            bg="transparent"
-            color={selected ? 'white' : '#6B7280'}
-            alignItems="center"
-            justifyContent="space-between"
-            cursor="pointer"
-            _hover={{ borderColor: '#4F46E5' }}
-            transition="border-color 0.2s"
-            fontSize="sm"
-          >
-            <Box as="span" overflow="hidden" whiteSpace="nowrap" textOverflow="ellipsis" flex={1} textAlign="left">
-              {selected ? selected.label : placeholder}
-            </Box>
-            <Icon as={FiChevronDown} color="#6B7280" flexShrink={0} ml={2} />
-          </Flex>
-        ) : (
+        <Flex
+          as="button"
+          onClick={isOpen ? close : open}
+          w="full"
+          textAlign="left"
+          px={3}
+          h="10"
+          borderRadius="md"
+          borderWidth="1px"
+          borderColor={isOpen ? '#4F46E5' : '#2d2d35'}
+          bg="transparent"
+          color={selected ? 'white' : '#6B7280'}
+          alignItems="center"
+          justifyContent="space-between"
+          cursor="pointer"
+          _hover={{ borderColor: '#4F46E5' }}
+          transition="border-color 0.2s"
+          fontSize="sm"
+        >
+          <Box as="span" overflow="hidden" whiteSpace="nowrap" textOverflow="ellipsis" flex={1} textAlign="left">
+            {selected ? selected.label : placeholder}
+          </Box>
+          <Icon
+            as={FiChevronDown}
+            color="#6B7280"
+            flexShrink={0}
+            ml={2}
+            transform={isOpen ? 'rotate(180deg)' : 'none'}
+            transition="transform 0.2s"
+          />
+        </Flex>
+
+        {isOpen && (
           <Box
+            position="absolute"
+            top="calc(100% + 4px)"
+            left={0}
+            right={0}
+            zIndex={200}
+            bg="#18181d"
             borderWidth="1px"
             borderColor="#4F46E5"
             borderRadius="md"
+            boxShadow="0 8px 24px rgba(0,0,0,0.6)"
             overflow="hidden"
-            bg="#18181d"
-            boxShadow="0 4px 12px rgba(0,0,0,0.4)"
           >
             <Input
               ref={inputRef}


### PR DESCRIPTION
## Problema
Al abrir un `SearchableSelect` dentro de un modal (`FormDialog`), el modal crecía en altura porque el componente alternaba entre el trigger y un bloque expandido inline, desplazando todo el contenido hacia abajo.

## Causa
El componente usaba `{!isOpen ? <trigger> : <expanded box>}` — al abrir, el trigger desaparecía y era reemplazado por un bloque más alto, aumentando la altura del formulario y por ende del modal.

## Solución
- El trigger (`h="10"`) siempre está visible y ocupa su espacio fijo en el flujo
- El dropdown se renderiza como `position: absolute` (`top: calc(100% + 4px)`) flotando sobre el contenido, sin afectar el layout
- `zIndex: 200` para aparecer sobre otros elementos del modal
- Icono chevron rota 180° cuando el dropdown está abierto (feedback visual)
- Borde del trigger cambia a indigo cuando está abierto

## Testing
- ✅ Sin errores TypeScript
- ✅ El modal no cambia de tamaño al abrir el select
- ✅ El dropdown flota sobre el contenido del formulario