### PR TITLE
fix: COLUMN_ALIASES mapea columnas a claves en inglés del schema

### DIFF
--- a/lib/actions/import.actions.ts
+++ b/lib/actions/import.actions.ts
@@ -153,14 +153,14 @@ export async function resolveImportRows(
 
 function buildDisplayData(raw: Record<string, unknown>) {
   return {
-    amount: String(raw.monto ?? raw.amount ?? ''),
-    currency: String(raw.moneda ?? raw.currency ?? ''),
-    type: String(raw.tipo ?? raw.type ?? ''),
-    category: String(raw.categoria ?? raw.category ?? ''),
-    account: String(raw.cuenta ?? raw.account ?? ''),
-    description: String(raw.descripcion ?? raw.description ?? ''),
-    date: String(raw.fecha ?? raw.date ?? ''),
-    notes: raw.notas != null ? String(raw.notas) : raw.notes != null ? String(raw.notes) : undefined,
+    amount: String(raw.amount ?? ''),
+    currency: String(raw.currency ?? ''),
+    type: String(raw.type ?? ''),
+    category: String(raw.category ?? ''),
+    account: String(raw.account ?? ''),
+    description: String(raw.description ?? ''),
+    date: String(raw.date ?? ''),
+    notes: raw.notes != null ? String(raw.notes) : undefined,
   }
 }
 

--- a/lib/utils/import-parser.ts
+++ b/lib/utils/import-parser.ts
@@ -1,28 +1,18 @@
 import type { ParsedImportRow } from '@/types/import.types'
 
-const REQUIRED_COLUMNS = ['fecha', 'descripcion', 'categoria', 'tipo', 'monto', 'moneda']
+const REQUIRED_COLUMNS = ['date', 'description', 'category', 'type', 'amount', 'currency']
 const MAX_ROWS = 500
 
-// Column aliases to support both Spanish and English headers
+// Maps Spanish and English column headers → schema field names (English)
 const COLUMN_ALIASES: Record<string, string> = {
-  fecha: 'fecha',
-  date: 'fecha',
-  descripcion: 'descripcion',
-  descripción: 'descripcion',
-  description: 'descripcion',
-  categoria: 'categoria',
-  categoría: 'categoria',
-  category: 'categoria',
-  cuenta: 'cuenta',
-  account: 'cuenta',
-  tipo: 'tipo',
-  type: 'tipo',
-  monto: 'monto',
-  amount: 'monto',
-  moneda: 'moneda',
-  currency: 'moneda',
-  notas: 'notas',
-  notes: 'notas',
+  fecha: 'date',           date: 'date',
+  descripcion: 'description', descripción: 'description', description: 'description',
+  categoria: 'category',   categoría: 'category',        category: 'category',
+  cuenta: 'account',       account: 'account',
+  tipo: 'type',            type: 'type',
+  monto: 'amount',         amount: 'amount',
+  moneda: 'currency',      currency: 'currency',
+  notas: 'notes',          notes: 'notes',
 }
 
 export async function parseImportFile(
@@ -42,13 +32,13 @@ export async function parseImportFile(
 
     if (raw.length < 2) return { rows: [], error: 'El archivo no contiene filas de datos' }
 
-    // Normalize headers
+    // Normalize headers to lowercase and map via aliases → English schema keys
     const rawHeaders = (raw[0] as unknown[]).map((h) =>
       String(h).toLowerCase().trim().replace(/\s+/g, '_')
     )
     const headers = rawHeaders.map((h) => COLUMN_ALIASES[h] ?? h)
 
-    // Validate required columns
+    // Validate required columns (now in English)
     const missing = REQUIRED_COLUMNS.filter((col) => !headers.includes(col))
     if (missing.length > 0) {
       return {
@@ -74,27 +64,27 @@ export async function parseImportFile(
       // Skip completely empty rows
       if (cells.every((c) => c === '' || c === null || c === undefined)) continue
 
-      const raw: Record<string, unknown> = {}
+      const rowData: Record<string, unknown> = {}
       headers.forEach((header, idx) => {
-        raw[header] = cells[idx] ?? ''
+        rowData[header] = cells[idx] ?? ''
       })
 
       // Normalize date: Excel serial numbers → YYYY-MM-DD
-      if (typeof raw.fecha === 'number') {
-        const parsed = XLSX.SSF.parse_date_code(raw.fecha as number)
+      if (typeof rowData.date === 'number') {
+        const parsed = XLSX.SSF.parse_date_code(rowData.date as number)
         if (parsed) {
           const month = String(parsed.m).padStart(2, '0')
           const day = String(parsed.d).padStart(2, '0')
-          raw.fecha = `${parsed.y}-${month}-${day}`
+          rowData.date = `${parsed.y}-${month}-${day}`
         }
       }
 
-      // Normalize amount: ensure it's a number string for coerce
-      if (typeof raw.monto === 'string') {
-        raw.monto = raw.monto.replace(/[,\s]/g, '')
+      // Strip thousands separators from amount strings
+      if (typeof rowData.amount === 'string') {
+        rowData.amount = rowData.amount.replace(/[,\s]/g, '')
       }
 
-      rows.push({ rowIndex: i + 1, raw })
+      rows.push({ rowIndex: i + 1, raw: rowData })
     }
 
     if (rows.length === 0) {


### PR DESCRIPTION
## Problema

El parser generaba `row.raw` con claves en español (`monto`, `moneda`, `fecha`, `descripcion`...) pero `importRowSchema` espera claves en inglés (`amount`, `currency`, `date`, `description`...). Zod no encontraba los campos → todas las filas fallaban con "received NaN / received undefined".

## Causa raíz

```typescript
// Antes (incorrecto)
fecha: 'fecha',  monto: 'monto',  moneda: 'moneda' ...
// row.raw = { fecha: '2026-05-14', monto: 50000, moneda: 'COP' }
// importRowSchema buscaba: date, amount, currency → undefined → error
```

## Fix

```typescript
// Ahora (correcto)
fecha: 'date',  monto: 'amount',  moneda: 'currency' ...
// row.raw = { date: '2026-05-14', amount: 50000, currency: 'COP' }
// importRowSchema encuentra todos los campos → validación exitosa
```

## Cambios

- `lib/utils/import-parser.ts`: `COLUMN_ALIASES` ahora mapea español → inglés; `REQUIRED_COLUMNS` actualizado; variable de loop renombrada de `raw` a `rowData` (evita shadowing)
- `lib/actions/import.actions.ts`: `buildDisplayData()` simplificada (elimina fallbacks `raw.monto ?? raw.amount` ya innecesarios)

## Testing

- Subir el Excel del usuario → sin errores de parsing en campos válidos
- Subir plantilla descargada → preview con check verde en todas las filas

Closes #347
Related to #346

---
_Generated by [Claude Code](https://claude.ai/code/session_01LczqCnF7rRwsS58vh4dBPj)_