### PR TITLE
FASE 1: Fixes importación masiva — bug parsing y plantilla Excel

### DIFF
--- a/lib/actions/import.actions.ts
+++ b/lib/actions/import.actions.ts
@@ -14,34 +14,44 @@ export async function downloadImportTemplate() {
   try {
     const XLSX = await import('xlsx')
 
+    const headers = ['fecha', 'descripcion', 'categoria', 'cuenta', 'tipo', 'monto', 'moneda', 'notas']
+
     const sampleRows = [
-      {
-        fecha: '2026-05-01',
-        descripcion: 'Mercado semanal',
-        categoria: 'Alimentación',
-        cuenta: 'Efectivo',
-        tipo: 'Gasto',
-        monto: 150000,
-        moneda: 'COP',
-        notas: 'Compras del mes',
-      },
-      {
-        fecha: '2026-05-05',
-        descripcion: 'Salario',
-        categoria: 'Salario',
-        cuenta: 'Bancolombia',
-        tipo: 'Ingreso',
-        monto: 3500,
-        moneda: 'USD',
-        notas: '',
-      },
+      ['2026-05-01', 'Mercado semanal', 'Alimentación', 'Efectivo', 'Gasto', 150000, 'COP', 'Compras del mes'],
+      ['2026-05-05', 'Salario', 'Salario', 'Bancolombia', 'Ingreso', 3500, 'USD', ''],
     ]
 
-    const ws = XLSX.utils.json_to_sheet(sampleRows)
+    // Build worksheet manually to support cell styles
+    const wsData = [headers, ...sampleRows]
+    const ws = XLSX.utils.aoa_to_sheet(wsData)
+
+    // Column widths
+    ws['!cols'] = [
+      { wch: 14 }, // fecha
+      { wch: 32 }, // descripcion
+      { wch: 22 }, // categoria
+      { wch: 22 }, // cuenta
+      { wch: 10 }, // tipo
+      { wch: 12 }, // monto
+      { wch: 10 }, // moneda
+      { wch: 28 }, // notas
+    ]
+
+    // Header cell styles: bold + indigo background + white text
+    const headerStyle = {
+      font: { bold: true, color: { rgb: 'FFFFFF' } },
+      fill: { patternType: 'solid', fgColor: { rgb: '4F46E5' } },
+      alignment: { horizontal: 'center' },
+    }
+    headers.forEach((_, col) => {
+      const cellRef = XLSX.utils.encode_cell({ r: 0, c: col })
+      if (ws[cellRef]) ws[cellRef].s = headerStyle
+    })
+
     const wb = XLSX.utils.book_new()
     XLSX.utils.book_append_sheet(wb, ws, 'Plantilla')
 
-    const base64 = XLSX.write(wb, { type: 'base64', bookType: 'xlsx' }) as string
+    const base64 = XLSX.write(wb, { type: 'base64', bookType: 'xlsx', cellStyles: true }) as string
     return { success: true, data: base64, filename: 'plantilla-importacion.xlsx' }
   } catch (error) {
     console.error('Template generation error:', error)

--- a/lib/actions/import.actions.ts
+++ b/lib/actions/import.actions.ts
@@ -153,14 +153,14 @@ export async function resolveImportRows(
 
 function buildDisplayData(raw: Record<string, unknown>) {
   return {
-    amount: String(raw.monto ?? raw.amount ?? ''),
-    currency: String(raw.moneda ?? raw.currency ?? ''),
-    type: String(raw.tipo ?? raw.type ?? ''),
-    category: String(raw.categoria ?? raw.category ?? ''),
-    account: String(raw.cuenta ?? raw.account ?? ''),
-    description: String(raw.descripcion ?? raw.description ?? ''),
-    date: String(raw.fecha ?? raw.date ?? ''),
-    notes: raw.notas != null ? String(raw.notas) : raw.notes != null ? String(raw.notes) : undefined,
+    amount: String(raw.amount ?? ''),
+    currency: String(raw.currency ?? ''),
+    type: String(raw.type ?? ''),
+    category: String(raw.category ?? ''),
+    account: String(raw.account ?? ''),
+    description: String(raw.description ?? ''),
+    date: String(raw.date ?? ''),
+    notes: raw.notes != null ? String(raw.notes) : undefined,
   }
 }
 

--- a/lib/utils/import-parser.ts
+++ b/lib/utils/import-parser.ts
@@ -1,28 +1,18 @@
 import type { ParsedImportRow } from '@/types/import.types'
 
-const REQUIRED_COLUMNS = ['fecha', 'descripcion', 'categoria', 'tipo', 'monto', 'moneda']
+const REQUIRED_COLUMNS = ['date', 'description', 'category', 'type', 'amount', 'currency']
 const MAX_ROWS = 500
 
-// Column aliases to support both Spanish and English headers
+// Maps Spanish and English column headers → schema field names (English)
 const COLUMN_ALIASES: Record<string, string> = {
-  fecha: 'fecha',
-  date: 'fecha',
-  descripcion: 'descripcion',
-  descripción: 'descripcion',
-  description: 'descripcion',
-  categoria: 'categoria',
-  categoría: 'categoria',
-  category: 'categoria',
-  cuenta: 'cuenta',
-  account: 'cuenta',
-  tipo: 'tipo',
-  type: 'tipo',
-  monto: 'monto',
-  amount: 'monto',
-  moneda: 'moneda',
-  currency: 'moneda',
-  notas: 'notas',
-  notes: 'notas',
+  fecha: 'date',           date: 'date',
+  descripcion: 'description', descripción: 'description', description: 'description',
+  categoria: 'category',   categoría: 'category',        category: 'category',
+  cuenta: 'account',       account: 'account',
+  tipo: 'type',            type: 'type',
+  monto: 'amount',         amount: 'amount',
+  moneda: 'currency',      currency: 'currency',
+  notas: 'notes',          notes: 'notes',
 }
 
 export async function parseImportFile(
@@ -42,13 +32,13 @@ export async function parseImportFile(
 
     if (raw.length < 2) return { rows: [], error: 'El archivo no contiene filas de datos' }
 
-    // Normalize headers
+    // Normalize headers to lowercase and map via aliases → English schema keys
     const rawHeaders = (raw[0] as unknown[]).map((h) =>
       String(h).toLowerCase().trim().replace(/\s+/g, '_')
     )
     const headers = rawHeaders.map((h) => COLUMN_ALIASES[h] ?? h)
 
-    // Validate required columns
+    // Validate required columns (now in English)
     const missing = REQUIRED_COLUMNS.filter((col) => !headers.includes(col))
     if (missing.length > 0) {
       return {
@@ -74,27 +64,27 @@ export async function parseImportFile(
       // Skip completely empty rows
       if (cells.every((c) => c === '' || c === null || c === undefined)) continue
 
-      const raw: Record<string, unknown> = {}
+      const rowData: Record<string, unknown> = {}
       headers.forEach((header, idx) => {
-        raw[header] = cells[idx] ?? ''
+        rowData[header] = cells[idx] ?? ''
       })
 
       // Normalize date: Excel serial numbers → YYYY-MM-DD
-      if (typeof raw.fecha === 'number') {
-        const parsed = XLSX.SSF.parse_date_code(raw.fecha as number)
+      if (typeof rowData.date === 'number') {
+        const parsed = XLSX.SSF.parse_date_code(rowData.date as number)
         if (parsed) {
           const month = String(parsed.m).padStart(2, '0')
           const day = String(parsed.d).padStart(2, '0')
-          raw.fecha = `${parsed.y}-${month}-${day}`
+          rowData.date = `${parsed.y}-${month}-${day}`
         }
       }
 
-      // Normalize amount: ensure it's a number string for coerce
-      if (typeof raw.monto === 'string') {
-        raw.monto = raw.monto.replace(/[,\s]/g, '')
+      // Strip thousands separators from amount strings
+      if (typeof rowData.amount === 'string') {
+        rowData.amount = rowData.amount.replace(/[,\s]/g, '')
       }
 
-      rows.push({ rowIndex: i + 1, raw })
+      rows.push({ rowIndex: i + 1, raw: rowData })
     }
 
     if (rows.length === 0) {


### PR DESCRIPTION
## Resumen de Fase 1

### PRs incluidos
- #349 — Fix crítico: `COLUMN_ALIASES` mapea columnas a claves en inglés del schema
- #350 — Mejora: plantilla Excel con encabezados estilizados y columnas anchas

### Fix #349 — Bug parsing (todos los errores "received NaN / undefined")

**Causa raíz**: `COLUMN_ALIASES` convertía `monto → monto`, `moneda → moneda`, etc., pero `importRowSchema` espera `amount`, `currency`, `date`, `description`. Zod no encontraba los campos en `row.raw` → todas las filas fallaban.

**Fix**: el mapa ahora convierte directamente a inglés: `monto → amount`, `moneda → currency`, `fecha → date`, `descripcion → description`, `notas → notes`.

### Mejora #350 — Plantilla Excel

- Columnas con ancho apropiado por campo (descripcion: 32, notas: 28, etc.)
- Encabezados en negrita + fondo indigo + texto blanco

### Verificación
- [ ] Subir el Excel original del usuario → sin errores de parsing en campos válidos
- [ ] Descargar nueva plantilla → columnas anchas y encabezados con color visible
- [ ] Flujo completo: subir → preview válido → importar → transacciones creadas

Closes #346

---

⚠️ **Checkpoint** — Aprobar para merge a main y tag `v2.3.0`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LczqCnF7rRwsS58vh4dBPj)_