### PR TITLE
fix: calcular periodo activo de presupuesto desde start_date

### DIFF
--- a/lib/actions/budgets.actions.ts
+++ b/lib/actions/budgets.actions.ts
@@ -35,15 +35,42 @@ export async function getBudgets(userId: string) {
 
     const budgetsWithSpent = budgets.map((budget) => {
       const now = new Date()
+      const start = new Date(budget.start_date)
 
       let periodStart: Date, periodEnd: Date
 
       if (budget.period === 'monthly') {
-        periodStart = new Date(now.getFullYear(), now.getMonth(), 1)
-        periodEnd = new Date(now.getFullYear(), now.getMonth() + 1, 0, 23, 59, 59)
+        // Calculate how many full months have elapsed since start_date
+        let monthsElapsed =
+          (now.getFullYear() - start.getFullYear()) * 12 +
+          (now.getMonth() - start.getMonth())
+        // If today's day is before the start day, we're in the previous cycle
+        if (now.getDate() < start.getDate()) monthsElapsed--
+
+        if (monthsElapsed < 0) {
+          // Budget starts in the future — no active period yet
+          periodStart = start
+          periodEnd = new Date(start.getFullYear(), start.getMonth() + 1, start.getDate() - 1, 23, 59, 59)
+        } else {
+          periodStart = new Date(start.getFullYear(), start.getMonth() + monthsElapsed, start.getDate())
+          periodEnd = new Date(start.getFullYear(), start.getMonth() + monthsElapsed + 1, start.getDate() - 1, 23, 59, 59)
+        }
       } else {
-        periodStart = new Date(now.getFullYear(), 0, 1)
-        periodEnd = new Date(now.getFullYear(), 11, 31, 23, 59, 59)
+        // yearly
+        let yearsElapsed = now.getFullYear() - start.getFullYear()
+        const pastAnniversary =
+          now.getMonth() > start.getMonth() ||
+          (now.getMonth() === start.getMonth() && now.getDate() >= start.getDate())
+        if (!pastAnniversary) yearsElapsed--
+
+        if (yearsElapsed < 0) {
+          // Budget starts in the future
+          periodStart = start
+          periodEnd = new Date(start.getFullYear() + 1, start.getMonth(), start.getDate() - 1, 23, 59, 59)
+        } else {
+          periodStart = new Date(start.getFullYear() + yearsElapsed, start.getMonth(), start.getDate())
+          periodEnd = new Date(start.getFullYear() + yearsElapsed + 1, start.getMonth(), start.getDate() - 1, 23, 59, 59)
+        }
       }
 
       const spent = (transactions || [])
@@ -60,6 +87,8 @@ export async function getBudgets(userId: string) {
       return {
         ...budget,
         spent,
+        periodStart: periodStart.toISOString().split('T')[0],
+        periodEnd: periodEnd.toISOString().split('T')[0],
       }
     })
 


### PR DESCRIPTION
## Cambios — Tarea 3.2

### Problema
`getBudgets` calculaba el periodo siempre sobre el mes/año actual, ignorando `start_date`. Un presupuesto con fecha futura mostraba gastos del mes actual.

### Fix
El periodo activo se calcula relativo a `start_date`:
- **Mensual:** `periodStart = start_date + N meses completos`, donde N es el número de ciclos transcurridos desde `start_date` hasta hoy
- **Anual:** igual pero con años
- Si `start_date` es en el futuro: `spent = 0` (ninguna transacción cae en ese periodo futuro)

### Ejemplo
- `start_date = 2026-08-01`, `period = monthly`, hoy = 2026-05-20
- Periodo activo: 2026-08-01 → 2026-08-31 → `spent = 0`

### Bonus
`getBudgets` ahora devuelve `periodStart` y `periodEnd` (ISO date string) para que la UI pueda mostrar el rango del periodo activo si se desea.

## Testing
- ✅ TypeScript compila sin errores

Closes #380
Related to #378

---
_Generated by [Claude Code](https://claude.ai/code/session_01XPgXLQwAtTpgt2K7VWVnAw)_