### PR TITLE
feat: agregar 'import' a TransactionSource y tipos de importación

### DIFF
--- a/lib/validations/transaction.ts
+++ b/lib/validations/transaction.ts
@@ -1,5 +1,27 @@
 import * as z from 'zod'
 
+// Raw row from an import file — uses human-readable names instead of UUIDs
+export const importRowSchema = z.object({
+  amount: z.coerce.number().positive('El monto debe ser positivo'),
+  currency: z.enum(['COP', 'USD', 'VES'], { error: 'Moneda debe ser COP, USD o VES' }),
+  type: z
+    .string()
+    .transform((v: string) => {
+      const lower = v.toLowerCase().trim()
+      if (lower === 'ingreso' || lower === 'income') return 'income'
+      if (lower === 'gasto' || lower === 'expense') return 'expense'
+      return lower
+    })
+    .pipe(z.enum(['income', 'expense'], { error: 'Tipo debe ser income/expense o Ingreso/Gasto' })),
+  category: z.string().min(1, 'La categoría es requerida'),
+  account: z.string().optional(),
+  description: z.string().min(1, 'La descripción es requerida'),
+  date: z.string().min(1, 'La fecha es requerida'),
+  notes: z.string().optional(),
+})
+
+export type ImportRowInput = z.infer<typeof importRowSchema>
+
 export const createTransactionSchema = z.object({
   amount: z.number().positive('Amount must be positive'),
   currency: z.enum(['COP', 'USD', 'VES']),

--- a/types/database.types.ts
+++ b/types/database.types.ts
@@ -1,7 +1,7 @@
 export type Currency = 'COP' | 'USD' | 'VES'
 export type TransactionType = 'income' | 'expense'
 export type BudgetPeriod = 'monthly' | 'yearly'
-export type TransactionSource = 'manual' | 'conversational'
+export type TransactionSource = 'manual' | 'conversational' | 'import'
 export type RecurrenceFrequency = 'daily' | 'weekly' | 'monthly' | 'yearly'
 
 export interface Whitelist {

--- a/types/import.types.ts
+++ b/types/import.types.ts
@@ -1,0 +1,23 @@
+import type { CreateTransactionInput } from '@/lib/validations/transaction'
+
+export type ParsedImportRow = {
+  rowIndex: number // 1-based, for user-facing error messages
+  raw: Record<string, unknown>
+}
+
+export type ResolvedImportRow = {
+  rowIndex: number
+  status: 'valid' | 'error'
+  errors: string[]
+  data?: CreateTransactionInput // only present when status === 'valid'
+  displayData: {
+    amount: number | string
+    currency: string
+    type: string
+    category: string
+    account: string
+    description: string
+    date: string
+    notes?: string
+  }
+}


### PR DESCRIPTION
## Cambios

- Extiende `TransactionSource` con `'import'` en `types/database.types.ts`
- Crea `types/import.types.ts` con `ParsedImportRow` y `ResolvedImportRow`
- Agrega `importRowSchema` en `lib/validations/transaction.ts` con normalización automática `Ingreso/Gasto → income/expense`

## Testing

- TypeScript compila sin errores nuevos
- `importRowSchema` acepta nombres de categoría/cuenta como strings en lugar de UUIDs
- `TransactionSource` incluye los tres valores: `'manual' | 'conversational' | 'import'`

Closes #324
Related to #323

---
_Generated by [Claude Code](https://claude.ai/code/session_01LczqCnF7rRwsS58vh4dBPj)_