### PR TITLE
feat: mejoras en categorías — separar vista, tipo ambos y control de duplicados

### DIFF
--- a/app/(dashboard)/categories/CategoriesPageClient.tsx
+++ b/app/(dashboard)/categories/CategoriesPageClient.tsx
@@ -27,11 +27,52 @@ import { useRouter } from 'next/navigation'
 import { toaster } from '@/lib/toaster'
 import { CategoryForm } from '@/components/categories/CategoryForm'
 import { CategoryEditForm } from '@/components/categories/CategoryEditForm'
-import type { Category } from '@/types/database.types'
+import type { Category, CategoryType } from '@/types/database.types'
 
 interface Props {
   userId: string
   initialCategories: Category[]
+}
+
+const TYPE_BADGE: Record<CategoryType, { label: string; palette: string }> = {
+  expense: { label: 'Gasto', palette: 'red' },
+  income: { label: 'Ingreso', palette: 'green' },
+  both: { label: 'Ambos', palette: 'purple' },
+}
+
+function CategorySection({
+  title,
+  categories,
+  readOnly,
+  onEdit,
+  onDelete,
+}: {
+  title: string
+  categories: Category[]
+  readOnly?: boolean
+  onEdit?: (cat: Category) => void
+  onDelete?: (cat: Category) => void
+}) {
+  if (categories.length === 0) return null
+
+  return (
+    <Box>
+      <Text fontWeight="semibold" color="#B0B0B0" mb={3} fontSize="sm" textTransform="uppercase">
+        {title}
+      </Text>
+      <SimpleGrid columns={{ base: 1, sm: 2, md: 3, lg: 4 }} gap={3}>
+        {categories.map((cat) => (
+          <CategoryCard
+            key={cat.id}
+            category={cat}
+            readOnly={readOnly}
+            onEdit={onEdit ? () => onEdit(cat) : undefined}
+            onDelete={onDelete ? () => onDelete(cat) : undefined}
+          />
+        ))}
+      </SimpleGrid>
+    </Box>
+  )
 }
 
 export function CategoriesPageClient({ userId, initialCategories }: Props) {
@@ -84,6 +125,14 @@ export function CategoriesPageClient({ userId, initialCategories }: Props) {
   const predefined = categories.filter((c) => c.user_id === null)
   const userCategories = categories.filter((c) => c.user_id !== null)
 
+  const predExpense = predefined.filter((c) => c.type === 'expense')
+  const predIncome = predefined.filter((c) => c.type === 'income')
+  const predBoth = predefined.filter((c) => c.type === 'both')
+
+  const userExpense = userCategories.filter((c) => c.type === 'expense')
+  const userIncome = userCategories.filter((c) => c.type === 'income')
+  const userBoth = userCategories.filter((c) => c.type === 'both')
+
   return (
     <Box p={6}>
       <HStack justify="space-between" mb={6}>
@@ -94,41 +143,56 @@ export function CategoriesPageClient({ userId, initialCategories }: Props) {
         </Button>
       </HStack>
 
-      <VStack gap={8} align="stretch">
-        {/* Categorías predefinidas */}
+      <VStack gap={10} align="stretch">
+        {/* Gastos */}
         <Box>
-          <Text fontWeight="semibold" color="#B0B0B0" mb={3} fontSize="sm" textTransform="uppercase">
-            Predefinidas
-          </Text>
-          <SimpleGrid columns={{ base: 1, sm: 2, md: 3, lg: 4 }} gap={3}>
-            {predefined.map((cat) => (
-              <CategoryCard key={cat.id} category={cat} readOnly />
-            ))}
-          </SimpleGrid>
+          <Heading size="md" color="white" mb={4}>💸 Gastos</Heading>
+          <VStack gap={6} align="stretch">
+            <CategorySection title="Predefinidas" categories={predExpense} readOnly />
+            <CategorySection
+              title="Mis Categorías"
+              categories={userExpense}
+              onEdit={handleEditOpen}
+              onDelete={handleDeleteOpen}
+            />
+            {userExpense.length === 0 && predExpense.length === 0 && (
+              <Text color="#808080" fontSize="sm">Sin categorías de gasto.</Text>
+            )}
+          </VStack>
         </Box>
 
-        {/* Categorías del usuario */}
+        {/* Ingresos */}
         <Box>
-          <Text fontWeight="semibold" color="#B0B0B0" mb={3} fontSize="sm" textTransform="uppercase">
-            Mis Categorías
-          </Text>
-          {userCategories.length === 0 ? (
-            <Text color="#808080" fontSize="sm">
-              Aún no tienes categorías personalizadas. Crea una con el botón de arriba.
-            </Text>
-          ) : (
-            <SimpleGrid columns={{ base: 1, sm: 2, md: 3, lg: 4 }} gap={3}>
-              {userCategories.map((cat) => (
-                <CategoryCard
-                  key={cat.id}
-                  category={cat}
-                  onEdit={() => handleEditOpen(cat)}
-                  onDelete={() => handleDeleteOpen(cat)}
-                />
-              ))}
-            </SimpleGrid>
-          )}
+          <Heading size="md" color="white" mb={4}>💰 Ingresos</Heading>
+          <VStack gap={6} align="stretch">
+            <CategorySection title="Predefinidas" categories={predIncome} readOnly />
+            <CategorySection
+              title="Mis Categorías"
+              categories={userIncome}
+              onEdit={handleEditOpen}
+              onDelete={handleDeleteOpen}
+            />
+            {userIncome.length === 0 && predIncome.length === 0 && (
+              <Text color="#808080" fontSize="sm">Sin categorías de ingreso.</Text>
+            )}
+          </VStack>
         </Box>
+
+        {/* Ambos */}
+        {(predBoth.length > 0 || userBoth.length > 0) && (
+          <Box>
+            <Heading size="md" color="white" mb={4}>🔄 Gastos e Ingresos</Heading>
+            <VStack gap={6} align="stretch">
+              <CategorySection title="Predefinidas" categories={predBoth} readOnly />
+              <CategorySection
+                title="Mis Categorías"
+                categories={userBoth}
+                onEdit={handleEditOpen}
+                onDelete={handleDeleteOpen}
+              />
+            </VStack>
+          </Box>
+        )}
       </VStack>
 
       {/* Modales */}
@@ -149,7 +213,6 @@ export function CategoriesPageClient({ userId, initialCategories }: Props) {
         />
       )}
 
-      {/* Confirmación eliminar */}
       <DialogRoot
         open={deleteDisclosure.open}
         onOpenChange={({ open }) => !open && deleteDisclosure.onClose()}
@@ -160,29 +223,29 @@ export function CategoriesPageClient({ userId, initialCategories }: Props) {
       >
         <DialogBackdrop />
         <DialogPositioner>
-        <DialogContent tabIndex={-1}>
-          <DialogHeader>
-            <DialogTitle>Eliminar Categoría</DialogTitle>
-          </DialogHeader>
-          <DialogCloseTrigger />
-          <DialogBody pb={6}>
-            <Text mb={4}>
-              ¿Seguro que deseas eliminar{' '}
-              <Text as="span" fontWeight="bold">
-                {selectedCategory?.icon} {selectedCategory?.name}
+          <DialogContent tabIndex={-1}>
+            <DialogHeader>
+              <DialogTitle>Eliminar Categoría</DialogTitle>
+            </DialogHeader>
+            <DialogCloseTrigger />
+            <DialogBody pb={6}>
+              <Text mb={4}>
+                ¿Seguro que deseas eliminar{' '}
+                <Text as="span" fontWeight="bold">
+                  {selectedCategory?.icon} {selectedCategory?.name}
+                </Text>
+                ? Esta acción no se puede deshacer.
               </Text>
-              ? Esta acción no se puede deshacer.
-            </Text>
-            <HStack justify="flex-end">
-              <Button variant="outline" onClick={deleteDisclosure.onClose}>
-                Cancelar
-              </Button>
-              <Button colorPalette="red" loading={deleteLoading} onClick={handleDelete}>
-                Eliminar
-              </Button>
-            </HStack>
-          </DialogBody>
-        </DialogContent>
+              <HStack justify="flex-end">
+                <Button variant="outline" onClick={deleteDisclosure.onClose}>
+                  Cancelar
+                </Button>
+                <Button colorPalette="red" loading={deleteLoading} onClick={handleDelete}>
+                  Eliminar
+                </Button>
+              </HStack>
+            </DialogBody>
+          </DialogContent>
         </DialogPositioner>
       </DialogRoot>
     </Box>
@@ -200,6 +263,8 @@ function CategoryCard({
   onEdit?: () => void
   onDelete?: () => void
 }) {
+  const badge = TYPE_BADGE[category.type] ?? TYPE_BADGE.expense
+
   return (
     <Box
       borderWidth="1px"
@@ -229,12 +294,8 @@ function CategoryCard({
             <Text fontWeight="medium" fontSize="sm" color="white">
               {category.name}
             </Text>
-            <Badge
-              colorPalette={category.type === 'income' ? 'green' : 'red'}
-              size="sm"
-              mt={1}
-            >
-              {category.type === 'income' ? 'Ingreso' : 'Gasto'}
+            <Badge colorPalette={badge.palette} size="sm" mt={1}>
+              {badge.label}
             </Badge>
           </Box>
         </HStack>

--- a/components/categories/CategoryEditForm.tsx
+++ b/components/categories/CategoryEditForm.tsx
@@ -1,13 +1,22 @@
 'use client'
 
-import { VStack, HStack, FieldRoot, FieldLabel, Input, Button, Badge } from '@chakra-ui/react'
+import { VStack, HStack, FieldRoot, FieldLabel } from '@chakra-ui/react'
 import { useState, useEffect } from 'react'
 import { updateCategory } from '@/lib/actions/categories.actions'
 import { toaster } from '@/lib/toaster'
 import { FormDialog } from '@/components/ui/FormDialog'
-import type { Category } from '@/types/database.types'
+import { FormInput } from '@/components/ui/FormInput'
+import { RadioSelect } from '@/components/ui/RadioSelect'
+import { PrimaryButton } from '@/components/ui/PrimaryButton'
+import type { Category, CategoryType } from '@/types/database.types'
 import { IconPicker } from './IconPicker'
 import { ColorPicker } from './ColorPicker'
+
+const TYPE_OPTIONS = [
+  { value: 'expense', label: 'Gasto' },
+  { value: 'income', label: 'Ingreso' },
+  { value: 'both', label: 'Ambos' },
+]
 
 interface Props {
   isOpen: boolean
@@ -21,6 +30,7 @@ export function CategoryEditForm({ isOpen, onClose, userId, category, onSuccess 
   const [loading, setLoading] = useState(false)
   const [formData, setFormData] = useState({
     name: category.name,
+    type: category.type as CategoryType,
     icon: category.icon ?? '',
     color: category.color ?? '#6366f1',
   })
@@ -28,6 +38,7 @@ export function CategoryEditForm({ isOpen, onClose, userId, category, onSuccess 
   useEffect(() => {
     setFormData({
       name: category.name,
+      type: category.type as CategoryType,
       icon: category.icon ?? '',
       color: category.color ?? '#6366f1',
     })
@@ -53,20 +64,21 @@ export function CategoryEditForm({ isOpen, onClose, userId, category, onSuccess 
     <FormDialog isOpen={isOpen} onClose={onClose} title="Editar Categoría">
       <form onSubmit={handleSubmit}>
         <VStack gap={4}>
-          <HStack w="full">
-            <Badge colorPalette={category.type === 'income' ? 'green' : 'red'} size="sm">
-              {category.type === 'income' ? 'Ingreso' : 'Gasto'}
-            </Badge>
-          </HStack>
+          <RadioSelect
+            label="Tipo"
+            value={formData.type}
+            onChange={(v) => setFormData({ ...formData, type: v as CategoryType })}
+            options={TYPE_OPTIONS}
+            required
+          />
 
-          <FieldRoot required w="full">
-            <FieldLabel>Nombre</FieldLabel>
-            <Input
-              value={formData.name}
-              onChange={(e) => setFormData({ ...formData, name: e.target.value })}
-              placeholder="Ej: Transporte"
-            />
-          </FieldRoot>
+          <FormInput
+            label="Nombre"
+            value={formData.name}
+            onChange={(v) => setFormData({ ...formData, name: v })}
+            placeholder="Ej: Transporte"
+            required
+          />
 
           <HStack gap={4} w="full">
             <FieldRoot>
@@ -86,9 +98,9 @@ export function CategoryEditForm({ isOpen, onClose, userId, category, onSuccess 
             </FieldRoot>
           </HStack>
 
-          <Button type="submit" bg="#4F46E5" color="white" _hover={{ bg: '#4338CA' }} width="full" loading={loading}>
+          <PrimaryButton type="submit" width="full" loading={loading}>
             Guardar Cambios
-          </Button>
+          </PrimaryButton>
         </VStack>
       </form>
     </FormDialog>

--- a/components/categories/CategoryForm.tsx
+++ b/components/categories/CategoryForm.tsx
@@ -10,10 +10,12 @@ import { RadioSelect } from '@/components/ui/RadioSelect'
 import { PrimaryButton } from '@/components/ui/PrimaryButton'
 import { IconPicker } from './IconPicker'
 import { ColorPicker } from './ColorPicker'
+import type { CategoryType } from '@/types/database.types'
 
 const TYPE_OPTIONS = [
   { value: 'expense', label: 'Gasto' },
   { value: 'income', label: 'Ingreso' },
+  { value: 'both', label: 'Ambos' },
 ]
 
 interface Props {
@@ -21,18 +23,19 @@ interface Props {
   onClose: () => void
   userId: string
   onSuccess: () => void
+  defaultType?: CategoryType
 }
 
 const defaultForm = {
   name: '',
-  type: 'expense' as 'income' | 'expense',
+  type: 'expense' as CategoryType,
   icon: '',
   color: '#6366f1',
 }
 
-export function CategoryForm({ isOpen, onClose, userId, onSuccess }: Props) {
+export function CategoryForm({ isOpen, onClose, userId, onSuccess, defaultType }: Props) {
   const [loading, setLoading] = useState(false)
-  const [formData, setFormData] = useState(defaultForm)
+  const [formData, setFormData] = useState({ ...defaultForm, type: defaultType ?? 'expense' as CategoryType })
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -44,7 +47,7 @@ export function CategoryForm({ isOpen, onClose, userId, onSuccess }: Props) {
       toaster.create({ title: 'Categoría creada', type: 'success', duration: 3000 })
       onSuccess()
       onClose()
-      setFormData(defaultForm)
+      setFormData({ ...defaultForm, type: defaultType ?? 'expense' })
     } else {
       toaster.create({ title: 'Error al crear', description: result.error, type: 'error', duration: 4000 })
     }
@@ -58,7 +61,7 @@ export function CategoryForm({ isOpen, onClose, userId, onSuccess }: Props) {
           <RadioSelect
             label="Tipo"
             value={formData.type}
-            onChange={(v) => setFormData({ ...formData, type: v as 'income' | 'expense' })}
+            onChange={(v) => setFormData({ ...formData, type: v as CategoryType })}
             options={TYPE_OPTIONS}
             required
           />

--- a/components/ui/CategorySelect.tsx
+++ b/components/ui/CategorySelect.tsx
@@ -12,7 +12,9 @@ interface Props {
 }
 
 export function CategorySelect({ value, onChange, categories, filterByType, required }: Props) {
-  const filtered = filterByType ? categories.filter((c) => c.type === filterByType) : categories
+  const filtered = filterByType
+    ? categories.filter((c) => c.type === filterByType || c.type === 'both')
+    : categories
 
   return (
     <FieldRoot required={required} w="full">

--- a/lib/actions/categories.actions.ts
+++ b/lib/actions/categories.actions.ts
@@ -15,7 +15,6 @@ export async function getCategories(userId: string) {
     return { success: false, error: 'User ID is required' }
   }
   try {
-    // Obtener predefinidas (user_id null) + del usuario en dos queries
     const [{ data: predefined, error: e1 }, { data: userCats, error: e2 }] =
       await Promise.all([
         insforgeAdmin.database.from('categories').select('*').is('user_id', null).order('name'),
@@ -32,12 +31,31 @@ export async function getCategories(userId: string) {
   }
 }
 
+async function checkDuplicateName(userId: string, name: string, excludeId?: string) {
+  const { data } = await insforgeAdmin.database
+    .from('categories')
+    .select('id, name')
+    .eq('user_id', userId)
+
+  if (!data) return false
+
+  return data.some((cat) => {
+    if (excludeId && cat.id === excludeId) return false
+    return cat.name.toUpperCase() === name.toUpperCase()
+  })
+}
+
 export async function createCategory(
   userId: string,
   data: CreateCategoryInput
 ) {
   try {
     const validated = createCategorySchema.parse(data)
+
+    const isDuplicate = await checkDuplicateName(userId, validated.name)
+    if (isDuplicate) {
+      return { success: false, error: `Ya existe una categoría con el nombre "${validated.name}"` }
+    }
 
     const { data: category, error } = await insforgeAdmin.database
       .from('categories')
@@ -63,6 +81,13 @@ export async function updateCategory(
   try {
     const validated = updateCategorySchema.parse(data)
 
+    if (validated.name) {
+      const isDuplicate = await checkDuplicateName(userId, validated.name, id)
+      if (isDuplicate) {
+        return { success: false, error: `Ya existe una categoría con el nombre "${validated.name}"` }
+      }
+    }
+
     const { data: category, error } = await insforgeAdmin.database
       .from('categories')
       .update(validated)
@@ -83,7 +108,6 @@ export async function updateCategory(
 
 export async function deleteCategory(id: string, userId: string) {
   try {
-    // Verificar que no tenga transacciones asociadas
     const { data: txCount } = await insforgeAdmin.database
       .from('transactions')
       .select('id')

--- a/lib/validations/category.ts
+++ b/lib/validations/category.ts
@@ -2,13 +2,14 @@ import * as z from 'zod'
 
 export const createCategorySchema = z.object({
   name: z.string().min(1, 'Name is required'),
-  type: z.enum(['income', 'expense']),
+  type: z.enum(['income', 'expense', 'both']),
   icon: z.string().optional(),
   color: z.string().optional(),
 })
 
 export const updateCategorySchema = z.object({
   name: z.string().min(1, 'Name is required'),
+  type: z.enum(['income', 'expense', 'both']).optional(),
   icon: z.string().optional(),
   color: z.string().optional(),
 })

--- a/types/database.types.ts
+++ b/types/database.types.ts
@@ -1,5 +1,6 @@
 export type Currency = 'COP' | 'USD' | 'VES'
 export type TransactionType = 'income' | 'expense'
+export type CategoryType = 'income' | 'expense' | 'both'
 export type BudgetPeriod = 'monthly' | 'yearly'
 export type TransactionSource = 'manual' | 'conversational' | 'import'
 export type RecurrenceFrequency = 'daily' | 'weekly' | 'monthly' | 'yearly'
@@ -24,7 +25,7 @@ export interface Category {
   id: string
   user_id: string | null // null = predefined
   name: string
-  type: TransactionType
+  type: CategoryType
   icon: string | null
   color: string | null
   created_at: string


### PR DESCRIPTION
## Cambios — Tareas 2.1, 2.2 y 2.3

### Tarea 2.1 — Vista separada por tipo
- La página de categorías ahora muestra 3 secciones: **💸 Gastos**, **💰 Ingresos**, **🔄 Gastos e Ingresos**
- Cada sección tiene subsecciones "Predefinidas" y "Mis Categorías"
- Badge de color en cada card: rojo (Gasto), verde (Ingreso), morado (Ambos)

### Tarea 2.2 — Tipo "Ambos"
- Nuevo tipo `'both'` en `CategoryType` (`types/database.types.ts`)
- Schema de validación actualizado para aceptar `'income' | 'expense' | 'both'`
- `CategoryForm` y `CategoryEditForm` incluyen opción "Ambos" en RadioSelect
- `CategoryEditForm` ahora permite cambiar el tipo al editar
- `CategorySelect` muestra categorías `'both'` cuando se filtra por tipo (gastos e ingresos)

### Tarea 2.3 — Control de duplicados
- `createCategory` y `updateCategory` verifican nombre duplicado (case-insensitive) antes de insertar/actualizar
- Retorna mensaje de error descriptivo: "Ya existe una categoría con el nombre X"

## Testing
- ✅ TypeScript compila sin errores

Closes #371, #372, #373
Related to #370

---
_Generated by [Claude Code](https://claude.ai/code/session_01XPgXLQwAtTpgt2K7VWVnAw)_