### PR TITLE
feat: reorganizar modal de transacciones y auto-cargar currency de cuenta

### DIFF
--- a/components/transactions/TransactionEditForm.tsx
+++ b/components/transactions/TransactionEditForm.tsx
@@ -58,6 +58,17 @@ export function TransactionEditForm({ isOpen, onClose, userId, categories, accou
     })
   }, [transaction])
 
+  const handleAccountChange = (accountId: string) => {
+    const account = accounts.find((a) => a.id === accountId)
+    setFormData((prev) => ({
+      ...prev,
+      account_id: accountId,
+      currency: account ? (account.currency as Currency) : prev.currency,
+    }))
+  }
+
+  const accountLocksCurrency = !!formData.account_id
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     setLoading(true)
@@ -97,13 +108,34 @@ export function TransactionEditForm({ isOpen, onClose, userId, categories, accou
               onChange={(v) => setFormData({ ...formData, amount: v })}
               isRequired
             />
+            {accounts.length > 0 ? (
+              <AccountSelect
+                value={formData.account_id}
+                onChange={handleAccountChange}
+                accounts={accounts}
+                label="Cuenta"
+                optional
+                placeholder="Sin cuenta específica"
+              />
+            ) : (
+              <CurrencySelect
+                value={formData.currency}
+                onChange={(v) => setFormData({ ...formData, currency: v })}
+                showFullLabel
+                required
+              />
+            )}
+          </SimpleGrid>
+
+          {accounts.length > 0 && (
             <CurrencySelect
               value={formData.currency}
               onChange={(v) => setFormData({ ...formData, currency: v })}
               showFullLabel
               required
+              disabled={accountLocksCurrency}
             />
-          </SimpleGrid>
+          )}
 
           <CategorySelect
             value={formData.category_id}
@@ -112,24 +144,6 @@ export function TransactionEditForm({ isOpen, onClose, userId, categories, accou
             filterByType={formData.type}
             required
           />
-
-          {accounts.length > 0 && (
-            <AccountSelect
-              value={formData.account_id}
-              onChange={(v) => setFormData({ ...formData, account_id: v })}
-              accounts={accounts}
-              label="Cuenta"
-              optional
-              placeholder="Sin cuenta específica"
-            />
-          )}
-
-          <Box w="full" minH="10">
-            <CurrencyPreview
-              amount={formData.amount ?? 0}
-              fromCurrency={formData.currency}
-            />
-          </Box>
 
           <SimpleGrid columns={{ base: 1, md: 2 }} gap={4} w="full">
             <FormInput
@@ -145,6 +159,13 @@ export function TransactionEditForm({ isOpen, onClose, userId, categories, accou
               required
             />
           </SimpleGrid>
+
+          <Box w="full" minH="10">
+            <CurrencyPreview
+              amount={formData.amount ?? 0}
+              fromCurrency={formData.currency}
+            />
+          </Box>
 
           <FormTextarea
             label="Notas (opcional)"

--- a/components/transactions/TransactionForm.tsx
+++ b/components/transactions/TransactionForm.tsx
@@ -55,6 +55,17 @@ export function TransactionForm({ isOpen, onClose, userId, categories, accounts 
     }
   }, [isOpen, initialDate])
 
+  const handleAccountChange = (accountId: string) => {
+    const account = accounts.find((a) => a.id === accountId)
+    setFormData((prev) => ({
+      ...prev,
+      account_id: accountId,
+      currency: account ? (account.currency as Currency) : prev.currency,
+    }))
+  }
+
+  const accountLocksCurrency = !!formData.account_id
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     setLoading(true)
@@ -95,13 +106,34 @@ export function TransactionForm({ isOpen, onClose, userId, categories, accounts 
               onChange={(v) => setFormData({ ...formData, amount: v })}
               isRequired
             />
+            {accounts.length > 0 ? (
+              <AccountSelect
+                value={formData.account_id}
+                onChange={handleAccountChange}
+                accounts={accounts}
+                label="Cuenta"
+                optional
+                placeholder="Sin cuenta específica"
+              />
+            ) : (
+              <CurrencySelect
+                value={formData.currency}
+                onChange={(v) => setFormData({ ...formData, currency: v })}
+                showFullLabel
+                required
+              />
+            )}
+          </SimpleGrid>
+
+          {accounts.length > 0 && (
             <CurrencySelect
               value={formData.currency}
               onChange={(v) => setFormData({ ...formData, currency: v })}
               showFullLabel
               required
+              disabled={accountLocksCurrency}
             />
-          </SimpleGrid>
+          )}
 
           <CategorySelect
             value={formData.category_id}
@@ -110,24 +142,6 @@ export function TransactionForm({ isOpen, onClose, userId, categories, accounts 
             filterByType={formData.type}
             required
           />
-
-          {accounts.length > 0 && (
-            <AccountSelect
-              value={formData.account_id}
-              onChange={(v) => setFormData({ ...formData, account_id: v })}
-              accounts={accounts}
-              label="Cuenta"
-              optional
-              placeholder="Sin cuenta específica"
-            />
-          )}
-
-          <Box w="full" minH="10">
-            <CurrencyPreview
-              amount={formData.amount ?? 0}
-              fromCurrency={formData.currency}
-            />
-          </Box>
 
           <SimpleGrid columns={{ base: 1, md: 2 }} gap={4} w="full">
             <FormInput
@@ -145,6 +159,13 @@ export function TransactionForm({ isOpen, onClose, userId, categories, accounts 
               disabled={lockedDate}
             />
           </SimpleGrid>
+
+          <Box w="full" minH="10">
+            <CurrencyPreview
+              amount={formData.amount ?? 0}
+              fromCurrency={formData.currency}
+            />
+          </Box>
 
           <FormTextarea
             label="Notas (opcional)"

--- a/components/ui/CurrencySelect.tsx
+++ b/components/ui/CurrencySelect.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { FieldRoot, FieldLabel, NativeSelectRoot, NativeSelectField } from '@chakra-ui/react'
+import { Box, FieldRoot, FieldLabel, NativeSelectRoot, NativeSelectField } from '@chakra-ui/react'
 import type { Currency } from '@/types/database.types'
 
 interface Props {
@@ -8,6 +8,7 @@ interface Props {
   onChange: (value: Currency) => void
   showFullLabel?: boolean
   required?: boolean
+  disabled?: boolean
 }
 
 const currencies: { value: Currency; short: string; full: string }[] = [
@@ -16,22 +17,24 @@ const currencies: { value: Currency; short: string; full: string }[] = [
   { value: 'VES', short: 'VES', full: 'VES - Bolívar (Bs)' },
 ]
 
-export function CurrencySelect({ value, onChange, showFullLabel = false, required }: Props) {
+export function CurrencySelect({ value, onChange, showFullLabel = false, required, disabled }: Props) {
   return (
     <FieldRoot required={required}>
       <FieldLabel>Moneda</FieldLabel>
-      <NativeSelectRoot>
-        <NativeSelectField
-          value={value}
-          onChange={(e) => onChange(e.target.value as Currency)}
-        >
-          {currencies.map((c) => (
-            <option key={c.value} value={c.value}>
-              {showFullLabel ? c.full : c.short}
-            </option>
-          ))}
-        </NativeSelectField>
-      </NativeSelectRoot>
+      <Box opacity={disabled ? 0.6 : 1} cursor={disabled ? 'not-allowed' : undefined} pointerEvents={disabled ? 'none' : undefined}>
+        <NativeSelectRoot>
+          <NativeSelectField
+            value={value}
+            onChange={(e) => onChange(e.target.value as Currency)}
+          >
+            {currencies.map((c) => (
+              <option key={c.value} value={c.value}>
+                {showFullLabel ? c.full : c.short}
+              </option>
+            ))}
+          </NativeSelectField>
+        </NativeSelectRoot>
+      </Box>
     </FieldRoot>
   )
 }


### PR DESCRIPTION
## Cambios
- **Nuevo orden de campos:** Tipo → Monto + Cuenta (lado a lado) → Moneda → Categoría → Descripción/Fecha → Preview → Notas
- **Auto-currency:** Al seleccionar una cuenta, la moneda se actualiza automáticamente al currency de esa cuenta
- **Bloqueo visual:** Si hay cuenta seleccionada, el selector de moneda queda bloqueado (pointer-events:none + opacity 0.6) para evitar incoherencia
- **Sin cuentas:** Si el usuario no tiene cuentas, CurrencySelect aparece libre junto al monto como antes
- **CurrencySelect:** Se añade prop `disabled` con bloqueo visual (Box wrapper con pointer-events:none)
- Aplica a `TransactionForm` (crear) y `TransactionEditForm` (editar)

## Testing
- ✅ TypeScript compila sin errores
- ✅ Funciona para crear y editar transacciones

Closes #367
Related to #362

---
_Generated by [Claude Code](https://claude.ai/code/session_01XPgXLQwAtTpgt2K7VWVnAw)_