### PR TITLE
FASE 4 — Tipo de cuenta Tarjeta de Crédito

### DIFF
--- a/components/settings/AccountForm.tsx
+++ b/components/settings/AccountForm.tsx
@@ -19,6 +19,7 @@ const TYPE_OPTIONS = [
   { value: 'digital', label: 'Digital' },
   { value: 'crypto', label: 'Crypto' },
   { value: 'cash', label: 'Efectivo' },
+  { value: 'card', label: 'Tarjeta de Crédito' },
 ]
 
 interface Props {
@@ -31,9 +32,10 @@ interface Props {
 
 const defaultForm = {
   name: '',
-  type: 'bank' as 'bank' | 'digital' | 'crypto' | 'cash',
+  type: 'bank' as 'bank' | 'digital' | 'crypto' | 'cash' | 'card',
   currency: 'COP' as Currency,
   balance: 0 as number | undefined,
+  credit_limit: undefined as number | undefined,
   icon: '💳',
   color: '#6366f1',
 }
@@ -49,6 +51,7 @@ export function AccountForm({ isOpen, onClose, userId, editingAccount, onSuccess
         type: editingAccount.type,
         currency: editingAccount.currency as Currency,
         balance: Number(editingAccount.balance) as number | undefined,
+        credit_limit: editingAccount.credit_limit != null ? Number(editingAccount.credit_limit) : undefined,
         icon: editingAccount.icon ?? '💳',
         color: editingAccount.color ?? '#6366f1',
       })
@@ -61,11 +64,13 @@ export function AccountForm({ isOpen, onClose, userId, editingAccount, onSuccess
     e.preventDefault()
     setLoading(true)
 
+    const isCard = formData.type === 'card'
     const data = {
       name: formData.name,
       type: formData.type,
       currency: formData.currency,
-      balance: formData.balance ?? 0,
+      balance: isCard ? (formData.credit_limit ?? 0) : (formData.balance ?? 0),
+      credit_limit: isCard ? (formData.credit_limit ?? null) : null,
       icon: formData.icon || null,
       color: formData.color || null,
     }
@@ -87,6 +92,8 @@ export function AccountForm({ isOpen, onClose, userId, editingAccount, onSuccess
     }
     setLoading(false)
   }
+
+  const isCard = formData.type === 'card'
 
   return (
     <FormDialog
@@ -119,11 +126,20 @@ export function AccountForm({ isOpen, onClose, userId, editingAccount, onSuccess
             required
           />
 
-          <InputAmount
-            label={editingAccount ? 'Balance actual' : 'Balance inicial'}
-            value={formData.balance}
-            onChange={(v) => setFormData({ ...formData, balance: v })}
-          />
+          {isCard ? (
+            <InputAmount
+              label="Cupo total"
+              value={formData.credit_limit}
+              onChange={(v) => setFormData({ ...formData, credit_limit: v })}
+              isRequired
+            />
+          ) : (
+            <InputAmount
+              label={editingAccount ? 'Balance actual' : 'Balance inicial'}
+              value={formData.balance}
+              onChange={(v) => setFormData({ ...formData, balance: v })}
+            />
+          )}
 
           <HStack gap={4} w="full">
             <FieldRoot>

--- a/components/settings/AccountMovementForm.tsx
+++ b/components/settings/AccountMovementForm.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { VStack } from '@chakra-ui/react'
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { createAccountMovement } from '@/lib/actions/account_movements.actions'
 import { toaster } from '@/lib/toaster'
 import { FormDialog } from '@/components/ui/FormDialog'
@@ -20,6 +20,7 @@ interface Props {
   userId: string
   accounts: Account[]
   onSuccess: () => void
+  preselectedToAccountId?: string
 }
 
 const defaultForm = {
@@ -33,9 +34,35 @@ const defaultForm = {
   date: getLocalDateString(),
 }
 
-export function AccountMovementForm({ isOpen, onClose, userId, accounts, onSuccess }: Props) {
+export function AccountMovementForm({ isOpen, onClose, userId, accounts, onSuccess, preselectedToAccountId }: Props) {
   const [loading, setLoading] = useState(false)
   const [formData, setFormData] = useState(defaultForm)
+
+  useEffect(() => {
+    if (isOpen) {
+      const toAccount = preselectedToAccountId
+        ? accounts.find((a) => a.id === preselectedToAccountId)
+        : undefined
+      setFormData({
+        ...defaultForm,
+        to_account_id: preselectedToAccountId ?? '',
+        to_currency: toAccount ? (toAccount.currency as Currency) : 'COP',
+        date: getLocalDateString(),
+      })
+    }
+  }, [isOpen, preselectedToAccountId, accounts])
+
+  const toAccount = accounts.find((a) => a.id === formData.to_account_id)
+  const isCardPayment = toAccount?.type === 'card'
+
+  const handleToAccountChange = (v: string) => {
+    const acc = accounts.find((a) => a.id === v)
+    setFormData((prev) => ({
+      ...prev,
+      to_account_id: v,
+      to_currency: acc ? (acc.currency as Currency) : prev.to_currency,
+    }))
+  }
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -53,7 +80,7 @@ export function AccountMovementForm({ isOpen, onClose, userId, accounts, onSucce
     })
 
     if (result.success) {
-      toaster.create({ title: 'Movimiento registrado', type: 'success', duration: 3000 })
+      toaster.create({ title: isCardPayment ? 'Pago de tarjeta registrado' : 'Movimiento registrado', type: 'success', duration: 3000 })
       onSuccess()
       onClose()
       setFormData(defaultForm)
@@ -64,7 +91,7 @@ export function AccountMovementForm({ isOpen, onClose, userId, accounts, onSucce
   }
 
   return (
-    <FormDialog isOpen={isOpen} onClose={onClose} title="Nuevo Movimiento entre Cuentas">
+    <FormDialog isOpen={isOpen} onClose={onClose} title={isCardPayment ? 'Pago de Tarjeta' : 'Nuevo Movimiento entre Cuentas'}>
       <form onSubmit={handleSubmit}>
         <VStack gap={4}>
           <AccountSelect
@@ -74,6 +101,7 @@ export function AccountMovementForm({ isOpen, onClose, userId, accounts, onSucce
             label="Cuenta origen"
             required
             placeholder="Seleccionar..."
+            excludeId={formData.to_account_id}
           />
 
           <InputAmount
@@ -92,16 +120,16 @@ export function AccountMovementForm({ isOpen, onClose, userId, accounts, onSucce
 
           <AccountSelect
             value={formData.to_account_id}
-            onChange={(v) => setFormData({ ...formData, to_account_id: v })}
+            onChange={handleToAccountChange}
             accounts={accounts}
-            label="Cuenta destino"
+            label={isCardPayment ? 'Tarjeta a pagar' : 'Cuenta destino'}
             required
             placeholder="Seleccionar..."
             excludeId={formData.from_account_id}
           />
 
           <InputAmount
-            label="Monto recibido"
+            label={isCardPayment ? 'Monto del pago' : 'Monto recibido'}
             value={formData.to_amount}
             onChange={(v) => setFormData({ ...formData, to_amount: v })}
             isRequired
@@ -118,7 +146,7 @@ export function AccountMovementForm({ isOpen, onClose, userId, accounts, onSucce
             label="Descripción (opcional)"
             value={formData.description}
             onChange={(v) => setFormData({ ...formData, description: v })}
-            placeholder="Ej: Cambio de dólares"
+            placeholder={isCardPayment ? 'Ej: Pago mensual tarjeta' : 'Ej: Cambio de dólares'}
           />
 
           <DateInput
@@ -129,7 +157,7 @@ export function AccountMovementForm({ isOpen, onClose, userId, accounts, onSucce
           />
 
           <PrimaryButton type="submit" width="full" loading={loading}>
-            Registrar Movimiento
+            {isCardPayment ? 'Registrar Pago' : 'Registrar Movimiento'}
           </PrimaryButton>
         </VStack>
       </form>

--- a/components/settings/AccountsTab.tsx
+++ b/components/settings/AccountsTab.tsx
@@ -30,6 +30,7 @@ const ACCOUNT_TYPE_LABELS: Record<string, string> = {
   digital: 'Digital',
   crypto: 'Crypto',
   cash: 'Efectivo',
+  card: 'Tarjeta de Crédito',
 }
 
 interface Props {
@@ -45,6 +46,7 @@ export function AccountsTab({ userId, initialAccounts, initialMovements }: Props
   const [isAccountFormOpen, setIsAccountFormOpen] = useState(false)
   const [isMovementFormOpen, setIsMovementFormOpen] = useState(false)
   const [editingAccount, setEditingAccount] = useState<Account | null>(null)
+  const [preselectedToAccountId, setPreselectedToAccountId] = useState<string | undefined>(undefined)
   const [deletingAccountId, setDeletingAccountId] = useState<string | null>(null)
   const [deletingMovementId, setDeletingMovementId] = useState<string | null>(null)
   const [deleteLoading, setDeleteLoading] = useState(false)
@@ -215,9 +217,38 @@ export function AccountsTab({ userId, initialAccounts, initialMovements }: Props
                       </IconButton>
                     </HStack>
                   </HStack>
-                  <Text fontWeight="bold" fontSize="lg" color="white">
-                    {formatCurrency(acc.balance, acc.currency as any)}
-                  </Text>
+                  {acc.type === 'card' && acc.credit_limit != null ? (
+                    <VStack align="stretch" gap={1}>
+                      <HStack justify="space-between">
+                        <Text fontSize="xs" color="#B0B0B0">Cupo disponible</Text>
+                        <Text fontWeight="bold" fontSize="md" color="white">
+                          {formatCurrency(acc.balance, acc.currency as any)}
+                        </Text>
+                      </HStack>
+                      <HStack justify="space-between">
+                        <Text fontSize="xs" color="#B0B0B0">Cupo total</Text>
+                        <Text fontSize="sm" color="#B0B0B0">
+                          {formatCurrency(acc.credit_limit, acc.currency as any)}
+                        </Text>
+                      </HStack>
+                      <Button
+                        size="xs"
+                        variant="outline"
+                        colorPalette="purple"
+                        mt={1}
+                        onClick={() => {
+                          setPreselectedToAccountId(acc.id)
+                          setIsMovementFormOpen(true)
+                        }}
+                      >
+                        Pagar tarjeta
+                      </Button>
+                    </VStack>
+                  ) : (
+                    <Text fontWeight="bold" fontSize="lg" color="white">
+                      {formatCurrency(acc.balance, acc.currency as any)}
+                    </Text>
+                  )}
                 </VStack>
               </Box>
             ))}
@@ -268,10 +299,11 @@ export function AccountsTab({ userId, initialAccounts, initialMovements }: Props
 
       <AccountMovementForm
         isOpen={isMovementFormOpen}
-        onClose={() => setIsMovementFormOpen(false)}
+        onClose={() => { setIsMovementFormOpen(false); setPreselectedToAccountId(undefined) }}
         userId={userId}
         accounts={accounts}
         onSuccess={handleMovementSuccess}
+        preselectedToAccountId={preselectedToAccountId}
       />
 
       <ConfirmDialog

--- a/components/transactions/TransactionForm.tsx
+++ b/components/transactions/TransactionForm.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { VStack, Box, SimpleGrid, Button } from '@chakra-ui/react'
+import { VStack, Box, SimpleGrid, Button, Text } from '@chakra-ui/react'
 import { useState, useEffect } from 'react'
 import { FiPlus } from 'react-icons/fi'
 import { createTransaction } from '@/lib/actions/transactions.actions'
@@ -19,6 +19,7 @@ import { CurrencyPreview } from './CurrencyPreview'
 import { QuickCategoryForm } from '@/components/categories/QuickCategoryForm'
 import type { Account, Category, Currency } from '@/types/database.types'
 import { getLocalDateString } from '@/lib/utils/dates'
+import { formatCurrency } from '@/lib/utils/currency'
 
 const TYPE_OPTIONS = [
   { value: 'expense', label: 'Gasto' },
@@ -70,6 +71,13 @@ export function TransactionForm({ isOpen, onClose, userId, categories, accounts 
   }
 
   const accountLocksCurrency = !!formData.account_id
+
+  const selectedAccount = accounts.find((a) => a.id === formData.account_id)
+  const cardOverLimit =
+    formData.type === 'expense' &&
+    selectedAccount?.type === 'card' &&
+    formData.amount != null &&
+    formData.amount > (selectedAccount.balance ?? 0)
 
   const handleCategoryCreated = (newCategory: Category) => {
     setLocalCategories((prev) => [...prev, newCategory])
@@ -144,6 +152,14 @@ export function TransactionForm({ isOpen, onClose, userId, categories, accounts 
                 required
                 disabled={accountLocksCurrency}
               />
+            )}
+
+            {cardOverLimit && (
+              <Box w="full" bg="#7f1d1d" borderRadius="md" px={3} py={2}>
+                <Text fontSize="sm" color="#fca5a5">
+                  El monto excede el cupo disponible ({formatCurrency(selectedAccount!.balance, selectedAccount!.currency as any)})
+                </Text>
+              </Box>
             )}
 
             <Box w="full">

--- a/lib/actions/accounts.actions.ts
+++ b/lib/actions/accounts.actions.ts
@@ -31,6 +31,11 @@ export async function createAccount(userId: string, data: CreateAccountInput) {
   try {
     const validated = createAccountSchema.parse(data)
 
+    // For card accounts, balance starts equal to credit_limit (available credit)
+    if (validated.type === 'card' && validated.credit_limit != null) {
+      validated.balance = validated.credit_limit
+    }
+
     const { data: account, error } = await insforgeAdmin.database
       .from('accounts')
       .insert([{ ...validated, user_id: userId }])

--- a/lib/validations/account.ts
+++ b/lib/validations/account.ts
@@ -2,9 +2,10 @@ import { z } from 'zod'
 
 export const createAccountSchema = z.object({
   name: z.string().min(1, 'El nombre es requerido'),
-  type: z.enum(['bank', 'digital', 'crypto', 'cash']),
+  type: z.enum(['bank', 'digital', 'crypto', 'cash', 'card']),
   currency: z.enum(['COP', 'USD', 'VES']),
   balance: z.number().default(0),
+  credit_limit: z.number().positive().nullable().optional(),
   color: z.string().nullable().optional(),
   icon: z.string().nullable().optional(),
 })

--- a/supabase/seeds/accounts-card-type-v3.0.sql
+++ b/supabase/seeds/accounts-card-type-v3.0.sql
@@ -1,0 +1,8 @@
+-- Migration: add credit_limit column and card type to accounts
+-- Run this against your InsForge/Supabase database
+
+ALTER TABLE accounts
+  ADD COLUMN IF NOT EXISTS credit_limit numeric(18, 2) DEFAULT NULL;
+
+-- The 'type' column is text, so 'card' is already valid without enum changes.
+-- No additional SQL needed for the type field.

--- a/types/database.types.ts
+++ b/types/database.types.ts
@@ -31,7 +31,7 @@ export interface Category {
   created_at: string
 }
 
-export type AccountType = 'bank' | 'digital' | 'crypto' | 'cash'
+export type AccountType = 'bank' | 'digital' | 'crypto' | 'cash' | 'card'
 
 export interface Account {
   id: string
@@ -40,6 +40,7 @@ export interface Account {
   type: AccountType
   currency: Currency
   balance: number
+  credit_limit: number | null
   color: string | null
   icon: string | null
   is_active: boolean


### PR DESCRIPTION
## FASE 4 — Tipo de cuenta: Tarjeta de Crédito

### Cambios incluidos

**Tarea 4.1 — Nuevo tipo 'card' con campo credit_limit**
- `AccountType` ahora incluye `'card'` (Tarjeta de Crédito)
- `Account` tiene campo `credit_limit: number | null`
- Al crear una tarjeta, el balance inicial = credit_limit (balance = cupo disponible siempre positivo)
- `AccountForm` muestra campo "Cupo total" (en lugar de balance) para cuentas tipo tarjeta
- SQL: `ALTER TABLE accounts ADD COLUMN IF NOT EXISTS credit_limit numeric(18,2) DEFAULT NULL`

**Tarea 4.2 — Advertencia al exceder cupo**
- `TransactionForm` muestra alerta roja si el monto de un gasto supera el cupo disponible de la tarjeta seleccionada

**Tarea 4.3 — Pago de tarjeta**
- Cards de tipo tarjeta en `AccountsTab` muestran "Cupo disponible / Cupo total"
- Botón "Pagar tarjeta" en la card abre el modal de movimiento con la tarjeta preseleccionada como destino
- `AccountMovementForm` detecta destino tipo tarjeta y adapta título/etiquetas a "Pago de Tarjeta"

### Migración requerida
```sql
ALTER TABLE accounts
  ADD COLUMN IF NOT EXISTS credit_limit numeric(18, 2) DEFAULT NULL;
```
✅ Ya aplicada en producción.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XPgXLQwAtTpgt2K7VWVnAw)_