### PR TITLE
fix: popovers de iconos y colores abren hacia arriba si no hay espacio

### DIFF
--- a/components/categories/ColorPicker.tsx
+++ b/components/categories/ColorPicker.tsx
@@ -24,6 +24,7 @@ const COLORS = [
 ]
 
 const PICKER_WIDTH = 200
+const PICKER_HEIGHT = 140
 
 interface Props {
   value: string
@@ -40,7 +41,11 @@ export function ColorPicker({ value, onChange }: Props) {
     if (!open && wrapperRef.current) {
       const rect = wrapperRef.current.getBoundingClientRect()
       const left = Math.min(rect.right - PICKER_WIDTH, window.innerWidth - PICKER_WIDTH - 8)
-      setPos({ top: rect.bottom + 4, left: Math.max(left, 8) })
+      const spaceBelow = window.innerHeight - rect.bottom
+      const top = spaceBelow >= PICKER_HEIGHT + 8
+        ? rect.bottom + 4
+        : rect.top - PICKER_HEIGHT - 4
+      setPos({ top, left: Math.max(left, 8) })
     }
     setOpen((v) => !v)
   }

--- a/components/categories/IconPicker.tsx
+++ b/components/categories/IconPicker.tsx
@@ -14,6 +14,7 @@ const ICONS = [
 ]
 
 const PICKER_WIDTH = 288
+const PICKER_HEIGHT = 280
 
 interface Props {
   value: string
@@ -33,7 +34,11 @@ export function IconPicker({ value, onChange }: Props) {
     if (!open && wrapperRef.current) {
       const rect = wrapperRef.current.getBoundingClientRect()
       const left = Math.min(rect.left, window.innerWidth - PICKER_WIDTH - 12)
-      setPos({ top: rect.bottom + 4, left: Math.max(left, 8) })
+      const spaceBelow = window.innerHeight - rect.bottom
+      const top = spaceBelow >= PICKER_HEIGHT + 8
+        ? rect.bottom + 4
+        : rect.top - PICKER_HEIGHT - 4
+      setPos({ top, left: Math.max(left, 8) })
     }
     setOpen((v) => !v)
   }


### PR DESCRIPTION
## Cambios
- Agrega lógica de smart-positioning en `IconPicker` y `ColorPicker`
- Calcula el espacio disponible debajo del trigger (`window.innerHeight - rect.bottom`)
- Si el espacio es insuficiente para el picker, posiciona encima del trigger (`rect.top - PICKER_HEIGHT - 4`)
- Si hay espacio suficiente, mantiene el comportamiento original (abre abajo)

## Problema resuelto
Con ciertos niveles de zoom en desktop, los pickers de iconos y colores dentro del modal de transacciones/categorías quedaban cortados al abrir hacia abajo.

## Testing
- ✅ TypeScript compila sin errores
- ✅ Aplica a `IconPicker` y `ColorPicker`

Closes #365
Related to #362

---
_Generated by [Claude Code](https://claude.ai/code/session_01XPgXLQwAtTpgt2K7VWVnAw)_