### PR TITLE
feat: crear categoría directamente desde el modal de transacciones

### DIFF
--- a/components/categories/QuickCategoryForm.tsx
+++ b/components/categories/QuickCategoryForm.tsx
@@ -1,0 +1,122 @@
+'use client'
+
+import {
+  Box,
+  VStack,
+  HStack,
+  FieldRoot,
+  FieldLabel,
+  Text,
+  DialogRoot,
+  DialogBackdrop,
+  DialogPositioner,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogBody,
+  DialogCloseTrigger,
+} from '@chakra-ui/react'
+import { useState } from 'react'
+import { createCategory } from '@/lib/actions/categories.actions'
+import { toaster } from '@/lib/toaster'
+import { FormInput } from '@/components/ui/FormInput'
+import { PrimaryButton } from '@/components/ui/PrimaryButton'
+import { IconPicker } from './IconPicker'
+import { ColorPicker } from './ColorPicker'
+import type { Category, CategoryType } from '@/types/database.types'
+
+interface Props {
+  isOpen: boolean
+  onClose: () => void
+  userId: string
+  defaultType: CategoryType
+  onCreated: (category: Category) => void
+}
+
+export function QuickCategoryForm({ isOpen, onClose, userId, defaultType, onCreated }: Props) {
+  const [loading, setLoading] = useState(false)
+  const [formData, setFormData] = useState({
+    name: '',
+    icon: '',
+    color: '#6366f1',
+  })
+
+  const typeLabel = defaultType === 'expense' ? 'Gasto' : defaultType === 'income' ? 'Ingreso' : 'Ambos'
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setLoading(true)
+
+    const result = await createCategory(userId, { ...formData, type: defaultType })
+
+    if (result.success && result.data) {
+      toaster.create({ title: `Categoría "${formData.name}" creada`, type: 'success', duration: 2500 })
+      onCreated(result.data as Category)
+      onClose()
+      setFormData({ name: '', icon: '', color: '#6366f1' })
+    } else {
+      toaster.create({ title: 'Error al crear', description: result.error, type: 'error', duration: 4000 })
+    }
+    setLoading(false)
+  }
+
+  return (
+    <DialogRoot
+      open={isOpen}
+      onOpenChange={({ open }) => !open && onClose()}
+      placement="center"
+      lazyMount
+      unmountOnExit
+    >
+      <DialogBackdrop />
+      <DialogPositioner>
+        <DialogContent tabIndex={-1} maxW="400px">
+          <DialogHeader>
+            <DialogTitle>Nueva Categoría</DialogTitle>
+          </DialogHeader>
+          <DialogCloseTrigger />
+          <DialogBody pb={6}>
+            <form onSubmit={handleSubmit}>
+              <VStack gap={4}>
+                <Box w="full" p={2} bg="#26262f" borderRadius="md">
+                  <Text fontSize="xs" color="#B0B0B0">
+                    Tipo: <Text as="span" color="white" fontWeight="medium">{typeLabel}</Text>
+                  </Text>
+                </Box>
+
+                <FormInput
+                  label="Nombre"
+                  value={formData.name}
+                  onChange={(v) => setFormData({ ...formData, name: v })}
+                  placeholder="Ej: Transporte"
+                  required
+                />
+
+                <HStack gap={4} w="full">
+                  <FieldRoot>
+                    <FieldLabel>Icono</FieldLabel>
+                    <IconPicker
+                      value={formData.icon}
+                      onChange={(icon) => setFormData({ ...formData, icon })}
+                    />
+                  </FieldRoot>
+                  <FieldRoot>
+                    <FieldLabel>Color</FieldLabel>
+                    <ColorPicker
+                      value={formData.color}
+                      onChange={(color) => setFormData({ ...formData, color })}
+                    />
+                  </FieldRoot>
+                </HStack>
+
+                <PrimaryButton type="submit" width="full" loading={loading}>
+                  Crear y Seleccionar
+                </PrimaryButton>
+              </VStack>
+            </form>
+          </DialogBody>
+        </DialogContent>
+      </DialogPositioner>
+    </DialogRoot>
+  )
+}

--- a/components/transactions/TransactionEditForm.tsx
+++ b/components/transactions/TransactionEditForm.tsx
@@ -1,7 +1,8 @@
 'use client'
 
-import { VStack, Box, SimpleGrid } from '@chakra-ui/react'
+import { VStack, Box, SimpleGrid, Button } from '@chakra-ui/react'
 import { useState, useEffect } from 'react'
+import { FiPlus } from 'react-icons/fi'
 import { updateTransaction } from '@/lib/actions/transactions.actions'
 import { toaster } from '@/lib/toaster'
 import { FormDialog } from '@/components/ui/FormDialog'
@@ -15,6 +16,7 @@ import { CategorySelect } from '@/components/ui/CategorySelect'
 import { AccountSelect } from '@/components/ui/AccountSelect'
 import { PrimaryButton } from '@/components/ui/PrimaryButton'
 import { CurrencyPreview } from './CurrencyPreview'
+import { QuickCategoryForm } from '@/components/categories/QuickCategoryForm'
 import type { Account, Category, Currency, TransactionWithCategory } from '@/types/database.types'
 
 const TYPE_OPTIONS = [
@@ -34,6 +36,8 @@ interface Props {
 
 export function TransactionEditForm({ isOpen, onClose, userId, categories, accounts = [], transaction, onSuccess }: Props) {
   const [loading, setLoading] = useState(false)
+  const [localCategories, setLocalCategories] = useState<Category[]>(categories)
+  const [quickCategoryOpen, setQuickCategoryOpen] = useState(false)
   const [formData, setFormData] = useState({
     type: transaction.type,
     amount: Number(transaction.amount) as number | undefined,
@@ -56,7 +60,13 @@ export function TransactionEditForm({ isOpen, onClose, userId, categories, accou
       date: transaction.date,
       notes: transaction.notes ?? '',
     })
-  }, [transaction])
+    setLocalCategories(categories)
+  }, [transaction, categories])
+
+  const handleCategoryCreated = (newCategory: Category) => {
+    setLocalCategories((prev) => [...prev, newCategory])
+    setFormData((prev) => ({ ...prev, category_id: newCategory.id }))
+  }
 
   const handleAccountChange = (accountId: string) => {
     const account = accounts.find((a) => a.id === accountId)
@@ -90,6 +100,7 @@ export function TransactionEditForm({ isOpen, onClose, userId, categories, accou
   }
 
   return (
+    <>
     <FormDialog isOpen={isOpen} onClose={onClose} title="Editar Transacción" size="lg">
       <form onSubmit={handleSubmit}>
         <VStack gap={4}>
@@ -137,13 +148,27 @@ export function TransactionEditForm({ isOpen, onClose, userId, categories, accou
             />
           )}
 
-          <CategorySelect
-            value={formData.category_id}
-            onChange={(v) => setFormData({ ...formData, category_id: v })}
-            categories={categories}
-            filterByType={formData.type}
-            required
-          />
+          <Box w="full">
+            <CategorySelect
+              value={formData.category_id}
+              onChange={(v) => setFormData({ ...formData, category_id: v })}
+              categories={localCategories}
+              filterByType={formData.type}
+              required
+            />
+            <Button
+              variant="ghost"
+              size="xs"
+              color="#6366f1"
+              mt={1}
+              px={0}
+              _hover={{ color: '#818cf8', bg: 'transparent' }}
+              onClick={() => setQuickCategoryOpen(true)}
+            >
+              <FiPlus style={{ marginRight: 4 }} />
+              Nueva categoría
+            </Button>
+          </Box>
 
           <SimpleGrid columns={{ base: 1, md: 2 }} gap={4} w="full">
             <FormInput
@@ -179,5 +204,14 @@ export function TransactionEditForm({ isOpen, onClose, userId, categories, accou
         </VStack>
       </form>
     </FormDialog>
+
+    <QuickCategoryForm
+      isOpen={quickCategoryOpen}
+      onClose={() => setQuickCategoryOpen(false)}
+      userId={userId}
+      defaultType={formData.type}
+      onCreated={handleCategoryCreated}
+    />
+    </>
   )
 }

--- a/components/transactions/TransactionForm.tsx
+++ b/components/transactions/TransactionForm.tsx
@@ -1,7 +1,8 @@
 'use client'
 
-import { VStack, Box, SimpleGrid } from '@chakra-ui/react'
+import { VStack, Box, SimpleGrid, Button } from '@chakra-ui/react'
 import { useState, useEffect } from 'react'
+import { FiPlus } from 'react-icons/fi'
 import { createTransaction } from '@/lib/actions/transactions.actions'
 import { toaster } from '@/lib/toaster'
 import { FormDialog } from '@/components/ui/FormDialog'
@@ -15,6 +16,7 @@ import { CategorySelect } from '@/components/ui/CategorySelect'
 import { AccountSelect } from '@/components/ui/AccountSelect'
 import { PrimaryButton } from '@/components/ui/PrimaryButton'
 import { CurrencyPreview } from './CurrencyPreview'
+import { QuickCategoryForm } from '@/components/categories/QuickCategoryForm'
 import type { Account, Category, Currency } from '@/types/database.types'
 import { getLocalDateString } from '@/lib/utils/dates'
 
@@ -48,12 +50,15 @@ const defaultForm = {
 export function TransactionForm({ isOpen, onClose, userId, categories, accounts = [], onSuccess, initialDate, lockedDate }: Props) {
   const [loading, setLoading] = useState(false)
   const [formData, setFormData] = useState({ ...defaultForm, date: initialDate ?? getLocalDateString() })
+  const [localCategories, setLocalCategories] = useState<Category[]>(categories)
+  const [quickCategoryOpen, setQuickCategoryOpen] = useState(false)
 
   useEffect(() => {
     if (isOpen) {
       setFormData({ ...defaultForm, date: initialDate ?? getLocalDateString() })
+      setLocalCategories(categories)
     }
-  }, [isOpen, initialDate])
+  }, [isOpen, initialDate, categories])
 
   const handleAccountChange = (accountId: string) => {
     const account = accounts.find((a) => a.id === accountId)
@@ -65,6 +70,11 @@ export function TransactionForm({ isOpen, onClose, userId, categories, accounts 
   }
 
   const accountLocksCurrency = !!formData.account_id
+
+  const handleCategoryCreated = (newCategory: Category) => {
+    setLocalCategories((prev) => [...prev, newCategory])
+    setFormData((prev) => ({ ...prev, category_id: newCategory.id }))
+  }
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -88,97 +98,121 @@ export function TransactionForm({ isOpen, onClose, userId, categories, accounts 
   }
 
   return (
-    <FormDialog isOpen={isOpen} onClose={onClose} title="Nueva Transacción" size="lg">
-      <form onSubmit={handleSubmit}>
-        <VStack gap={4}>
-          <RadioSelect
-            label="Tipo"
-            value={formData.type}
-            onChange={(v) => setFormData({ ...formData, type: v as 'income' | 'expense', category_id: '' })}
-            options={TYPE_OPTIONS}
-            required
-          />
-
-          <SimpleGrid columns={{ base: 1, md: 2 }} gap={4} w="full">
-            <InputAmount
-              label="Monto"
-              value={formData.amount}
-              onChange={(v) => setFormData({ ...formData, amount: v })}
-              isRequired
+    <>
+      <FormDialog isOpen={isOpen} onClose={onClose} title="Nueva Transacción" size="lg">
+        <form onSubmit={handleSubmit}>
+          <VStack gap={4}>
+            <RadioSelect
+              label="Tipo"
+              value={formData.type}
+              onChange={(v) => setFormData({ ...formData, type: v as 'income' | 'expense', category_id: '' })}
+              options={TYPE_OPTIONS}
+              required
             />
-            {accounts.length > 0 ? (
-              <AccountSelect
-                value={formData.account_id}
-                onChange={handleAccountChange}
-                accounts={accounts}
-                label="Cuenta"
-                optional
-                placeholder="Sin cuenta específica"
+
+            <SimpleGrid columns={{ base: 1, md: 2 }} gap={4} w="full">
+              <InputAmount
+                label="Monto"
+                value={formData.amount}
+                onChange={(v) => setFormData({ ...formData, amount: v })}
+                isRequired
               />
-            ) : (
+              {accounts.length > 0 ? (
+                <AccountSelect
+                  value={formData.account_id}
+                  onChange={handleAccountChange}
+                  accounts={accounts}
+                  label="Cuenta"
+                  optional
+                  placeholder="Sin cuenta específica"
+                />
+              ) : (
+                <CurrencySelect
+                  value={formData.currency}
+                  onChange={(v) => setFormData({ ...formData, currency: v })}
+                  showFullLabel
+                  required
+                />
+              )}
+            </SimpleGrid>
+
+            {accounts.length > 0 && (
               <CurrencySelect
                 value={formData.currency}
                 onChange={(v) => setFormData({ ...formData, currency: v })}
                 showFullLabel
                 required
+                disabled={accountLocksCurrency}
               />
             )}
-          </SimpleGrid>
 
-          {accounts.length > 0 && (
-            <CurrencySelect
-              value={formData.currency}
-              onChange={(v) => setFormData({ ...formData, currency: v })}
-              showFullLabel
-              required
-              disabled={accountLocksCurrency}
+            <Box w="full">
+              <CategorySelect
+                value={formData.category_id}
+                onChange={(v) => setFormData({ ...formData, category_id: v })}
+                categories={localCategories}
+                filterByType={formData.type}
+                required
+              />
+              <Button
+                variant="ghost"
+                size="xs"
+                color="#6366f1"
+                mt={1}
+                px={0}
+                _hover={{ color: '#818cf8', bg: 'transparent' }}
+                onClick={() => setQuickCategoryOpen(true)}
+              >
+                <FiPlus style={{ marginRight: 4 }} />
+                Nueva categoría
+              </Button>
+            </Box>
+
+            <SimpleGrid columns={{ base: 1, md: 2 }} gap={4} w="full">
+              <FormInput
+                label="Descripción"
+                value={formData.description}
+                onChange={(v) => setFormData({ ...formData, description: v })}
+                placeholder="Ej: Compra en supermercado"
+                required
+              />
+              <DateInput
+                label="Fecha"
+                value={formData.date}
+                onChange={(v) => setFormData({ ...formData, date: v })}
+                required
+                disabled={lockedDate}
+              />
+            </SimpleGrid>
+
+            <Box w="full" minH="10">
+              <CurrencyPreview
+                amount={formData.amount ?? 0}
+                fromCurrency={formData.currency}
+              />
+            </Box>
+
+            <FormTextarea
+              label="Notas (opcional)"
+              value={formData.notes}
+              onChange={(v) => setFormData({ ...formData, notes: v })}
+              placeholder="Notas adicionales..."
             />
-          )}
 
-          <CategorySelect
-            value={formData.category_id}
-            onChange={(v) => setFormData({ ...formData, category_id: v })}
-            categories={categories}
-            filterByType={formData.type}
-            required
-          />
+            <PrimaryButton type="submit" width="full" loading={loading}>
+              Crear Transacción
+            </PrimaryButton>
+          </VStack>
+        </form>
+      </FormDialog>
 
-          <SimpleGrid columns={{ base: 1, md: 2 }} gap={4} w="full">
-            <FormInput
-              label="Descripción"
-              value={formData.description}
-              onChange={(v) => setFormData({ ...formData, description: v })}
-              placeholder="Ej: Compra en supermercado"
-              required
-            />
-            <DateInput
-              label="Fecha"
-              value={formData.date}
-              onChange={(v) => setFormData({ ...formData, date: v })}
-              required
-              disabled={lockedDate}
-            />
-          </SimpleGrid>
-
-          <Box w="full" minH="10">
-            <CurrencyPreview
-              amount={formData.amount ?? 0}
-              fromCurrency={formData.currency}
-            />
-          </Box>
-
-          <FormTextarea
-            label="Notas (opcional)"
-            value={formData.notes}
-            onChange={(v) => setFormData({ ...formData, notes: v })}
-            placeholder="Notas adicionales..."
-          />
-
-          <PrimaryButton type="submit" width="full" loading={loading}>
-            Crear Transacción
-          </PrimaryButton>
-        </VStack>
-      </form>
-    </FormDialog>
+      <QuickCategoryForm
+        isOpen={quickCategoryOpen}
+        onClose={() => setQuickCategoryOpen(false)}
+        userId={userId}
+        defaultType={formData.type}
+        onCreated={handleCategoryCreated}
+      />
+    </>
   )
 }


### PR DESCRIPTION
## Cambios — Tarea 2.4

- Nuevo componente `QuickCategoryForm`: modal pequeño para crear una categoría rápidamente con nombre, icono y color. El tipo se pre-llena con el tipo de la transacción actual
- `TransactionForm` y `TransactionEditForm` ahora muestran un botón **"＋ Nueva categoría"** debajo del selector de categorías
- Al crear exitosamente, la nueva categoría se añade al estado local (sin reload) y queda **auto-seleccionada** en el campo de categoría
- El modal de transacciones permanece abierto durante todo el flujo

## UX
1. Usuario abre modal de nueva transacción
2. No encuentra la categoría que busca → hace clic en "＋ Nueva categoría"
3. Se abre un mini-modal con nombre, icono y color (tipo pre-cargado del paso anterior)
4. Crea la categoría → vuelve al modal de transacciones con la nueva categoría seleccionada
5. Continúa llenando el formulario normalmente

## Testing
- ✅ TypeScript compila sin errores

Closes #374
Related to #370

---
_Generated by [Claude Code](https://claude.ai/code/session_01XPgXLQwAtTpgt2K7VWVnAw)_