### PR TITLE
fix: reportes — monedas sin mezclar y tooltips con formato correcto

### DIFF
--- a/components/ReportStatistics.tsx
+++ b/components/ReportStatistics.tsx
@@ -33,12 +33,17 @@ interface Props {
   filters?: ReportFiltersState
 }
 
+function getDominantCurrency(transactions: TransactionWithCategory[]): string {
+  const counts = transactions.reduce<Record<string, number>>((acc, t) => {
+    acc[t.currency] = (acc[t.currency] || 0) + 1
+    return acc
+  }, {})
+  return Object.entries(counts).sort((a, b) => b[1] - a[1])[0]?.[0] ?? 'COP'
+}
+
 export function ReportStatistics({ userId, filters }: Props) {
-  const [stats, setStats] = useState({
-    totalIncome: 0,
-    totalExpense: 0,
-    netBalance: 0,
-  })
+  const [stats, setStats] = useState({ totalIncome: 0, totalExpense: 0, netBalance: 0 })
+  const [currency, setCurrency] = useState('COP')
   const [loading, setLoading] = useState(true)
 
   useEffect(() => {
@@ -48,41 +53,32 @@ export function ReportStatistics({ userId, filters }: Props) {
       if (result.success && result.data) {
         let transactions = result.data as TransactionWithCategory[]
 
-        // Aplicar filtros de fecha
         if (filters?.startDate) {
           transactions = transactions.filter((t) => t.date >= filters.startDate)
         }
         if (filters?.endDate) {
           transactions = transactions.filter((t) => t.date <= filters.endDate)
         }
-
-        // Aplicar filtro de tipo
         if (filters?.transactionType && filters.transactionType !== 'all') {
           transactions = transactions.filter((t) => t.type === filters.transactionType)
         }
-
-        // Aplicar filtro de categoría
         if (filters?.categoryIds && filters.categoryIds.length > 0) {
           transactions = transactions.filter((t) => filters.categoryIds.includes(t.category_id || ''))
         }
 
-        // Calcular estadísticas
+        const dominant = getDominantCurrency(transactions)
+        setCurrency(dominant)
+
+        const filtered = transactions.filter((t) => t.currency === dominant)
+
         let totalIncome = 0
         let totalExpense = 0
-
-        transactions.forEach((t) => {
-          if (t.type === 'income') {
-            totalIncome += Number(t.amount)
-          } else {
-            totalExpense += Number(t.amount)
-          }
+        filtered.forEach((t) => {
+          if (t.type === 'income') totalIncome += Number(t.amount)
+          else totalExpense += Number(t.amount)
         })
 
-        setStats({
-          totalIncome,
-          totalExpense,
-          netBalance: totalIncome - totalExpense,
-        })
+        setStats({ totalIncome, totalExpense, netBalance: totalIncome - totalExpense })
       }
       setLoading(false)
     }
@@ -90,28 +86,27 @@ export function ReportStatistics({ userId, filters }: Props) {
   }, [userId, filters])
 
   if (loading) {
-    return (
-      <Center py={10}>
-        <Spinner />
-      </Center>
-    )
+    return <Center py={10}><Spinner /></Center>
   }
 
   return (
     <SimpleGrid columns={{ base: 1, md: 3 }} gap={6} mb={8}>
       <StatCard
         label="Ingresos Totales"
-        value={formatCurrency(stats.totalIncome, 'COP')}
+        value={formatCurrency(stats.totalIncome, currency)}
+        helpText={`En ${currency}`}
         color="#2ECC71"
       />
       <StatCard
         label="Gastos Totales"
-        value={formatCurrency(stats.totalExpense, 'COP')}
+        value={formatCurrency(stats.totalExpense, currency)}
+        helpText={`En ${currency}`}
         color="#E74C3C"
       />
       <StatCard
         label="Balance Neto"
-        value={formatCurrency(Math.abs(stats.netBalance), 'COP')}
+        value={formatCurrency(Math.abs(stats.netBalance), currency)}
+        helpText={`En ${currency}`}
         color={stats.netBalance >= 0 ? '#2ECC71' : '#E74C3C'}
       />
     </SimpleGrid>

--- a/components/ReportsContent.tsx
+++ b/components/ReportsContent.tsx
@@ -34,7 +34,7 @@ export function ReportsContent({ userId }: Props) {
         <ExpensesByCategoryChart userId={userId} type="expense" filters={filters} />
         <ExpensesByCategoryChart userId={userId} type="income" filters={filters} />
         <Box gridColumn={{ base: 'auto', md: '1 / -1' }}>
-          <MonthlyComparisonChart userId={userId} months={12} filters={filters} />
+          <MonthlyComparisonChart userId={userId} />
         </Box>
         <Box gridColumn={{ base: 'auto', md: '1 / -1' }}>
           <AccumulatedBalanceChart userId={userId} filters={filters} />

--- a/components/charts/AccumulatedBalanceChart.tsx
+++ b/components/charts/AccumulatedBalanceChart.tsx
@@ -14,9 +14,9 @@ import {
 } from 'recharts'
 import { getTransactions } from '@/lib/actions/transactions.actions'
 import { Card } from '@/components/ui/Card'
+import { formatCurrency } from '@/lib/utils/currency'
 import type { TransactionWithCategory } from '@/types/database.types'
 import type { ReportFiltersState } from '@/components/ReportFilters'
-import { formatCurrency } from '@/lib/utils/currency'
 
 interface ChartDataPoint {
   date: string
@@ -28,8 +28,17 @@ interface Props {
   filters?: ReportFiltersState
 }
 
+function getDominantCurrency(transactions: TransactionWithCategory[]): string {
+  const counts = transactions.reduce<Record<string, number>>((acc, t) => {
+    acc[t.currency] = (acc[t.currency] || 0) + 1
+    return acc
+  }, {})
+  return Object.entries(counts).sort((a, b) => b[1] - a[1])[0]?.[0] ?? 'COP'
+}
+
 export function AccumulatedBalanceChart({ userId, filters }: Props) {
   const [chartData, setChartData] = useState<ChartDataPoint[]>([])
+  const [currency, setCurrency] = useState('COP')
   const [loading, setLoading] = useState(true)
 
   useEffect(() => {
@@ -39,56 +48,39 @@ export function AccumulatedBalanceChart({ userId, filters }: Props) {
       if (result.success && result.data) {
         let transactions = result.data as TransactionWithCategory[]
 
-        // Aplicar filtros de fecha
         if (filters?.startDate) {
           transactions = transactions.filter((t) => t.date >= filters.startDate)
         }
         if (filters?.endDate) {
           transactions = transactions.filter((t) => t.date <= filters.endDate)
         }
-
-        // Aplicar filtro de tipo
         if (filters?.transactionType && filters.transactionType !== 'all') {
           transactions = transactions.filter((t) => t.type === filters.transactionType)
         }
-
-        // Aplicar filtro de categoría
         if (filters?.categoryIds && filters.categoryIds.length > 0) {
           transactions = transactions.filter((t) => filters.categoryIds.includes(t.category_id || ''))
         }
 
-        // Ordenar por fecha
-        const sorted = [...transactions].sort((a, b) =>
-          a.date.localeCompare(b.date)
-        )
+        const dominant = getDominantCurrency(transactions)
+        setCurrency(dominant)
 
-        // Calcular balance acumulado
+        // Solo moneda dominante para el balance acumulado
+        const filtered = transactions.filter((t) => t.currency === dominant)
+        const sorted = [...filtered].sort((a, b) => a.date.localeCompare(b.date))
+
         let accumulatedBalance = 0
         const data: ChartDataPoint[] = sorted.map((t) => {
           const amount = Number(t.amount)
-
-          if (filters?.transactionType === 'all' || !filters?.transactionType) {
-            // Mostrar balance real: ingresos - gastos
-            if (t.type === 'income') {
-              accumulatedBalance += amount
-            } else {
-              accumulatedBalance -= amount
-            }
-          } else if (filters.transactionType === 'income') {
-            // Solo ingresos acumulados
+          if (filters?.transactionType === 'income') {
             accumulatedBalance += amount
-          } else if (filters.transactionType === 'expense') {
-            // Solo gastos acumulados (como negativo)
+          } else if (filters?.transactionType === 'expense') {
             accumulatedBalance -= amount
+          } else {
+            accumulatedBalance += t.type === 'income' ? amount : -amount
           }
-
-          return {
-            date: t.date,
-            balance: accumulatedBalance,
-          }
+          return { date: t.date, balance: accumulatedBalance }
         })
 
-        // Tomar últimas 30 transacciones para gráfico más legible
         setChartData(data.slice(-30))
       }
       setLoading(false)
@@ -99,9 +91,7 @@ export function AccumulatedBalanceChart({ userId, filters }: Props) {
   if (loading) {
     return (
       <Card>
-        <Center py={10}>
-          <Spinner />
-        </Center>
+        <Center py={10}><Spinner /></Center>
       </Card>
     )
   }
@@ -109,25 +99,22 @@ export function AccumulatedBalanceChart({ userId, filters }: Props) {
   if (chartData.length === 0) {
     return (
       <Card>
-        <Heading size="md" mb={4}>
-          Balance Acumulado
-        </Heading>
+        <Heading size="md" mb={4}>Balance Acumulado</Heading>
         <Text color="#B0B0B0">No hay datos para mostrar.</Text>
       </Card>
     )
   }
 
-  const currentBalance = chartData[chartData.length - 1]?.balance || 0
+  const currentBalance = chartData[chartData.length - 1]?.balance ?? 0
 
   return (
     <Card>
       <Box mb={4}>
-        <Heading size="md" mb={2}>
-          Balance Acumulado
-        </Heading>
+        <Heading size="md" mb={2}>Balance Acumulado</Heading>
         <Text fontSize="2xl" fontWeight="bold" color={currentBalance >= 0 ? '#2ECC71' : '#E74C3C'}>
-          {formatCurrency(currentBalance, 'COP')}
+          {formatCurrency(currentBalance, currency)}
         </Text>
+        <Text fontSize="xs" color="#B0B0B0">Solo moneda dominante: {currency}</Text>
       </Box>
       <Box h="400px">
         <ResponsiveContainer width="100%" height="100%">
@@ -138,9 +125,9 @@ export function AccumulatedBalanceChart({ userId, filters }: Props) {
               tick={{ fontSize: 12 }}
               interval={Math.floor(chartData.length / 5)}
             />
-            <YAxis tickFormatter={(value) => formatCurrency(Number(value), 'COP')} width={110} />
+            <YAxis tickFormatter={(value) => formatCurrency(Number(value), currency)} width={110} />
             <Tooltip
-              formatter={(value) => [formatCurrency(Number(value), 'COP'), 'Balance']}
+              formatter={(value) => [formatCurrency(Number(value), currency), 'Balance']}
               contentStyle={{
                 backgroundColor: '#1a1a23',
                 border: '1px solid #2d2d35',

--- a/components/charts/ExpensesByCategoryChart.tsx
+++ b/components/charts/ExpensesByCategoryChart.tsx
@@ -12,12 +12,14 @@ import {
 } from 'recharts'
 import { getTransactions } from '@/lib/actions/transactions.actions'
 import { Card } from '@/components/ui/Card'
+import { formatCurrency } from '@/lib/utils/currency'
 import type { TransactionWithCategory } from '@/types/database.types'
 import type { ReportFiltersState } from '@/components/ReportFilters'
 
 interface ChartDataPoint {
   name: string
   value: number
+  currency: string
 }
 
 interface Props {
@@ -26,37 +28,37 @@ interface Props {
   filters?: ReportFiltersState
 }
 
-// Colores para ingresos (tonos positivos: verdes y azules)
 const INCOME_COLORS = [
-  '#2ECC71', // Verde brillante
-  '#27AE60', // Verde oscuro
-  '#16A085', // Verde azulado
-  '#1ABC9C', // Turquesa
-  '#3498DB', // Azul brillante
-  '#2980B9', // Azul oscuro
-  '#8E44AD', // Púrpura (positivo)
-  '#9B59B6', // Púrpura claro
-  '#48C9B0', // Verde agua
-  '#17A589', // Verde agua oscuro
-  '#6C5CE7', // Azul púrpura
-  '#74B9FF', // Azul claro
+  '#2ECC71', '#27AE60', '#16A085', '#1ABC9C',
+  '#3498DB', '#2980B9', '#8E44AD', '#9B59B6',
+  '#48C9B0', '#17A589', '#6C5CE7', '#74B9FF',
 ]
 
-// Colores para gastos (tonos negativos: amarillos, naranjas y rojos)
 const EXPENSE_COLORS = [
-  '#E74C3C', // Rojo brillante
-  '#C0392B', // Rojo oscuro
-  '#E67E22', // Naranja oscuro
-  '#D35400', // Naranja más oscuro
-  '#F39C12', // Amarillo naranja
-  '#F1C40F', // Amarillo brillante
-  '#E59866', // Naranja claro
-  '#DC7633', // Naranja medio
-  '#CB4335', // Rojo medio
-  '#A93226', // Rojo muy oscuro
-  '#F4D03F', // Amarillo claro
-  '#E8DAEF', // Rosa claro (negativo suave)
+  '#E74C3C', '#C0392B', '#E67E22', '#D35400',
+  '#F39C12', '#F1C40F', '#E59866', '#DC7633',
+  '#CB4335', '#A93226', '#F4D03F', '#E8DAEF',
 ]
+
+function getDominantCurrency(transactions: TransactionWithCategory[]): string {
+  const counts = transactions.reduce<Record<string, number>>((acc, t) => {
+    acc[t.currency] = (acc[t.currency] || 0) + 1
+    return acc
+  }, {})
+  return Object.entries(counts).sort((a, b) => b[1] - a[1])[0]?.[0] ?? 'COP'
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function CustomTooltip({ active, payload }: any) {
+  if (!active || !payload?.length) return null
+  const { name, value, currency } = payload[0].payload as ChartDataPoint
+  return (
+    <Box bg="#1a1a23" border="1px solid #2d2d35" borderRadius="8px" px={3} py={2}>
+      <Text fontSize="sm" color="#B0B0B0">{name}</Text>
+      <Text fontSize="sm" fontWeight="bold" color="white">{formatCurrency(value, currency)}</Text>
+    </Box>
+  )
+}
 
 export function ExpensesByCategoryChart({ userId, type = 'expense', filters }: Props) {
   const [chartData, setChartData] = useState<ChartDataPoint[]>([])
@@ -69,39 +71,36 @@ export function ExpensesByCategoryChart({ userId, type = 'expense', filters }: P
       if (result.success && result.data) {
         let transactions = result.data as TransactionWithCategory[]
 
-        // Filtrar por el tipo del componente (expense o income)
         transactions = transactions.filter((t) => t.type === type)
 
-        // Si el filtro de tipo es específico y NO coincide con el type prop, devolver vacío
         if (filters?.transactionType && filters.transactionType !== 'all' && filters.transactionType !== type) {
           setChartData([])
           setLoading(false)
           return
         }
 
-        // Aplicar filtros de fecha
         if (filters?.startDate) {
           transactions = transactions.filter((t) => t.date >= filters.startDate)
         }
         if (filters?.endDate) {
           transactions = transactions.filter((t) => t.date <= filters.endDate)
         }
-
-        // Aplicar filtro de categoría
         if (filters?.categoryIds && filters.categoryIds.length > 0) {
           transactions = transactions.filter((t) => filters.categoryIds.includes(t.category_id || ''))
         }
 
-        // Agrupar por categoría
-        const grouped = transactions.reduce<Record<string, number>>((acc, t) => {
+        // Agrupar por (categoría, moneda) para no mezclar divisas
+        const dominated = getDominantCurrency(transactions)
+        const sameCurrency = transactions.filter((t) => t.currency === dominated)
+
+        const grouped = sameCurrency.reduce<Record<string, number>>((acc, t) => {
           const categoryName = t.category?.name || 'Sin categoría'
           acc[categoryName] = (acc[categoryName] || 0) + Number(t.amount)
           return acc
         }, {})
 
-        // Convertir a array y ordenar por valor descendente
         const data = Object.entries(grouped)
-          .map(([name, value]) => ({ name, value }))
+          .map(([name, value]) => ({ name, value, currency: dominated }))
           .sort((a, b) => b.value - a.value)
 
         setChartData(data)
@@ -112,13 +111,12 @@ export function ExpensesByCategoryChart({ userId, type = 'expense', filters }: P
   }, [userId, type, filters])
 
   const title = type === 'expense' ? 'Gastos por Categoría' : 'Ingresos por Categoría'
+  const currency = chartData[0]?.currency ?? 'COP'
 
   if (loading) {
     return (
       <Card>
-        <Center py={10}>
-          <Spinner />
-        </Center>
+        <Center py={10}><Spinner /></Center>
       </Card>
     )
   }
@@ -126,9 +124,7 @@ export function ExpensesByCategoryChart({ userId, type = 'expense', filters }: P
   if (chartData.length === 0) {
     return (
       <Card>
-        <Heading size="md" mb={4}>
-          {title}
-        </Heading>
+        <Heading size="md" mb={4}>{title}</Heading>
         <Text color="#B0B0B0">No hay datos para mostrar.</Text>
       </Card>
     )
@@ -136,9 +132,8 @@ export function ExpensesByCategoryChart({ userId, type = 'expense', filters }: P
 
   return (
     <Card>
-      <Heading size="md" mb={4}>
-        {title}
-      </Heading>
+      <Heading size="md" mb={1}>{title}</Heading>
+      <Text fontSize="xs" color="#B0B0B0" mb={4}>Solo moneda dominante: {currency}</Text>
       <Box h={{ base: '280px', md: '400px' }}>
         <ResponsiveContainer width="100%" height="100%">
           <PieChart margin={{ top: 10, right: 10, left: 10, bottom: 10 }}>
@@ -149,25 +144,14 @@ export function ExpensesByCategoryChart({ userId, type = 'expense', filters }: P
               cx="50%"
               cy="50%"
               outerRadius="40%"
-              label={({ name, percent = 0 }) =>
-                `${name} ${(percent * 100).toFixed(0)}%`
-              }
+              label={({ name, percent = 0 }) => `${name} ${(percent * 100).toFixed(0)}%`}
             >
               {chartData.map((_, index) => {
                 const colorPalette = type === 'income' ? INCOME_COLORS : EXPENSE_COLORS
-                return (
-                  <Cell key={`cell-${index}`} fill={colorPalette[index % colorPalette.length]} />
-                )
+                return <Cell key={`cell-${index}`} fill={colorPalette[index % colorPalette.length]} />
               })}
             </Pie>
-            <Tooltip
-              formatter={(value) => `$${Number(value).toFixed(2)}`}
-              contentStyle={{
-                backgroundColor: '#1a1a1a',
-                border: '1px solid #333',
-                borderRadius: '4px',
-              }}
-            />
+            <Tooltip content={<CustomTooltip />} />
             <Legend />
           </PieChart>
         </ResponsiveContainer>

--- a/components/charts/MonthlyComparisonChart.tsx
+++ b/components/charts/MonthlyComparisonChart.tsx
@@ -14,9 +14,8 @@ import {
 } from 'recharts'
 import { getTransactions } from '@/lib/actions/transactions.actions'
 import { Card } from '@/components/ui/Card'
-import type { TransactionWithCategory } from '@/types/database.types'
-import type { ReportFiltersState } from '@/components/ReportFilters'
 import { formatCurrency } from '@/lib/utils/currency'
+import type { TransactionWithCategory } from '@/types/database.types'
 
 interface ChartDataPoint {
   month: string
@@ -26,84 +25,75 @@ interface ChartDataPoint {
 
 interface Props {
   userId: string
-  months?: number
-  filters?: ReportFiltersState
 }
 
-export function MonthlyComparisonChart({ userId, months = 12, filters }: Props) {
+const MONTH_LABELS: Record<string, string> = {
+  '01': 'Ene', '02': 'Feb', '03': 'Mar', '04': 'Abr',
+  '05': 'May', '06': 'Jun', '07': 'Jul', '08': 'Ago',
+  '09': 'Sep', '10': 'Oct', '11': 'Nov', '12': 'Dic',
+}
+
+function getDominantCurrency(transactions: TransactionWithCategory[]): string {
+  const counts = transactions.reduce<Record<string, number>>((acc, t) => {
+    acc[t.currency] = (acc[t.currency] || 0) + 1
+    return acc
+  }, {})
+  return Object.entries(counts).sort((a, b) => b[1] - a[1])[0]?.[0] ?? 'COP'
+}
+
+export function MonthlyComparisonChart({ userId }: Props) {
   const [chartData, setChartData] = useState<ChartDataPoint[]>([])
+  const [currency, setCurrency] = useState('COP')
   const [loading, setLoading] = useState(true)
+  const currentYear = new Date().getFullYear()
 
   useEffect(() => {
     async function fetchData() {
       const result = await getTransactions(userId, 500)
 
       if (result.success && result.data) {
-        let transactions = result.data as TransactionWithCategory[]
+        const allTransactions = result.data as TransactionWithCategory[]
 
-        // Aplicar filtros de fecha
-        if (filters?.startDate) {
-          transactions = transactions.filter((t) => t.date >= filters.startDate)
-        }
-        if (filters?.endDate) {
-          transactions = transactions.filter((t) => t.date <= filters.endDate)
-        }
-
-        // Aplicar filtro de tipo
-        if (filters?.transactionType && filters.transactionType !== 'all') {
-          transactions = transactions.filter((t) => t.type === filters.transactionType)
-        }
-
-        // Aplicar filtro de categoría
-        if (filters?.categoryIds && filters.categoryIds.length > 0) {
-          transactions = transactions.filter((t) => filters.categoryIds.includes(t.category_id || ''))
-        }
-
-        // Agrupar por mes
-        const grouped = transactions.reduce<Record<string, ChartDataPoint>>(
-          (acc, t) => {
-            const month = t.date.slice(0, 7) // YYYY-MM
-            if (!acc[month]) {
-              acc[month] = { month, income: 0, expense: 0 }
-            }
-            // Solo contar el tipo de transacción correspondiente
-            if (filters?.transactionType === 'all' || !filters?.transactionType) {
-              // Mostrar ambos tipos
-              if (t.type === 'income') {
-                acc[month].income += Number(t.amount)
-              } else {
-                acc[month].expense += Number(t.amount)
-              }
-            } else if (filters.transactionType === 'income') {
-              // Solo ingresos, gastos = 0
-              acc[month].income += Number(t.amount)
-            } else if (filters.transactionType === 'expense') {
-              // Solo gastos, ingresos = 0
-              acc[month].expense += Number(t.amount)
-            }
-            return acc
-          },
-          {}
+        // Siempre filtrar al año actual
+        const yearTransactions = allTransactions.filter(
+          (t) => t.date.startsWith(String(currentYear))
         )
 
-        // Convertir a array, ordenar y tomar últimos N meses
-        const data = Object.values(grouped)
-          .sort((a, b) => a.month.localeCompare(b.month))
-          .slice(-months)
+        const dominant = getDominantCurrency(yearTransactions)
+        setCurrency(dominant)
 
-        setChartData(data)
+        // Solo la moneda dominante para no mezclar
+        const filtered = yearTransactions.filter((t) => t.currency === dominant)
+
+        // Inicializar los 12 meses del año
+        const grouped: Record<string, ChartDataPoint> = {}
+        for (let m = 1; m <= 12; m++) {
+          const key = `${currentYear}-${String(m).padStart(2, '0')}`
+          grouped[key] = { month: key, income: 0, expense: 0 }
+        }
+
+        filtered.forEach((t) => {
+          const month = t.date.slice(0, 7)
+          if (grouped[month]) {
+            if (t.type === 'income') {
+              grouped[month].income += Number(t.amount)
+            } else {
+              grouped[month].expense += Number(t.amount)
+            }
+          }
+        })
+
+        setChartData(Object.values(grouped))
       }
       setLoading(false)
     }
     fetchData()
-  }, [userId, months, filters])
+  }, [userId, currentYear])
 
   if (loading) {
     return (
       <Card>
-        <Center py={10}>
-          <Spinner />
-        </Center>
+        <Center py={10}><Spinner /></Center>
       </Card>
     )
   }
@@ -111,9 +101,7 @@ export function MonthlyComparisonChart({ userId, months = 12, filters }: Props) 
   if (chartData.length === 0) {
     return (
       <Card>
-        <Heading size="md" mb={4}>
-          Comparación Mensual
-        </Heading>
+        <Heading size="md" mb={4}>Comparación Mensual {currentYear}</Heading>
         <Text color="#B0B0B0">No hay datos para mostrar.</Text>
       </Card>
     )
@@ -121,22 +109,32 @@ export function MonthlyComparisonChart({ userId, months = 12, filters }: Props) 
 
   return (
     <Card>
-      <Heading size="md" mb={4}>
-        Comparación Mensual
-      </Heading>
+      <Heading size="md" mb={1}>Comparación Mensual {currentYear}</Heading>
+      <Text fontSize="xs" color="#B0B0B0" mb={4}>Solo moneda dominante: {currency}</Text>
       <Box h={{ base: '250px', md: '400px' }}>
         <ResponsiveContainer width="100%" height="100%">
           <BarChart data={chartData} margin={{ top: 10, right: 10, left: 0, bottom: 10 }}>
             <CartesianGrid strokeDasharray="3 3" />
-            <XAxis dataKey="month" />
-            <YAxis tickFormatter={(value) => formatCurrency(Number(value), 'COP')} width={110} />
+            <XAxis
+              dataKey="month"
+              tickFormatter={(v: string) => MONTH_LABELS[v.slice(5)] ?? v}
+            />
+            <YAxis
+              tickFormatter={(value) => formatCurrency(Number(value), currency)}
+              width={110}
+            />
             <Tooltip
-              formatter={(value) => [formatCurrency(Number(value), 'COP'), '']}
+              formatter={(value) => [formatCurrency(Number(value), currency), '']}
               contentStyle={{
                 backgroundColor: '#1a1a23',
                 border: '1px solid #2d2d35',
                 borderRadius: '8px',
                 color: '#ffffff',
+              }}
+              labelFormatter={(label) => {
+                const str = String(label)
+                const [year, month] = str.split('-')
+                return `${MONTH_LABELS[month] ?? month} ${year}`
               }}
               labelStyle={{ color: '#B0B0B0' }}
               cursor={{ fill: 'rgba(255, 255, 255, 0.04)' }}


### PR DESCRIPTION
## Cambios
- Categorías, estadísticas y balance acumulado usan la **moneda dominante** de las transacciones filtradas (no hardcodean COP)
- Agrupa por `(categoría, moneda)` — no suma COP + USD
- Todos los tooltips usan `formatCurrency(value, currency)` con moneda real
- `MonthlyComparisonChart` ignora filtros del reporte, siempre muestra los 12 meses del año actual
- Labels del eje X muestran nombre corto del mes (Ene, Feb, ...)

Closes #310
Related to #309