### PR TITLE
feat: plantilla Excel con encabezados estilizados y columnas anchas

### DIFF
--- a/lib/actions/import.actions.ts
+++ b/lib/actions/import.actions.ts
@@ -14,34 +14,44 @@ export async function downloadImportTemplate() {
   try {
     const XLSX = await import('xlsx')
 
+    const headers = ['fecha', 'descripcion', 'categoria', 'cuenta', 'tipo', 'monto', 'moneda', 'notas']
+
     const sampleRows = [
-      {
-        fecha: '2026-05-01',
-        descripcion: 'Mercado semanal',
-        categoria: 'Alimentación',
-        cuenta: 'Efectivo',
-        tipo: 'Gasto',
-        monto: 150000,
-        moneda: 'COP',
-        notas: 'Compras del mes',
-      },
-      {
-        fecha: '2026-05-05',
-        descripcion: 'Salario',
-        categoria: 'Salario',
-        cuenta: 'Bancolombia',
-        tipo: 'Ingreso',
-        monto: 3500,
-        moneda: 'USD',
-        notas: '',
-      },
+      ['2026-05-01', 'Mercado semanal', 'Alimentación', 'Efectivo', 'Gasto', 150000, 'COP', 'Compras del mes'],
+      ['2026-05-05', 'Salario', 'Salario', 'Bancolombia', 'Ingreso', 3500, 'USD', ''],
     ]
 
-    const ws = XLSX.utils.json_to_sheet(sampleRows)
+    // Build worksheet manually to support cell styles
+    const wsData = [headers, ...sampleRows]
+    const ws = XLSX.utils.aoa_to_sheet(wsData)
+
+    // Column widths
+    ws['!cols'] = [
+      { wch: 14 }, // fecha
+      { wch: 32 }, // descripcion
+      { wch: 22 }, // categoria
+      { wch: 22 }, // cuenta
+      { wch: 10 }, // tipo
+      { wch: 12 }, // monto
+      { wch: 10 }, // moneda
+      { wch: 28 }, // notas
+    ]
+
+    // Header cell styles: bold + indigo background + white text
+    const headerStyle = {
+      font: { bold: true, color: { rgb: 'FFFFFF' } },
+      fill: { patternType: 'solid', fgColor: { rgb: '4F46E5' } },
+      alignment: { horizontal: 'center' },
+    }
+    headers.forEach((_, col) => {
+      const cellRef = XLSX.utils.encode_cell({ r: 0, c: col })
+      if (ws[cellRef]) ws[cellRef].s = headerStyle
+    })
+
     const wb = XLSX.utils.book_new()
     XLSX.utils.book_append_sheet(wb, ws, 'Plantilla')
 
-    const base64 = XLSX.write(wb, { type: 'base64', bookType: 'xlsx' }) as string
+    const base64 = XLSX.write(wb, { type: 'base64', bookType: 'xlsx', cellStyles: true }) as string
     return { success: true, data: base64, filename: 'plantilla-importacion.xlsx' }
   } catch (error) {
     console.error('Template generation error:', error)


### PR DESCRIPTION
## Cambios

Mejora visual de la plantilla descargable de importación:

- **Columnas anchas**: `ws['!cols']` define anchos personalizados por columna (descripcion: 32, categoria/cuenta: 22, notas: 28, etc.)
- **Encabezados estilizados**: negrita + fondo indigo `#4F46E5` + texto blanco usando la API de cell styles de xlsx
- Cambia `json_to_sheet` por `aoa_to_sheet` para tener control granular de cada celda
- `XLSX.write` con `cellStyles: true` para incluir los estilos en el `.xlsx` generado

## Testing

- Descargar la plantilla → abre en Excel/Google Sheets con columnas anchas
- Los encabezados se ven en negrita con fondo de color indigo y texto blanco
- Las filas de ejemplo son legibles sin tener que redimensionar columnas manualmente

Closes #348
Related to #346

---
_Generated by [Claude Code](https://claude.ai/code/session_01LczqCnF7rRwsS58vh4dBPj)_