### PR TITLE
feat: historial de abonos a deudas con cards desplegables

### DIFF
--- a/app/(dashboard)/loans/LoansPageClient.tsx
+++ b/app/(dashboard)/loans/LoansPageClient.tsx
@@ -7,7 +7,7 @@ import { FiPlus } from 'react-icons/fi'
 import { Card } from '@/components/ui/Card'
 import { LoanForm } from '@/components/loans/LoanForm'
 import { LoanPaymentForm } from '@/components/loans/LoanPaymentForm'
-import { LoansTable } from '@/components/loans/LoansTable'
+import { LoanCards } from '@/components/loans/LoanCards'
 import { deleteLoan, settleLoan } from '@/lib/actions/loans.actions'
 import { toaster } from '@/lib/toaster'
 import type { Account, LoanWithAccount } from '@/types/database.types'
@@ -25,6 +25,8 @@ export function LoansPageClient({ userId, initialLoans, accounts }: Props) {
   const { open: isPaymentOpen, onOpen: onPaymentOpen, onClose: onPaymentClose } = useDisclosure()
   const [editingLoan, setEditingLoan] = useState<LoanWithAccount | null>(null)
   const [payingLoan, setPayingLoan] = useState<LoanWithAccount | null>(null)
+
+  const refresh = useCallback(() => router.refresh(), [router])
 
   const handleEdit = useCallback((loan: LoanWithAccount) => {
     setEditingLoan(loan)
@@ -44,21 +46,21 @@ export function LoansPageClient({ userId, initialLoans, accounts }: Props) {
         type: 'success',
         duration: 3000,
       })
-      router.refresh()
+      refresh()
     } else {
       toaster.create({ title: result.error ?? 'Error al saldar', type: 'error', duration: 4000 })
     }
-  }, [userId, router])
+  }, [userId, refresh])
 
   const handleDelete = useCallback(async (loan: LoanWithAccount) => {
     const result = await deleteLoan(userId, loan.id)
     if (result.success) {
       toaster.create({ title: 'Préstamo eliminado', type: 'success', duration: 3000 })
-      router.refresh()
+      refresh()
     } else {
       toaster.create({ title: result.error ?? 'Error al eliminar', type: 'error', duration: 4000 })
     }
-  }, [userId, router])
+  }, [userId, refresh])
 
   const handleEditClose = useCallback(() => {
     onEditClose()
@@ -92,24 +94,28 @@ export function LoansPageClient({ userId, initialLoans, accounts }: Props) {
 
       <Card mb={6}>
         <Heading size="sm" mb={4} color="white">Activos</Heading>
-        <LoansTable
+        <LoanCards
           loans={activeLoans}
+          userId={userId}
           onEdit={handleEdit}
           onSettle={handleSettle}
           onDelete={handleDelete}
           onPayment={handlePayment}
+          onRefresh={refresh}
         />
       </Card>
 
       {settledLoans.length > 0 && (
         <Card>
           <Heading size="sm" mb={4} color="#B0B0B0">Historial — Saldados</Heading>
-          <LoansTable
+          <LoanCards
             loans={settledLoans}
+            userId={userId}
             onEdit={handleEdit}
             onSettle={handleSettle}
             onDelete={handleDelete}
             onPayment={handlePayment}
+            onRefresh={refresh}
           />
         </Card>
       )}
@@ -119,7 +125,7 @@ export function LoansPageClient({ userId, initialLoans, accounts }: Props) {
         onClose={onCreateClose}
         userId={userId}
         accounts={accounts}
-        onSuccess={() => router.refresh()}
+        onSuccess={refresh}
       />
 
       {editingLoan && (
@@ -129,7 +135,7 @@ export function LoansPageClient({ userId, initialLoans, accounts }: Props) {
           userId={userId}
           accounts={accounts}
           loan={editingLoan}
-          onSuccess={() => { router.refresh(); handleEditClose() }}
+          onSuccess={() => { refresh(); handleEditClose() }}
         />
       )}
 
@@ -139,7 +145,7 @@ export function LoansPageClient({ userId, initialLoans, accounts }: Props) {
           onClose={handlePaymentClose}
           loan={payingLoan}
           userId={userId}
-          onSuccess={() => router.refresh()}
+          onSuccess={refresh}
         />
       )}
     </Box>

--- a/components/loans/LoanCards.tsx
+++ b/components/loans/LoanCards.tsx
@@ -1,0 +1,360 @@
+'use client'
+
+import { useState } from 'react'
+import {
+  Box,
+  VStack,
+  HStack,
+  Text,
+  Badge,
+  Button,
+  IconButton,
+  Spinner,
+} from '@chakra-ui/react'
+import { FiEdit2, FiTrash2, FiCheckCircle, FiPlusCircle, FiChevronDown, FiChevronUp } from 'react-icons/fi'
+import { formatCurrency } from '@/lib/utils/currency'
+import { getLoanPayments, deleteLoanPayment } from '@/lib/actions/loans.actions'
+import { ConfirmDialog } from '@/components/ui/ConfirmDialog'
+import { toaster } from '@/lib/toaster'
+import type { LoanWithAccount, LoanPayment } from '@/types/database.types'
+
+interface Props {
+  loans: LoanWithAccount[]
+  userId: string
+  onEdit: (loan: LoanWithAccount) => void
+  onSettle: (loan: LoanWithAccount) => void
+  onDelete: (loan: LoanWithAccount) => void
+  onPayment: (loan: LoanWithAccount) => void
+  onRefresh: () => void
+}
+
+function settleLabel(loan: LoanWithAccount) {
+  return loan.type === 'lent' ? '¡Ya me pagaron!' : '¡Ya pagué!'
+}
+
+function PaymentHistory({
+  loan,
+  userId,
+  onRefresh,
+}: {
+  loan: LoanWithAccount
+  userId: string
+  onRefresh: () => void
+}) {
+  const [payments, setPayments] = useState<LoanPayment[] | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [deletingId, setDeletingId] = useState<string | null>(null)
+  const [confirmPayment, setConfirmPayment] = useState<LoanPayment | null>(null)
+
+  const load = async () => {
+    setLoading(true)
+    const result = await getLoanPayments(userId, loan.id)
+    setLoading(false)
+    if (result.success) setPayments(result.data as LoanPayment[])
+  }
+
+  if (payments === null && !loading) {
+    // Trigger load on mount of this component
+    load()
+  }
+
+  const handleDeletePayment = async () => {
+    if (!confirmPayment) return
+    setDeletingId(confirmPayment.id)
+    const result = await deleteLoanPayment(userId, confirmPayment.id)
+    setDeletingId(null)
+    if (result.success) {
+      toaster.create({ title: 'Abono eliminado', type: 'success', duration: 2500 })
+      setConfirmPayment(null)
+      onRefresh()
+      load()
+    } else {
+      toaster.create({ title: result.error ?? 'Error al eliminar', type: 'error', duration: 4000 })
+    }
+  }
+
+  const legacyPaid = Number(loan.paid_amount ?? 0)
+  const hasLegacy = legacyPaid > 0 && payments !== null && payments.length === 0
+
+  if (loading) {
+    return (
+      <HStack justify="center" py={3}>
+        <Spinner size="sm" color="#6366f1" />
+      </HStack>
+    )
+  }
+
+  if (!payments || (payments.length === 0 && !hasLegacy)) {
+    return (
+      <Text fontSize="xs" color="#808080" py={2} textAlign="center">
+        Sin historial de abonos registrados.
+      </Text>
+    )
+  }
+
+  return (
+    <>
+      <VStack gap={1} align="stretch" pt={1}>
+        {hasLegacy && (
+          <HStack
+            justify="space-between"
+            bg="#26262f"
+            borderRadius="md"
+            px={3}
+            py={2}
+            opacity={0.7}
+          >
+            <Text fontSize="xs" color="#B0B0B0">Historial previo (sin fecha)</Text>
+            <Text fontSize="xs" fontWeight="600" color="white">
+              {formatCurrency(legacyPaid, loan.currency)}
+            </Text>
+          </HStack>
+        )}
+        {payments.map((p) => (
+          <HStack
+            key={p.id}
+            justify="space-between"
+            bg="#26262f"
+            borderRadius="md"
+            px={3}
+            py={2}
+          >
+            <Box>
+              <Text fontSize="xs" color="white" fontWeight="500">
+                {formatCurrency(Number(p.amount), p.currency)}
+              </Text>
+              {p.notes && (
+                <Text fontSize="xs" color="#808080">{p.notes}</Text>
+              )}
+            </Box>
+            <HStack gap={2}>
+              <Text fontSize="xs" color="#B0B0B0">{p.date}</Text>
+              {loan.status === 'active' && (
+                <IconButton
+                  aria-label="Eliminar abono"
+                  size="2xs"
+                  variant="ghost"
+                  color="#F43F5E"
+                  loading={deletingId === p.id}
+                  onClick={() => setConfirmPayment(p)}
+                >
+                  <FiTrash2 />
+                </IconButton>
+              )}
+            </HStack>
+          </HStack>
+        ))}
+      </VStack>
+
+      <ConfirmDialog
+        isOpen={confirmPayment !== null}
+        onClose={() => setConfirmPayment(null)}
+        onConfirm={handleDeletePayment}
+        title="Eliminar abono"
+        description={`¿Eliminar el abono de ${confirmPayment ? formatCurrency(Number(confirmPayment.amount), confirmPayment.currency) : ''}? El saldo de la cuenta será revertido.`}
+        confirmLabel="Eliminar"
+      />
+    </>
+  )
+}
+
+function LoanCard({
+  loan,
+  userId,
+  onEdit,
+  onSettle,
+  onDelete,
+  onPayment,
+  onRefresh,
+}: {
+  loan: LoanWithAccount
+  userId: string
+  onEdit: () => void
+  onSettle: () => void
+  onDelete: () => void
+  onPayment: () => void
+  onRefresh: () => void
+}) {
+  const [expanded, setExpanded] = useState(false)
+  const [confirmDelete, setConfirmDelete] = useState(false)
+
+  const total = Number(loan.amount)
+  const paid = Number(loan.paid_amount ?? 0)
+  const remaining = total - paid
+  const paidPercent = total > 0 ? Math.min(100, (paid / total) * 100) : 0
+  const isSettled = loan.status === 'settled'
+
+  return (
+    <Box
+      bg="#1a1a23"
+      borderRadius="xl"
+      borderWidth="1px"
+      borderColor={isSettled ? '#2d2d35' : '#3a3a42'}
+      overflow="hidden"
+      opacity={isSettled ? 0.75 : 1}
+      transition="opacity 0.15s"
+    >
+      {/* Header */}
+      <Box px={4} pt={4} pb={3}>
+        <HStack justify="space-between" align="start" mb={2}>
+          <Box>
+            <Text fontWeight="700" color="white" fontSize="md">{loan.person_name}</Text>
+            <HStack gap={2} mt={1} flexWrap="wrap">
+              <Badge colorPalette={loan.type === 'lent' ? 'blue' : 'orange'} size="sm">
+                {loan.type === 'lent' ? 'Presté' : 'Me prestaron'}
+              </Badge>
+              {loan.account && (
+                <Text fontSize="xs" color="#808080">
+                  {loan.account.icon ?? ''} {loan.account.name}
+                </Text>
+              )}
+            </HStack>
+          </Box>
+          <Box textAlign="right">
+            <Text fontWeight="700" fontSize="lg" color={loan.type === 'lent' ? '#F43F5E' : '#10B981'}>
+              {formatCurrency(total, loan.currency)}
+            </Text>
+            {paid > 0 && (
+              <Text fontSize="xs" color="#B0B0B0">
+                Pendiente: {formatCurrency(remaining, loan.currency)}
+              </Text>
+            )}
+          </Box>
+        </HStack>
+
+        {/* Progress bar */}
+        {paid > 0 && (
+          <Box mt={1} mb={2}>
+            <Box bg="#2d2d35" borderRadius="full" h="4px">
+              <Box
+                bg={paidPercent >= 100 ? '#10B981' : '#6366f1'}
+                borderRadius="full"
+                h="4px"
+                w={`${paidPercent}%`}
+                transition="width 0.3s"
+              />
+            </Box>
+            <Text fontSize="xs" color="#B0B0B0" mt={1}>
+              Abonado: {formatCurrency(paid, loan.currency)} ({Math.round(paidPercent)}%)
+            </Text>
+          </Box>
+        )}
+
+        {loan.notes && (
+          <Text fontSize="xs" color="#808080" mb={2}>{loan.notes}</Text>
+        )}
+
+        {/* Actions */}
+        <HStack gap={2} mt={2} flexWrap="wrap">
+          {!isSettled && (
+            <>
+              <Button
+                size="xs"
+                bg="#F97316"
+                color="white"
+                _hover={{ bg: '#EA580C' }}
+                onClick={onPayment}
+              >
+                <FiPlusCircle />
+                Abono
+              </Button>
+              <Button
+                size="xs"
+                bg="#4F46E5"
+                color="white"
+                _hover={{ bg: '#4338CA' }}
+                onClick={onSettle}
+              >
+                <FiCheckCircle />
+                {settleLabel(loan)}
+              </Button>
+              <IconButton
+                aria-label="Editar"
+                size="xs"
+                variant="ghost"
+                onClick={onEdit}
+              >
+                <FiEdit2 />
+              </IconButton>
+            </>
+          )}
+          <IconButton
+            aria-label="Eliminar"
+            size="xs"
+            variant="ghost"
+            color="#F43F5E"
+            onClick={() => setConfirmDelete(true)}
+          >
+            <FiTrash2 />
+          </IconButton>
+        </HStack>
+      </Box>
+
+      {/* Toggle historial */}
+      <Button
+        w="full"
+        variant="ghost"
+        size="xs"
+        color="#B0B0B0"
+        borderTop="1px solid"
+        borderColor="#2d2d35"
+        borderRadius="0"
+        py={2}
+        h="auto"
+        _hover={{ bg: '#26262f', color: 'white' }}
+        onClick={() => setExpanded((v) => !v)}
+      >
+        <HStack gap={1}>
+          {expanded ? <FiChevronUp /> : <FiChevronDown />}
+          <Text fontSize="xs">{expanded ? 'Ocultar historial' : 'Ver historial de abonos'}</Text>
+        </HStack>
+      </Button>
+
+      {/* Historial */}
+      {expanded && (
+        <Box px={4} pb={3} borderTop="1px solid" borderColor="#2d2d35" bg="#18181d">
+          <Text fontSize="xs" fontWeight="600" color="#B0B0B0" pt={3} pb={2} textTransform="uppercase">
+            Historial
+          </Text>
+          <PaymentHistory loan={loan} userId={userId} onRefresh={onRefresh} />
+        </Box>
+      )}
+
+      <ConfirmDialog
+        isOpen={confirmDelete}
+        onClose={() => setConfirmDelete(false)}
+        onConfirm={() => { onDelete(); setConfirmDelete(false) }}
+        title="Eliminar préstamo"
+        description={`¿Eliminar el préstamo de ${loan.person_name}?${loan.status === 'active' ? ' El saldo de la cuenta será revertido.' : ''}`}
+        confirmLabel="Eliminar"
+      />
+    </Box>
+  )
+}
+
+export function LoanCards({ loans, userId, onEdit, onSettle, onDelete, onPayment, onRefresh }: Props) {
+  if (loans.length === 0) {
+    return (
+      <Box py={6} textAlign="center">
+        <Text color="#B0B0B0">No hay registros.</Text>
+      </Box>
+    )
+  }
+
+  return (
+    <VStack gap={3} align="stretch">
+      {loans.map((loan) => (
+        <LoanCard
+          key={loan.id}
+          loan={loan}
+          userId={userId}
+          onEdit={() => onEdit(loan)}
+          onSettle={() => onSettle(loan)}
+          onDelete={() => onDelete(loan)}
+          onPayment={() => onPayment(loan)}
+          onRefresh={onRefresh}
+        />
+      ))}
+    </VStack>
+  )
+}

--- a/components/loans/LoanPaymentForm.tsx
+++ b/components/loans/LoanPaymentForm.tsx
@@ -4,9 +4,12 @@ import { useState } from 'react'
 import { VStack, Button, Text } from '@chakra-ui/react'
 import { FormDialog } from '@/components/ui/FormDialog'
 import { InputAmount } from '@/components/ui/InputAmount'
+import { DateInput } from '@/components/ui/DateInput'
+import { FormTextarea } from '@/components/ui/FormTextarea'
 import { addLoanPayment } from '@/lib/actions/loans.actions'
 import { toaster } from '@/lib/toaster'
 import { formatCurrency } from '@/lib/utils/currency'
+import { getLocalDateString } from '@/lib/utils/dates'
 import type { LoanWithAccount } from '@/types/database.types'
 
 interface Props {
@@ -19,6 +22,8 @@ interface Props {
 
 export function LoanPaymentForm({ isOpen, onClose, loan, userId, onSuccess }: Props) {
   const [amount, setAmount] = useState<number | undefined>(undefined)
+  const [date, setDate] = useState(getLocalDateString())
+  const [notes, setNotes] = useState('')
   const [loading, setLoading] = useState(false)
 
   const remaining = Number(loan.amount) - Number(loan.paid_amount ?? 0)
@@ -39,13 +44,15 @@ export function LoanPaymentForm({ isOpen, onClose, loan, userId, onSuccess }: Pr
     }
 
     setLoading(true)
-    const result = await addLoanPayment(userId, loan.id, amount)
+    const result = await addLoanPayment(userId, loan.id, amount, date || undefined, notes || undefined)
     setLoading(false)
 
     if (result.success) {
       const msg = result.settled ? 'Préstamo saldado completamente' : 'Abono registrado'
       toaster.create({ title: msg, type: 'success', duration: 3000 })
       setAmount(undefined)
+      setDate(getLocalDateString())
+      setNotes('')
       onClose()
       onSuccess()
     } else {
@@ -61,7 +68,10 @@ export function LoanPaymentForm({ isOpen, onClose, loan, userId, onSuccess }: Pr
     >
       <VStack gap={4} align="stretch">
         <Text fontSize="sm" color="#B0B0B0">
-          Saldo pendiente: <Text as="span" color="white" fontWeight="600">{formatCurrency(remaining, loan.currency)}</Text>
+          Saldo pendiente:{' '}
+          <Text as="span" color="white" fontWeight="600">
+            {formatCurrency(remaining, loan.currency)}
+          </Text>
         </Text>
 
         <InputAmount
@@ -69,6 +79,20 @@ export function LoanPaymentForm({ isOpen, onClose, loan, userId, onSuccess }: Pr
           value={amount}
           onChange={setAmount}
           isRequired
+        />
+
+        <DateInput
+          label="Fecha del abono"
+          value={date}
+          onChange={setDate}
+          required
+        />
+
+        <FormTextarea
+          label="Notas (opcional)"
+          value={notes}
+          onChange={setNotes}
+          placeholder="Ej: Transferencia Bancolombia"
         />
 
         <Button

--- a/lib/actions/loans.actions.ts
+++ b/lib/actions/loans.actions.ts
@@ -16,6 +16,62 @@ export async function getLoans(userId: string) {
   return { success: true, data }
 }
 
+export async function getLoanPayments(userId: string, loanId: string) {
+  const { data, error } = await insforgeAdmin.database
+    .from('loan_payments')
+    .select('*')
+    .eq('loan_id', loanId)
+    .eq('user_id', userId)
+    .order('date', { ascending: false })
+
+  if (error) return { success: false, error: error.message }
+  return { success: true, data }
+}
+
+export async function deleteLoanPayment(userId: string, paymentId: string) {
+  const { data: payment, error: fetchErr } = await insforgeAdmin.database
+    .from('loan_payments')
+    .select('*, loan:loans(*)')
+    .eq('id', paymentId)
+    .eq('user_id', userId)
+    .single()
+
+  if (fetchErr || !payment) return { success: false, error: 'Pago no encontrado' }
+
+  const loan = payment.loan
+  if (!loan) return { success: false, error: 'Deuda no encontrada' }
+
+  // Reverse balance: payment was subtracted/added before — reverse it
+  if (loan.account_id) {
+    await applyBalanceDelta(
+      loan.account_id,
+      payment.amount,
+      payment.currency,
+      loan.type === 'lent' ? 'subtract' : 'add'
+    )
+  }
+
+  // Decrease paid_amount on loan
+  const newPaid = Math.max(0, Number(loan.paid_amount) - Number(payment.amount))
+  await insforgeAdmin.database
+    .from('loans')
+    .update({ paid_amount: newPaid, status: 'active', updated_at: new Date().toISOString() })
+    .eq('id', loan.id)
+    .eq('user_id', userId)
+
+  const { error } = await insforgeAdmin.database
+    .from('loan_payments')
+    .delete()
+    .eq('id', paymentId)
+    .eq('user_id', userId)
+
+  if (error) return { success: false, error: error.message }
+
+  revalidatePath('/loans')
+  revalidatePath('/dashboard')
+  return { success: true }
+}
+
 export async function createLoan(userId: string, input: LoanFormData) {
   const parsed = loanSchema.safeParse(input)
   if (!parsed.success) return { success: false, error: parsed.error.issues[0].message }
@@ -125,7 +181,9 @@ export async function deleteLoan(userId: string, loanId: string) {
 export async function addLoanPayment(
   userId: string,
   loanId: string,
-  paymentAmount: number
+  paymentAmount: number,
+  paymentDate?: string,
+  paymentNotes?: string
 ) {
   const { data: loan, error: fetchErr } = await insforgeAdmin.database
     .from('loans')
@@ -141,7 +199,7 @@ export async function addLoanPayment(
   const newPaid = currentPaid + paymentAmount
   const loanAmount = Number(loan.amount)
 
-  // Apply balance delta: lent = I got partial payment back (add); borrowed = I paid partial (subtract)
+  // Apply balance delta
   if (loan.account_id) {
     await applyBalanceDelta(
       loan.account_id,
@@ -151,37 +209,37 @@ export async function addLoanPayment(
     )
   }
 
-  if (newPaid >= loanAmount) {
-    // Fully settled via partial payments
-    const { error } = await insforgeAdmin.database
-      .from('loans')
-      .update({
-        paid_amount: loanAmount,
-        status: 'settled',
-        settled_at: new Date().toISOString(),
-        updated_at: new Date().toISOString(),
-      })
-      .eq('id', loanId)
-      .eq('user_id', userId)
+  // Insert payment record
+  await insforgeAdmin.database
+    .from('loan_payments')
+    .insert({
+      loan_id: loanId,
+      user_id: userId,
+      amount: paymentAmount,
+      currency: loan.currency,
+      date: paymentDate ?? new Date().toISOString().split('T')[0],
+      notes: paymentNotes ?? null,
+    })
 
-    if (error) return { success: false, error: error.message }
-  } else {
-    const { error } = await insforgeAdmin.database
-      .from('loans')
-      .update({
-        paid_amount: newPaid,
-        updated_at: new Date().toISOString(),
-      })
-      .eq('id', loanId)
-      .eq('user_id', userId)
+  const isSettled = newPaid >= loanAmount
 
-    if (error) return { success: false, error: error.message }
-  }
+  const { error } = await insforgeAdmin.database
+    .from('loans')
+    .update({
+      paid_amount: isSettled ? loanAmount : newPaid,
+      status: isSettled ? 'settled' : 'active',
+      ...(isSettled ? { settled_at: new Date().toISOString() } : {}),
+      updated_at: new Date().toISOString(),
+    })
+    .eq('id', loanId)
+    .eq('user_id', userId)
+
+  if (error) return { success: false, error: error.message }
 
   revalidatePath('/loans')
   revalidatePath('/movimientos')
   revalidatePath('/dashboard')
-  return { success: true, settled: newPaid >= loanAmount }
+  return { success: true, settled: isSettled }
 }
 
 export async function settleLoan(userId: string, loanId: string) {
@@ -195,20 +253,37 @@ export async function settleLoan(userId: string, loanId: string) {
   if (fetchErr || !loan) return { success: false, error: 'Préstamo no encontrado' }
   if (loan.status === 'settled') return { success: false, error: 'Ya está saldado' }
 
+  const remaining = Number(loan.amount) - Number(loan.paid_amount ?? 0)
+
   // lent settled = I got paid back → add money back
   // borrowed settled = I paid back → subtract money
-  if (loan.account_id) {
+  if (loan.account_id && remaining > 0) {
     await applyBalanceDelta(
       loan.account_id,
-      loan.amount,
+      remaining,
       loan.currency,
       loan.type === 'lent' ? 'add' : 'subtract'
     )
   }
 
+  // Insert final payment record for the remaining amount
+  if (remaining > 0) {
+    await insforgeAdmin.database
+      .from('loan_payments')
+      .insert({
+        loan_id: loanId,
+        user_id: userId,
+        amount: remaining,
+        currency: loan.currency,
+        date: new Date().toISOString().split('T')[0],
+        notes: 'Saldo final',
+      })
+  }
+
   const { error } = await insforgeAdmin.database
     .from('loans')
     .update({
+      paid_amount: Number(loan.amount),
       status: 'settled',
       settled_at: new Date().toISOString(),
       updated_at: new Date().toISOString(),

--- a/supabase/seeds/loan-payments-v3.0.sql
+++ b/supabase/seeds/loan-payments-v3.0.sql
@@ -1,0 +1,26 @@
+-- Migration: loan_payments table for detailed payment history
+-- Run this against your InsForge/Supabase database
+
+CREATE TABLE IF NOT EXISTS loan_payments (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  loan_id uuid NOT NULL REFERENCES loans(id) ON DELETE CASCADE,
+  user_id uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  amount numeric(18, 2) NOT NULL CHECK (amount > 0),
+  currency text NOT NULL DEFAULT 'COP',
+  date date NOT NULL DEFAULT CURRENT_DATE,
+  notes text,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- Index for fast lookups by loan
+CREATE INDEX IF NOT EXISTS loan_payments_loan_id_idx ON loan_payments(loan_id);
+CREATE INDEX IF NOT EXISTS loan_payments_user_id_idx ON loan_payments(user_id);
+
+-- Row Level Security (same pattern as other tables)
+ALTER TABLE loan_payments ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can manage their own loan payments"
+  ON loan_payments
+  FOR ALL
+  USING (user_id = auth.uid())
+  WITH CHECK (user_id = auth.uid());

--- a/types/database.types.ts
+++ b/types/database.types.ts
@@ -179,3 +179,14 @@ export interface Loan {
 export interface LoanWithAccount extends Loan {
   account: Pick<Account, 'id' | 'name' | 'currency' | 'icon'> | null
 }
+
+export interface LoanPayment {
+  id: string
+  loan_id: string
+  user_id: string
+  amount: number
+  currency: Currency
+  date: string
+  notes: string | null
+  created_at: string
+}


### PR DESCRIPTION
## Cambios — Tarea 3.1

### DB
- Nueva tabla `loan_payments` — migration en `supabase/seeds/loan-payments-v3.0.sql`
  - ⚠️ Requiere ejecutar este SQL en la base de datos antes de usar la nueva funcionalidad

### Backend
- Nuevo tipo `LoanPayment` en `types/database.types.ts`
- `addLoanPayment` ahora acepta `date` y `notes`, e inserta en `loan_payments` además de actualizar `paid_amount`
- `settleLoan` inserta el saldo final como registro de pago
- Nuevas funciones: `getLoanPayments`, `deleteLoanPayment` (con reversión de balance)

### UI
- **`LoanCards`** reemplaza `LoansTable`: cards con barra de progreso de pago y acordeón desplegable
  - Barra de progreso morado/verde según porcentaje pagado
  - Botón "Ver historial de abonos" que expande y carga el historial desde la BD
  - Soporte legacy: deudas con `paid_amount > 0` sin registros en `loan_payments` muestran "Historial previo"
  - Se puede eliminar un abono (revierte el balance de la cuenta)
- **`LoanPaymentForm`** ahora incluye campos de Fecha y Notas del abono

## Testing
- ✅ TypeScript compila sin errores

Closes #379
Related to #378

---
_Generated by [Claude Code](https://claude.ai/code/session_01XPgXLQwAtTpgt2K7VWVnAw)_