### PR TITLE
fix: remove module-level throws that break Vercel production build

### DIFF
--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -2,18 +2,13 @@ import { NextAuthOptions } from 'next-auth'
 import GoogleProvider from 'next-auth/providers/google'
 import { insforge } from './insforge'
 
-if (!process.env.GOOGLE_CLIENT_ID) {
-  throw new Error('Missing GOOGLE_CLIENT_ID')
-}
-if (!process.env.GOOGLE_CLIENT_SECRET) {
-  throw new Error('Missing GOOGLE_CLIENT_SECRET')
-}
-
+// Do NOT throw here at module level — Next.js evaluates imports during the
+// build's "Collecting page data" phase before runtime env vars are injected.
 export const authOptions: NextAuthOptions = {
   providers: [
     GoogleProvider({
-      clientId: process.env.GOOGLE_CLIENT_ID,
-      clientSecret: process.env.GOOGLE_CLIENT_SECRET,
+      clientId: process.env.GOOGLE_CLIENT_ID ?? '',
+      clientSecret: process.env.GOOGLE_CLIENT_SECRET ?? '',
       authorization: {
         params: {
           prompt: 'consent',

--- a/lib/insforge-admin.ts
+++ b/lib/insforge-admin.ts
@@ -1,14 +1,9 @@
 import { createClient } from '@insforge/sdk'
 
-if (!process.env.INSFORGE_API_KEY) {
-  throw new Error('Missing env.INSFORGE_API_KEY')
-}
-
-/**
- * Admin InsForge client — uses the full-access API key.
- * Bypasses RLS policies. Only use server-side (no NEXT_PUBLIC_ prefix).
- */
+// Do NOT throw here at module level — Next.js evaluates imports during the
+// build's "Collecting page data" phase before runtime env vars are injected.
+// Missing key errors will surface naturally from the SDK at runtime.
 export const insforgeAdmin = createClient({
-  baseUrl: process.env.NEXT_PUBLIC_INSFORGE_URL!,
-  anonKey: process.env.INSFORGE_API_KEY,
+  baseUrl: process.env.NEXT_PUBLIC_INSFORGE_URL ?? '',
+  anonKey: process.env.INSFORGE_API_KEY ?? '',
 })

--- a/lib/insforge.ts
+++ b/lib/insforge.ts
@@ -1,15 +1,10 @@
 import { createClient } from '@insforge/sdk'
 
-if (!process.env.NEXT_PUBLIC_INSFORGE_URL) {
-  throw new Error('Missing env.NEXT_PUBLIC_INSFORGE_URL')
-}
-if (!process.env.NEXT_PUBLIC_INSFORGE_ANON_KEY) {
-  throw new Error('Missing env.NEXT_PUBLIC_INSFORGE_ANON_KEY')
-}
-
+// Do NOT throw here at module level — Next.js evaluates imports during the
+// build's "Collecting page data" phase before runtime env vars are injected.
 export const insforge = createClient({
-  baseUrl: process.env.NEXT_PUBLIC_INSFORGE_URL,
-  anonKey: process.env.NEXT_PUBLIC_INSFORGE_ANON_KEY,
+  baseUrl: process.env.NEXT_PUBLIC_INSFORGE_URL ?? '',
+  anonKey: process.env.NEXT_PUBLIC_INSFORGE_ANON_KEY ?? '',
 })
 
 export async function testInsforgeConnection() {


### PR DESCRIPTION
Closing this PR — the root cause is not module-level throws but the GitHub Action's `vercel pull` not downloading Vercel's encrypted/sensitive env vars. The fix is in the Action YAML itself (separate PR).