### PR TITLE
feat: reemplazar CategorySelect con Chakra NativeSelect

### DIFF
--- a/components/ui/CategorySelect.tsx
+++ b/components/ui/CategorySelect.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { SearchableSelect } from '@/components/ui/SearchableSelect'
+import { FieldRoot, FieldLabel, NativeSelectRoot, NativeSelectField } from '@chakra-ui/react'
 import type { Category } from '@/types/database.types'
 
 interface Props {
@@ -14,19 +14,22 @@ interface Props {
 export function CategorySelect({ value, onChange, categories, filterByType, required }: Props) {
   const filtered = filterByType ? categories.filter((c) => c.type === filterByType) : categories
 
-  const options = filtered.map((cat) => ({
-    value: cat.id,
-    label: `${cat.icon} ${cat.name}`,
-  }))
-
   return (
-    <SearchableSelect
-      label="Categoría"
-      value={value}
-      onChange={onChange}
-      options={options}
-      placeholder="Seleccionar categoría..."
-      required={required}
-    />
+    <FieldRoot required={required} w="full">
+      <FieldLabel>Categoría</FieldLabel>
+      <NativeSelectRoot>
+        <NativeSelectField
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+        >
+          <option value="">Seleccionar categoría...</option>
+          {filtered.map((cat) => (
+            <option key={cat.id} value={cat.id}>
+              {cat.icon} {cat.name}
+            </option>
+          ))}
+        </NativeSelectField>
+      </NativeSelectRoot>
+    </FieldRoot>
   )
 }


### PR DESCRIPTION
## Cambios
- Reescrito `CategorySelect` usando `NativeSelectRoot`/`NativeSelectField` de Chakra UI v3
- Elimina dependencia de `SearchableSelect`
- Mantiene props: value, onChange, categories, filterByType, required

Closes #300
Related to #297