### PR TITLE
feat: calendario de recordatorios — BD, CRUD y tab Programado (FASE 6)

### DIFF
--- a/app/(dashboard)/calendar/page.tsx
+++ b/app/(dashboard)/calendar/page.tsx
@@ -6,7 +6,9 @@ import { CalendarPageContent } from '@/components/calendar/CalendarPageContent'
 import { getTransactions } from '@/lib/actions/transactions.actions'
 import { getCategories } from '@/lib/actions/categories.actions'
 import { getAccounts } from '@/lib/actions/accounts.actions'
-import type { TransactionWithCategory, Account } from '@/types/database.types'
+import { getReminders } from '@/lib/actions/reminders.actions'
+import { getRecurringTransactions } from '@/lib/actions/recurring.actions'
+import type { TransactionWithCategory, Account, ReminderWithCategory, RecurringTransactionWithCategory } from '@/types/database.types'
 
 export default async function CalendarPage() {
   const session = await getServerSession(authOptions)
@@ -26,15 +28,19 @@ export default async function CalendarPage() {
     redirect('/login')
   }
 
-  const [transactionsResult, categoriesResult, accountsResult] = await Promise.all([
+  const [transactionsResult, categoriesResult, accountsResult, remindersResult, recurringResult] = await Promise.all([
     getTransactions(user.id, 1000),
     getCategories(user.id),
     getAccounts(user.id),
+    getReminders(user.id),
+    getRecurringTransactions(user.id, 200),
   ])
 
   const transactions: TransactionWithCategory[] = transactionsResult.success ? (transactionsResult.data ?? []) : []
   const categories = categoriesResult.success ? (categoriesResult.data ?? []) : []
   const accounts = (accountsResult.success ? accountsResult.data : []) as Account[]
+  const reminders = (remindersResult.success ? remindersResult.data : []) as ReminderWithCategory[]
+  const recurringTransactions = (recurringResult.success ? recurringResult.data : []) as RecurringTransactionWithCategory[]
 
   return (
     <CalendarPageContent
@@ -42,6 +48,8 @@ export default async function CalendarPage() {
       initialTransactions={transactions}
       categories={categories}
       accounts={accounts}
+      reminders={reminders}
+      recurringTransactions={recurringTransactions}
     />
   )
 }

--- a/components/calendar/CalendarPageContent.tsx
+++ b/components/calendar/CalendarPageContent.tsx
@@ -1,30 +1,95 @@
 'use client'
 
-import { VStack, Heading } from '@chakra-ui/react'
+import { VStack, HStack, Heading, Box, Text, Button } from '@chakra-ui/react'
+import { useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { TransactionCalendar } from '@/components/calendar/TransactionCalendar'
-import type { TransactionWithCategory, Account, Category } from '@/types/database.types'
+import { RemindersCalendar } from '@/components/calendar/RemindersCalendar'
+import { RemindersList } from '@/components/reminders/RemindersList'
+import type { TransactionWithCategory, Account, Category, ReminderWithCategory, RecurringTransactionWithCategory } from '@/types/database.types'
 
 interface Props {
   userId: string
   initialTransactions: TransactionWithCategory[]
   categories: Category[]
   accounts: Account[]
+  reminders: ReminderWithCategory[]
+  recurringTransactions: RecurringTransactionWithCategory[]
 }
 
-export function CalendarPageContent({ userId, initialTransactions, categories, accounts }: Props) {
+type Tab = 'transactions' | 'scheduled'
+
+export function CalendarPageContent({ userId, initialTransactions, categories, accounts, reminders, recurringTransactions }: Props) {
   const router = useRouter()
+  const [activeTab, setActiveTab] = useState<Tab>('transactions')
 
   return (
-    <VStack alignItems="flex-start" gap={6}>
-      <Heading size="lg">Calendario de Transacciones</Heading>
-      <TransactionCalendar
-        userId={userId}
-        initialTransactions={initialTransactions}
-        categories={categories}
-        accounts={accounts}
-        onTransactionCreated={() => router.refresh()}
-      />
+    <VStack alignItems="flex-start" gap={6} w="full">
+      <Heading size="lg">Calendario</Heading>
+
+      {/* Tab bar */}
+      <HStack gap={0} borderWidth="1px" borderRadius="lg" borderColor="#2d2d35" overflow="hidden" w="fit-content">
+        <Button
+          size="sm"
+          variant="ghost"
+          px={5}
+          py={2}
+          borderRadius="0"
+          bg={activeTab === 'transactions' ? '#4F46E5' : 'transparent'}
+          color={activeTab === 'transactions' ? 'white' : '#B0B0B0'}
+          _hover={{ bg: activeTab === 'transactions' ? '#4338CA' : '#1a1a23' }}
+          onClick={() => setActiveTab('transactions')}
+        >
+          📅 Transacciones
+        </Button>
+        <Box w="1px" bg="#2d2d35" h="full" />
+        <Button
+          size="sm"
+          variant="ghost"
+          px={5}
+          py={2}
+          borderRadius="0"
+          bg={activeTab === 'scheduled' ? '#4F46E5' : 'transparent'}
+          color={activeTab === 'scheduled' ? 'white' : '#B0B0B0'}
+          _hover={{ bg: activeTab === 'scheduled' ? '#4338CA' : '#1a1a23' }}
+          onClick={() => setActiveTab('scheduled')}
+        >
+          🔔 Programado
+        </Button>
+      </HStack>
+
+      {activeTab === 'transactions' && (
+        <TransactionCalendar
+          userId={userId}
+          initialTransactions={initialTransactions}
+          categories={categories}
+          accounts={accounts}
+          onTransactionCreated={() => router.refresh()}
+        />
+      )}
+
+      {activeTab === 'scheduled' && (
+        <VStack gap={6} align="stretch" w="full">
+          <Text fontSize="sm" color="#B0B0B0">
+            Visualiza tus recordatorios y suscripciones recurrentes. Haz clic en un recordatorio del día de hoy para registrar la transacción.
+          </Text>
+
+          <RemindersCalendar
+            userId={userId}
+            reminders={reminders}
+            recurringTransactions={recurringTransactions}
+            categories={categories}
+            accounts={accounts}
+          />
+
+          <RemindersList
+            userId={userId}
+            reminders={reminders}
+            categories={categories}
+            onRefresh={() => router.refresh()}
+          />
+        </VStack>
+      )}
     </VStack>
   )
 }

--- a/components/calendar/RemindersCalendar.tsx
+++ b/components/calendar/RemindersCalendar.tsx
@@ -1,0 +1,341 @@
+'use client'
+
+import {
+  Box,
+  Button,
+  Grid,
+  HStack,
+  Text,
+  VStack,
+  Badge,
+  useBreakpointValue,
+} from '@chakra-ui/react'
+import { useState } from 'react'
+import { FiPlus } from 'react-icons/fi'
+import type { ReminderWithCategory, RecurringTransactionWithCategory, Account, Category } from '@/types/database.types'
+import { formatCurrency } from '@/lib/utils/currency'
+import { getLocalDateString } from '@/lib/utils/dates'
+import { TransactionForm } from '@/components/transactions/TransactionForm'
+
+const WEEKDAYS = ['Dom', 'Lun', 'Mar', 'Mié', 'Jue', 'Vie', 'Sáb']
+const MONTHS = ['Enero', 'Febrero', 'Marzo', 'Abril', 'Mayo', 'Junio', 'Julio', 'Agosto', 'Septiembre', 'Octubre', 'Noviembre', 'Diciembre']
+
+interface DayItem {
+  type: 'reminder' | 'recurring'
+  label: string
+  icon: string
+  color: string
+  reminder?: ReminderWithCategory
+  recurring?: RecurringTransactionWithCategory
+}
+
+function getItemsForDay(
+  reminders: ReminderWithCategory[],
+  recurring: RecurringTransactionWithCategory[],
+  year: number,
+  month: number,
+  day: number
+): DayItem[] {
+  const date = new Date(year, month, day)
+  const dayOfWeek = date.getDay()
+  const dateStr = getLocalDateString(date)
+  const items: DayItem[] = []
+
+  for (const r of reminders) {
+    if (!r.is_active) continue
+    let matches = false
+    switch (r.frequency) {
+      case 'once':
+        matches = r.specific_date === dateStr
+        break
+      case 'weekly':
+        matches = r.day_of_week === dayOfWeek
+        break
+      case 'monthly':
+        matches = r.day_of_month === day
+        break
+      case 'yearly':
+        matches = r.day_of_month === day && r.month_of_year === (month + 1)
+        break
+    }
+    if (matches) {
+      items.push({
+        type: 'reminder',
+        label: r.description,
+        icon: r.category?.icon ?? '🔔',
+        color: r.category?.color ?? '#6366f1',
+        reminder: r,
+      })
+    }
+  }
+
+  for (const rt of recurring) {
+    if (!rt.is_active) continue
+    if (dateStr < rt.start_date) continue
+    if (rt.end_date && dateStr > rt.end_date) continue
+    const startDate = new Date(rt.start_date + 'T12:00:00')
+    let matches = false
+    switch (rt.frequency) {
+      case 'daily':
+        matches = true
+        break
+      case 'weekly':
+        matches = startDate.getDay() === dayOfWeek
+        break
+      case 'monthly':
+        matches = startDate.getDate() === day
+        break
+      case 'yearly':
+        matches = startDate.getDate() === day && startDate.getMonth() === month
+        break
+    }
+    if (matches) {
+      items.push({
+        type: 'recurring',
+        label: rt.description,
+        icon: rt.category?.icon ?? '🔄',
+        color: rt.category?.color ?? '#10B981',
+        recurring: rt,
+      })
+    }
+  }
+
+  return items
+}
+
+interface Props {
+  userId: string
+  reminders: ReminderWithCategory[]
+  recurringTransactions: RecurringTransactionWithCategory[]
+  categories: Category[]
+  accounts: Account[]
+}
+
+export function RemindersCalendar({ userId, reminders, recurringTransactions, categories, accounts }: Props) {
+  const [currentDate, setCurrentDate] = useState(new Date())
+  const [registerFor, setRegisterFor] = useState<{ date: string; reminder: ReminderWithCategory } | null>(null)
+  const isMobile = useBreakpointValue({ base: true, md: false })
+
+  const year = currentDate.getFullYear()
+  const month = currentDate.getMonth()
+  const daysInMonth = new Date(year, month + 1, 0).getDate()
+  const firstDay = new Date(year, month, 1).getDay()
+  const today = getLocalDateString(new Date())
+
+  const handlePrevMonth = () => setCurrentDate(new Date(year, month - 1))
+  const handleNextMonth = () => setCurrentDate(new Date(year, month + 1))
+
+  const monthHeader = (
+    <HStack justifyContent="space-between" alignItems="center">
+      <Button onClick={handlePrevMonth} variant="ghost" size={{ base: 'sm', md: 'md' }}>← Anterior</Button>
+      <Text fontSize={{ base: 'md', md: 'lg' }} fontWeight="bold">
+        {MONTHS[month]} {year}
+      </Text>
+      <Button onClick={handleNextMonth} variant="ghost" size={{ base: 'sm', md: 'md' }}>Siguiente →</Button>
+    </HStack>
+  )
+
+  // Desktop grid
+  const desktopView = (() => {
+    const days: (number | null)[] = []
+    for (let i = 0; i < firstDay; i++) days.push(null)
+    for (let i = 1; i <= daysInMonth; i++) days.push(i)
+
+    return (
+      <>
+        <Grid templateColumns="repeat(7, 1fr)" gap="1">
+          {WEEKDAYS.map((d) => (
+            <Text key={d} textAlign="center" fontWeight="bold" fontSize="sm" py="2">{d}</Text>
+          ))}
+        </Grid>
+        <Grid templateColumns="repeat(7, 1fr)" gap="1" autoRows="minmax(100px, 1fr)">
+          {days.map((day, idx) => {
+            if (day === null) return <Box key={`empty-${idx}`} />
+            const dateStr = getLocalDateString(new Date(year, month, day))
+            const items = getItemsForDay(reminders, recurringTransactions, year, month, day)
+            const isToday = dateStr === today
+            return (
+              <Box
+                key={day}
+                borderWidth="1px"
+                borderRadius="md"
+                p="2"
+                bg={items.length > 0 ? '#1a1a27' : 'transparent'}
+                borderColor={isToday ? '#4F46E5' : items.length > 0 ? '#3b3b4f' : '#2d2d35'}
+                transition="background 0.2s"
+              >
+                <VStack alignItems="flex-start" gap="1" height="100%">
+                  <HStack justify="space-between" w="full">
+                    <Text fontWeight="bold" fontSize="sm" color={isToday ? '#818cf8' : 'white'}>{day}</Text>
+                    {isToday && <Box w={2} h={2} borderRadius="full" bg="#4F46E5" />}
+                  </HStack>
+                  <VStack alignItems="flex-start" gap="0.5" width="100%" flex="1" overflowY="auto">
+                    {items.slice(0, 3).map((item, i) => (
+                      <HStack
+                        key={i}
+                        w="full"
+                        gap={1}
+                        cursor={item.type === 'reminder' && isToday ? 'pointer' : 'default'}
+                        onClick={() => {
+                          if (item.type === 'reminder' && item.reminder) {
+                            setRegisterFor({ date: dateStr, reminder: item.reminder })
+                          }
+                        }}
+                        _hover={item.type === 'reminder' && isToday ? { opacity: 0.8 } : {}}
+                      >
+                        <Box
+                          w={2}
+                          h={2}
+                          borderRadius="full"
+                          bg={item.color}
+                          flexShrink={0}
+                          mt="1px"
+                        />
+                        <Text fontSize="xs" color="#D0D0D0" lineClamp={1}>
+                          {item.icon} {item.label}
+                        </Text>
+                      </HStack>
+                    ))}
+                    {items.length > 3 && (
+                      <Text fontSize="xs" color="#808080">+{items.length - 3} más</Text>
+                    )}
+                  </VStack>
+                </VStack>
+              </Box>
+            )
+          })}
+        </Grid>
+      </>
+    )
+  })()
+
+  // Mobile list
+  const mobileView = (() => {
+    const daysWithItems: { day: number; dateStr: string; items: DayItem[] }[] = []
+    for (let d = 1; d <= daysInMonth; d++) {
+      const dateStr = getLocalDateString(new Date(year, month, d))
+      const items = getItemsForDay(reminders, recurringTransactions, year, month, d)
+      if (items.length > 0) daysWithItems.push({ day: d, dateStr, items })
+    }
+
+    if (daysWithItems.length === 0) {
+      return (
+        <Box py={8} textAlign="center">
+          <Text color="#808080">Sin recordatorios ni suscripciones este mes</Text>
+        </Box>
+      )
+    }
+
+    return (
+      <VStack gap={2} align="stretch">
+        {daysWithItems.map(({ day, dateStr, items }) => {
+          const isToday = dateStr === today
+          return (
+            <Box key={day} borderWidth="1px" borderRadius="lg" borderColor={isToday ? '#4F46E5' : '#2d2d35'} overflow="hidden">
+              <HStack px={4} py={3} bg="#1a1a27" justify="space-between">
+                <HStack gap={3}>
+                  <Box
+                    w={9} h={9}
+                    borderRadius="full"
+                    bg={isToday ? '#4F46E5' : '#2d2d35'}
+                    display="flex" alignItems="center" justifyContent="center" flexShrink={0}
+                  >
+                    <Text fontWeight="bold" fontSize="sm" color="white">{day}</Text>
+                  </Box>
+                  <VStack align="flex-start" gap={0}>
+                    <Text fontSize="sm" fontWeight="semibold" color="white">
+                      {WEEKDAYS[new Date(year, month, day).getDay()]}
+                      {isToday && <Badge ml={2} size="xs" colorPalette="purple">Hoy</Badge>}
+                    </Text>
+                    <Text fontSize="xs" color="#808080">{items.length} evento{items.length !== 1 ? 's' : ''}</Text>
+                  </VStack>
+                </HStack>
+              </HStack>
+              <VStack gap={0} align="stretch" px={4} py={2} bg="#18181d">
+                {items.map((item, i) => (
+                  <HStack
+                    key={i}
+                    justify="space-between"
+                    py={2}
+                    borderTopWidth={i > 0 ? '1px' : '0'}
+                    borderColor="#2d2d35"
+                  >
+                    <HStack gap={2} flex={1}>
+                      <Box w={2} h={2} borderRadius="full" bg={item.color} flexShrink={0} />
+                      <VStack align="flex-start" gap={0} flex={1}>
+                        <Text fontSize="sm" color="white">{item.icon} {item.label}</Text>
+                        <HStack gap={1}>
+                          <Badge size="xs" variant="outline" colorPalette={item.type === 'reminder' ? 'purple' : 'green'}>
+                            {item.type === 'reminder' ? 'Recordatorio' : 'Suscripción'}
+                          </Badge>
+                          {item.recurring && (
+                            <Text fontSize="xs" color="#808080">
+                              {formatCurrency(Number(item.recurring.amount), item.recurring.currency)}
+                            </Text>
+                          )}
+                        </HStack>
+                      </VStack>
+                    </HStack>
+                    {item.type === 'reminder' && isToday && item.reminder && (
+                      <Button
+                        size="xs"
+                        bg="#4F46E5"
+                        color="white"
+                        _hover={{ bg: '#4338CA' }}
+                        flexShrink={0}
+                        onClick={() => setRegisterFor({ date: dateStr, reminder: item.reminder! })}
+                      >
+                        <FiPlus />
+                        Registrar
+                      </Button>
+                    )}
+                  </HStack>
+                ))}
+              </VStack>
+            </Box>
+          )
+        })}
+      </VStack>
+    )
+  })()
+
+  return (
+    <>
+      <Box borderWidth="1px" borderRadius="lg" p={{ base: 4, md: 6 }} bg="bg.surface" width="100%">
+        <VStack gap="4" alignItems="stretch">
+          {monthHeader}
+
+          {/* Legend */}
+          <HStack gap={4} flexWrap="wrap">
+            <HStack gap={1}>
+              <Box w={2} h={2} borderRadius="full" bg="#6366f1" />
+              <Text fontSize="xs" color="#B0B0B0">Recordatorio</Text>
+            </HStack>
+            <HStack gap={1}>
+              <Box w={2} h={2} borderRadius="full" bg="#10B981" />
+              <Text fontSize="xs" color="#B0B0B0">Suscripción recurrente</Text>
+            </HStack>
+            <Text fontSize="xs" color="#B0B0B0">· Haz clic en un recordatorio de hoy para registrar la transacción</Text>
+          </HStack>
+
+          {isMobile ? mobileView : desktopView}
+        </VStack>
+      </Box>
+
+      {registerFor && (
+        <TransactionForm
+          isOpen
+          onClose={() => setRegisterFor(null)}
+          userId={userId}
+          categories={categories}
+          accounts={accounts}
+          initialDate={registerFor.date}
+          lockedDate
+          onSuccess={() => setRegisterFor(null)}
+          prefillDescription={registerFor.reminder.description}
+          prefillCategoryId={registerFor.reminder.category_id ?? undefined}
+        />
+      )}
+    </>
+  )
+}

--- a/components/reminders/ReminderForm.tsx
+++ b/components/reminders/ReminderForm.tsx
@@ -1,0 +1,204 @@
+'use client'
+
+import { VStack, HStack, Text, Box } from '@chakra-ui/react'
+import { useState, useEffect } from 'react'
+import { createReminder, updateReminder } from '@/lib/actions/reminders.actions'
+import { toaster } from '@/lib/toaster'
+import { FormDialog } from '@/components/ui/FormDialog'
+import { FormInput } from '@/components/ui/FormInput'
+import { DateInput } from '@/components/ui/DateInput'
+import { RadioSelect } from '@/components/ui/RadioSelect'
+import { PrimaryButton } from '@/components/ui/PrimaryButton'
+import { CategorySelect } from '@/components/ui/CategorySelect'
+import type { Category, Reminder } from '@/types/database.types'
+import { getLocalDateString } from '@/lib/utils/dates'
+
+const FREQUENCY_OPTIONS = [
+  { value: 'once', label: 'Una vez' },
+  { value: 'weekly', label: 'Semanal' },
+  { value: 'monthly', label: 'Mensual' },
+  { value: 'yearly', label: 'Anual' },
+]
+
+const WEEKDAY_OPTIONS = [
+  { value: '0', label: 'Domingo' },
+  { value: '1', label: 'Lunes' },
+  { value: '2', label: 'Martes' },
+  { value: '3', label: 'Miércoles' },
+  { value: '4', label: 'Jueves' },
+  { value: '5', label: 'Viernes' },
+  { value: '6', label: 'Sábado' },
+]
+
+const MONTH_OPTIONS = [
+  { value: '1', label: 'Enero' }, { value: '2', label: 'Febrero' },
+  { value: '3', label: 'Marzo' }, { value: '4', label: 'Abril' },
+  { value: '5', label: 'Mayo' }, { value: '6', label: 'Junio' },
+  { value: '7', label: 'Julio' }, { value: '8', label: 'Agosto' },
+  { value: '9', label: 'Septiembre' }, { value: '10', label: 'Octubre' },
+  { value: '11', label: 'Noviembre' }, { value: '12', label: 'Diciembre' },
+]
+
+interface Props {
+  isOpen: boolean
+  onClose: () => void
+  userId: string
+  categories: Category[]
+  editingReminder?: Reminder | null
+  onSuccess: () => void
+}
+
+const defaultForm = {
+  description: '',
+  category_id: '',
+  frequency: 'monthly' as 'once' | 'weekly' | 'monthly' | 'yearly',
+  day_of_week: 1,
+  day_of_month: 1,
+  month_of_year: 1,
+  specific_date: getLocalDateString(),
+}
+
+export function ReminderForm({ isOpen, onClose, userId, categories, editingReminder, onSuccess }: Props) {
+  const [loading, setLoading] = useState(false)
+  const [formData, setFormData] = useState(defaultForm)
+
+  useEffect(() => {
+    if (editingReminder) {
+      setFormData({
+        description: editingReminder.description,
+        category_id: editingReminder.category_id ?? '',
+        frequency: editingReminder.frequency,
+        day_of_week: editingReminder.day_of_week ?? 1,
+        day_of_month: editingReminder.day_of_month ?? 1,
+        month_of_year: editingReminder.month_of_year ?? 1,
+        specific_date: editingReminder.specific_date ?? getLocalDateString(),
+      })
+    } else {
+      setFormData(defaultForm)
+    }
+  }, [editingReminder, isOpen])
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setLoading(true)
+
+    const payload = {
+      description: formData.description,
+      category_id: formData.category_id || null,
+      frequency: formData.frequency,
+      day_of_week: formData.frequency === 'weekly' ? formData.day_of_week : null,
+      day_of_month: (formData.frequency === 'monthly' || formData.frequency === 'yearly') ? formData.day_of_month : null,
+      month_of_year: formData.frequency === 'yearly' ? formData.month_of_year : null,
+      specific_date: formData.frequency === 'once' ? formData.specific_date : null,
+      is_active: true,
+    }
+
+    const result = editingReminder
+      ? await updateReminder(userId, editingReminder.id, payload)
+      : await createReminder(userId, payload)
+
+    if (result.success) {
+      toaster.create({ title: editingReminder ? 'Recordatorio actualizado' : 'Recordatorio creado', type: 'success', duration: 3000 })
+      onSuccess()
+      onClose()
+    } else {
+      toaster.create({ title: 'Error', description: result.error, type: 'error', duration: 4000 })
+    }
+    setLoading(false)
+  }
+
+  return (
+    <FormDialog
+      isOpen={isOpen}
+      onClose={onClose}
+      title={editingReminder ? 'Editar Recordatorio' : 'Nuevo Recordatorio'}
+    >
+      <form onSubmit={handleSubmit}>
+        <VStack gap={4}>
+          <FormInput
+            label="Descripción"
+            value={formData.description}
+            onChange={(v) => setFormData({ ...formData, description: v })}
+            placeholder="Ej: Pago arriendo"
+            required
+          />
+
+          <Box w="full">
+            <CategorySelect
+              value={formData.category_id}
+              onChange={(v) => setFormData({ ...formData, category_id: v })}
+              categories={categories}
+            />
+          </Box>
+
+          <RadioSelect
+            label="Frecuencia"
+            value={formData.frequency}
+            onChange={(v) => setFormData({ ...formData, frequency: v as typeof formData.frequency })}
+            options={FREQUENCY_OPTIONS}
+            required
+          />
+
+          {formData.frequency === 'once' && (
+            <DateInput
+              label="Fecha"
+              value={formData.specific_date}
+              onChange={(v) => setFormData({ ...formData, specific_date: v })}
+              required
+            />
+          )}
+
+          {formData.frequency === 'weekly' && (
+            <RadioSelect
+              label="Día de la semana"
+              value={String(formData.day_of_week)}
+              onChange={(v) => setFormData({ ...formData, day_of_week: Number(v) })}
+              options={WEEKDAY_OPTIONS}
+              required
+            />
+          )}
+
+          {(formData.frequency === 'monthly' || formData.frequency === 'yearly') && (
+            <HStack gap={3} w="full" align="flex-end">
+              <Box flex={1}>
+                <Text fontSize="sm" color="#B0B0B0" mb={1}>Día del mes</Text>
+                <input
+                  type="number"
+                  min={1}
+                  max={31}
+                  value={formData.day_of_month}
+                  onChange={(e) => setFormData({ ...formData, day_of_month: Number(e.target.value) })}
+                  style={{
+                    width: '100%',
+                    background: '#18181d',
+                    border: '1px solid #2d2d35',
+                    borderRadius: '8px',
+                    padding: '8px 12px',
+                    color: 'white',
+                    fontSize: '14px',
+                  }}
+                  required
+                />
+              </Box>
+              {formData.frequency === 'yearly' && (
+                <Box flex={2}>
+                  <RadioSelect
+                    label="Mes"
+                    value={String(formData.month_of_year)}
+                    onChange={(v) => setFormData({ ...formData, month_of_year: Number(v) })}
+                    options={MONTH_OPTIONS}
+                    required
+                  />
+                </Box>
+              )}
+            </HStack>
+          )}
+
+          <PrimaryButton type="submit" width="full" loading={loading}>
+            {editingReminder ? 'Guardar cambios' : 'Crear Recordatorio'}
+          </PrimaryButton>
+        </VStack>
+      </form>
+    </FormDialog>
+  )
+}

--- a/components/reminders/RemindersList.tsx
+++ b/components/reminders/RemindersList.tsx
@@ -1,0 +1,156 @@
+'use client'
+
+import { VStack, HStack, Box, Text, Badge, IconButton, Button } from '@chakra-ui/react'
+import { useState } from 'react'
+import { FiEdit2, FiTrash2, FiPlus } from 'react-icons/fi'
+import { deleteReminder } from '@/lib/actions/reminders.actions'
+import { toaster } from '@/lib/toaster'
+import { ConfirmDialog } from '@/components/ui/ConfirmDialog'
+import { ReminderForm } from './ReminderForm'
+import type { Category, ReminderWithCategory } from '@/types/database.types'
+
+const FREQUENCY_LABELS: Record<string, string> = {
+  once: 'Una vez',
+  weekly: 'Semanal',
+  monthly: 'Mensual',
+  yearly: 'Anual',
+}
+
+const WEEKDAY_NAMES = ['Domingo', 'Lunes', 'Martes', 'Miércoles', 'Jueves', 'Viernes', 'Sábado']
+const MONTH_NAMES = ['', 'Enero', 'Febrero', 'Marzo', 'Abril', 'Mayo', 'Junio', 'Julio', 'Agosto', 'Septiembre', 'Octubre', 'Noviembre', 'Diciembre']
+
+function getReminderScheduleLabel(r: ReminderWithCategory): string {
+  switch (r.frequency) {
+    case 'once':
+      return r.specific_date ? `El ${r.specific_date}` : '—'
+    case 'weekly':
+      return `Cada ${r.day_of_week != null ? WEEKDAY_NAMES[r.day_of_week] : '—'}`
+    case 'monthly':
+      return `Día ${r.day_of_month} de cada mes`
+    case 'yearly':
+      return `${r.day_of_month} de ${r.month_of_year != null ? MONTH_NAMES[r.month_of_year] : '—'} de cada año`
+    default:
+      return '—'
+  }
+}
+
+interface Props {
+  userId: string
+  reminders: ReminderWithCategory[]
+  categories: Category[]
+  onRefresh: () => void
+}
+
+export function RemindersList({ userId, reminders, categories, onRefresh }: Props) {
+  const [isFormOpen, setIsFormOpen] = useState(false)
+  const [editingReminder, setEditingReminder] = useState<ReminderWithCategory | null>(null)
+  const [deletingId, setDeletingId] = useState<string | null>(null)
+  const [deleteLoading, setDeleteLoading] = useState(false)
+
+  const handleDelete = async () => {
+    if (!deletingId) return
+    setDeleteLoading(true)
+    const result = await deleteReminder(userId, deletingId)
+    setDeleteLoading(false)
+    setDeletingId(null)
+    if (result.success) {
+      toaster.create({ title: 'Recordatorio eliminado', type: 'success', duration: 3000 })
+      onRefresh()
+    } else {
+      toaster.create({ title: result.error ?? 'Error', type: 'error', duration: 4000 })
+    }
+  }
+
+  return (
+    <VStack gap={4} align="stretch">
+      <HStack justify="space-between">
+        <Text fontWeight="semibold" color="white">Mis Recordatorios</Text>
+        <Button
+          size="sm"
+          bg="#4F46E5"
+          color="white"
+          _hover={{ bg: '#4338CA' }}
+          onClick={() => { setEditingReminder(null); setIsFormOpen(true) }}
+        >
+          <FiPlus />
+          Nuevo
+        </Button>
+      </HStack>
+
+      {reminders.length === 0 ? (
+        <Text color="#B0B0B0" fontSize="sm">No tienes recordatorios. Crea uno para verlo en el calendario.</Text>
+      ) : (
+        <VStack gap={2} align="stretch">
+          {reminders.map((r) => (
+            <Box
+              key={r.id}
+              borderWidth="1px"
+              borderRadius="xl"
+              px={4}
+              py={3}
+              bg="#1a1a23"
+              borderColor="#2d2d35"
+              _hover={{ borderColor: '#4F46E5' }}
+              transition="border-color 0.2s"
+            >
+              <HStack justify="space-between" align="flex-start">
+                <VStack align="start" gap={1} flex={1}>
+                  <Text fontWeight="semibold" fontSize="sm" color="white">
+                    {r.category?.icon ?? '🔔'} {r.description}
+                  </Text>
+                  <HStack gap={2} flexWrap="wrap">
+                    <Badge size="sm" variant="outline" colorPalette="purple">
+                      {FREQUENCY_LABELS[r.frequency]}
+                    </Badge>
+                    <Text fontSize="xs" color="#B0B0B0">{getReminderScheduleLabel(r)}</Text>
+                    {r.category && (
+                      <Text fontSize="xs" color="#B0B0B0">· {r.category.name}</Text>
+                    )}
+                  </HStack>
+                </VStack>
+                <HStack gap={1} flexShrink={0}>
+                  <IconButton
+                    aria-label="Editar"
+                    size="xs"
+                    variant="ghost"
+                    color="#B0B0B0"
+                    onClick={() => { setEditingReminder(r); setIsFormOpen(true) }}
+                  >
+                    <FiEdit2 />
+                  </IconButton>
+                  <IconButton
+                    aria-label="Eliminar"
+                    size="xs"
+                    variant="ghost"
+                    color="#ef4444"
+                    onClick={() => setDeletingId(r.id)}
+                  >
+                    <FiTrash2 />
+                  </IconButton>
+                </HStack>
+              </HStack>
+            </Box>
+          ))}
+        </VStack>
+      )}
+
+      <ReminderForm
+        isOpen={isFormOpen}
+        onClose={() => setIsFormOpen(false)}
+        userId={userId}
+        categories={categories}
+        editingReminder={editingReminder}
+        onSuccess={onRefresh}
+      />
+
+      <ConfirmDialog
+        isOpen={deletingId !== null}
+        onClose={() => setDeletingId(null)}
+        onConfirm={handleDelete}
+        title="Eliminar recordatorio"
+        description="¿Estás seguro? Esta acción no se puede deshacer."
+        isLoading={deleteLoading}
+      />
+    </VStack>
+  )
+}

--- a/components/transactions/TransactionForm.tsx
+++ b/components/transactions/TransactionForm.tsx
@@ -35,6 +35,8 @@ interface Props {
   onSuccess: () => void
   initialDate?: string
   lockedDate?: boolean
+  prefillDescription?: string
+  prefillCategoryId?: string
 }
 
 const defaultForm = {
@@ -48,7 +50,7 @@ const defaultForm = {
   notes: '',
 }
 
-export function TransactionForm({ isOpen, onClose, userId, categories, accounts = [], onSuccess, initialDate, lockedDate }: Props) {
+export function TransactionForm({ isOpen, onClose, userId, categories, accounts = [], onSuccess, initialDate, lockedDate, prefillDescription, prefillCategoryId }: Props) {
   const [loading, setLoading] = useState(false)
   const [formData, setFormData] = useState({ ...defaultForm, date: initialDate ?? getLocalDateString() })
   const [localCategories, setLocalCategories] = useState<Category[]>(categories)
@@ -56,10 +58,15 @@ export function TransactionForm({ isOpen, onClose, userId, categories, accounts 
 
   useEffect(() => {
     if (isOpen) {
-      setFormData({ ...defaultForm, date: initialDate ?? getLocalDateString() })
+      setFormData({
+        ...defaultForm,
+        date: initialDate ?? getLocalDateString(),
+        description: prefillDescription ?? '',
+        category_id: prefillCategoryId ?? '',
+      })
       setLocalCategories(categories)
     }
-  }, [isOpen, initialDate, categories])
+  }, [isOpen, initialDate, categories, prefillDescription, prefillCategoryId])
 
   const handleAccountChange = (accountId: string) => {
     const account = accounts.find((a) => a.id === accountId)

--- a/lib/actions/reminders.actions.ts
+++ b/lib/actions/reminders.actions.ts
@@ -1,0 +1,63 @@
+'use server'
+
+import { revalidatePath } from 'next/cache'
+import { insforgeAdmin } from '@/lib/insforge-admin'
+import { reminderSchema, type ReminderFormData } from '@/lib/validations/reminder'
+
+export async function getReminders(userId: string) {
+  const { data, error } = await insforgeAdmin.database
+    .from('reminders')
+    .select('*, category:categories(*)')
+    .eq('user_id', userId)
+    .order('created_at', { ascending: false })
+
+  if (error) return { success: false, error: error.message }
+  return { success: true, data }
+}
+
+export async function createReminder(userId: string, input: ReminderFormData) {
+  const parsed = reminderSchema.safeParse(input)
+  if (!parsed.success) return { success: false, error: parsed.error.issues[0].message }
+
+  const { data, error } = await insforgeAdmin.database
+    .from('reminders')
+    .insert({ ...parsed.data, user_id: userId })
+    .select()
+    .single()
+
+  if (error) return { success: false, error: error.message }
+
+  revalidatePath('/calendar')
+  return { success: true, data }
+}
+
+export async function updateReminder(userId: string, id: string, input: ReminderFormData) {
+  const parsed = reminderSchema.safeParse(input)
+  if (!parsed.success) return { success: false, error: parsed.error.issues[0].message }
+
+  const { data, error } = await insforgeAdmin.database
+    .from('reminders')
+    .update(parsed.data)
+    .eq('id', id)
+    .eq('user_id', userId)
+    .select()
+    .single()
+
+  if (error) return { success: false, error: error.message }
+
+  revalidatePath('/calendar')
+  return { success: true, data }
+}
+
+export async function deleteReminder(userId: string, id: string) {
+  const { error } = await insforgeAdmin.database
+    .from('reminders')
+    .delete()
+    .eq('id', id)
+    .eq('user_id', userId)
+
+  if (error) return { success: false, error: error.message }
+
+  revalidatePath('/calendar')
+  return { success: true }
+}

--- a/lib/validations/reminder.ts
+++ b/lib/validations/reminder.ts
@@ -1,0 +1,14 @@
+import { z } from 'zod'
+
+export const reminderSchema = z.object({
+  description: z.string().min(1, 'La descripción es requerida'),
+  category_id: z.string().uuid().nullable().optional(),
+  frequency: z.enum(['once', 'weekly', 'monthly', 'yearly']),
+  day_of_week: z.number().int().min(0).max(6).nullable().optional(),
+  day_of_month: z.number().int().min(1).max(31).nullable().optional(),
+  month_of_year: z.number().int().min(1).max(12).nullable().optional(),
+  specific_date: z.string().nullable().optional(),
+  is_active: z.boolean().optional().default(true),
+})
+
+export type ReminderFormData = z.infer<typeof reminderSchema>

--- a/supabase/seeds/reminders-v3.0.sql
+++ b/supabase/seeds/reminders-v3.0.sql
@@ -1,0 +1,26 @@
+-- Migration: reminders table for scheduled financial reminders
+-- Run this against your InsForge/Supabase database
+
+CREATE TABLE IF NOT EXISTS reminders (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  description text NOT NULL,
+  category_id uuid NULL REFERENCES categories(id) ON DELETE SET NULL,
+  frequency text NOT NULL CHECK (frequency IN ('once', 'weekly', 'monthly', 'yearly')),
+  day_of_week int NULL CHECK (day_of_week BETWEEN 0 AND 6),
+  day_of_month int NULL CHECK (day_of_month BETWEEN 1 AND 31),
+  month_of_year int NULL CHECK (month_of_year BETWEEN 1 AND 12),
+  specific_date date NULL,
+  is_active boolean NOT NULL DEFAULT true,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS reminders_user_id_idx ON reminders(user_id);
+
+ALTER TABLE reminders ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can manage their own reminders"
+  ON reminders
+  FOR ALL
+  USING (user_id = auth.uid())
+  WITH CHECK (user_id = auth.uid());

--- a/types/database.types.ts
+++ b/types/database.types.ts
@@ -191,3 +191,23 @@ export interface LoanPayment {
   notes: string | null
   created_at: string
 }
+
+export type ReminderFrequency = 'once' | 'weekly' | 'monthly' | 'yearly'
+
+export interface Reminder {
+  id: string
+  user_id: string
+  description: string
+  category_id: string | null
+  frequency: ReminderFrequency
+  day_of_week: number | null
+  day_of_month: number | null
+  month_of_year: number | null
+  specific_date: string | null
+  is_active: boolean
+  created_at: string
+}
+
+export interface ReminderWithCategory extends Reminder {
+  category: Category | null
+}


### PR DESCRIPTION
## Resumen

Implementa el sistema completo de recordatorios financieros con calendario de dos tabs.

### Tarea 6.1 — Nueva tabla `reminders`
- Frecuencias soportadas: `once`, `weekly`, `monthly`, `yearly`
- Campos: `description`, `category_id`, `frequency`, `day_of_week`, `day_of_month`, `month_of_year`, `specific_date`, `is_active`
- RLS: usuarios solo ven sus propios recordatorios
- SQL: `supabase/seeds/reminders-v3.0.sql`

### Tarea 6.2 — CRUD de recordatorios
- `ReminderForm`: formulario con campos condicionales según frecuencia
- `RemindersList`: lista con editar/eliminar y etiqueta descriptiva del horario
- Server actions: `getReminders`, `createReminder`, `updateReminder`, `deleteReminder`

### Tarea 6.3 — Dos tabs en el calendario
- **Tab "Transacciones"**: el calendario existente sin cambios
- **Tab "Programado"**: `RemindersCalendar` que calcula qué recordatorios y suscripciones recurrentes caen en cada día del mes. Incluye leyenda y visualización desktop (grid) + mobile (lista)

### Tarea 6.4 — Registrar transacción desde recordatorio
- Al hacer clic en un recordatorio del **día de hoy**, abre el `TransactionForm` con `description` y `category_id` pre-cargados
- `TransactionForm` acepta nuevas props `prefillDescription` y `prefillCategoryId`

### Migración requerida
```sql
-- supabase/seeds/reminders-v3.0.sql
CREATE TABLE IF NOT EXISTS reminders ( ... )
```

---
_Generated by [Claude Code](https://claude.ai/code/session_01XPgXLQwAtTpgt2K7VWVnAw)_