### PR TITLE
feat: formato de fecha DD/MM/YYYY en inputs de fecha

### DIFF
--- a/components/ui/DateInput.tsx
+++ b/components/ui/DateInput.tsx
@@ -2,6 +2,30 @@
 
 import { FieldRoot, FieldLabel, Input, Box, IconButton } from '@chakra-ui/react'
 import { FiX } from 'react-icons/fi'
+import { useState, useEffect } from 'react'
+
+function isoToDisplay(iso: string): string {
+  if (!iso || iso.length < 10) return ''
+  const [year, month, day] = iso.split('-')
+  if (!year || !month || !day) return ''
+  return `${day}/${month}/${year}`
+}
+
+function displayToIso(display: string): string {
+  const match = display.match(/^(\d{2})\/(\d{2})\/(\d{4})$/)
+  if (!match) return ''
+  const [, day, month, year] = match
+  return `${year}-${month}-${day}`
+}
+
+function autoFormatDate(raw: string): string {
+  const digits = raw.replace(/\D/g, '')
+  let result = ''
+  if (digits.length > 0) result += digits.substring(0, 2)
+  if (digits.length >= 3) result += '/' + digits.substring(2, 4)
+  if (digits.length >= 5) result += '/' + digits.substring(4, 8)
+  return result
+}
 
 interface Props {
   label: string
@@ -14,7 +38,29 @@ interface Props {
 }
 
 export function DateInput({ label, value, onChange, required, disabled, optional, showClear = true }: Props) {
-  const showButton = showClear && value && !disabled
+  const [displayValue, setDisplayValue] = useState(() => isoToDisplay(value))
+
+  useEffect(() => {
+    setDisplayValue(isoToDisplay(value))
+  }, [value])
+
+  const handleChange = (raw: string) => {
+    const formatted = autoFormatDate(raw)
+    setDisplayValue(formatted)
+    const iso = displayToIso(formatted)
+    if (iso) {
+      onChange(iso)
+    } else if (!formatted) {
+      onChange('')
+    }
+  }
+
+  const handleClear = () => {
+    setDisplayValue('')
+    onChange('')
+  }
+
+  const showButton = showClear && displayValue && !disabled
 
   return (
     <FieldRoot required={required} w="full">
@@ -24,13 +70,15 @@ export function DateInput({ label, value, onChange, required, disabled, optional
       </FieldLabel>
       <Box position="relative" w="full">
         <Input
-          type="date"
-          value={value}
-          onChange={(e) => onChange(e.target.value)}
+          type="text"
+          value={displayValue}
+          onChange={(e) => handleChange(e.target.value)}
+          placeholder="DD/MM/YYYY"
           disabled={disabled}
           opacity={disabled ? 0.6 : 1}
           cursor={disabled ? 'not-allowed' : undefined}
           pr={showButton ? '8' : undefined}
+          maxLength={10}
         />
         {showButton && (
           <IconButton
@@ -44,7 +92,7 @@ export function DateInput({ label, value, onChange, required, disabled, optional
             zIndex={2}
             color="#B0B0B0"
             _hover={{ color: 'white', bg: '#26262f' }}
-            onClick={() => onChange('')}
+            onClick={handleClear}
             minW="auto"
             h="auto"
             p="1"


### PR DESCRIPTION
## Cambios
- Reemplaza el input nativo `type="date"` por un input de texto con formato visual DD/MM/YYYY
- El valor interno sigue siendo ISO (YYYY-MM-DD) — la interfaz de props no cambia
- Auto-formatea mientras el usuario escribe (agrega `/` automáticamente)
- Convierte DD/MM/YYYY → ISO al llamar `onChange`, y ISO → DD/MM/YYYY al recibir `value`
- Botón de limpiar (X) funciona igual que antes

## Testing
- ✅ TypeScript compila sin errores
- ✅ Consistente en todos los formularios que usan `DateInput` (transacciones, préstamos, presupuestos, metas de ahorro, movimientos, filtros de reportes)

## Related
Closes #363
Related to #362

---
_Generated by [Claude Code](https://claude.ai/code/session_01XPgXLQwAtTpgt2K7VWVnAw)_