### PR TITLE
fix(ci): fix production deploy action — use Vercel remote build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,16 +37,10 @@ jobs:
       - name: Install Vercel CLI
         run: pnpm add -g vercel@latest
 
-      - name: Pull Vercel Environment Info
-        run: vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
-
-      - name: Build Project
-        run: vercel build --token=${{ secrets.VERCEL_TOKEN }}
-
       - name: Deploy to Vercel (Preview)
         id: deploy
         run: |
-          url=$(vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }})
+          url=$(vercel deploy --token=${{ secrets.VERCEL_TOKEN }})
           echo "url=$url" >> $GITHUB_OUTPUT
 
       - name: Comment PR with preview URL
@@ -82,11 +76,5 @@ jobs:
       - name: Install Vercel CLI
         run: pnpm add -g vercel@latest
 
-      - name: Pull Vercel Environment Info
-        run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
-
-      - name: Build Project
-        run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
-
       - name: Deploy to Vercel (Production)
-        run: vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}
+        run: vercel deploy --prod --token=${{ secrets.VERCEL_TOKEN }}


### PR DESCRIPTION
## Problema

El job `deploy-production` usaba el patrón `vercel pull` + `vercel build --prod` + `vercel deploy --prebuilt`. Este patrón falla en CI porque `vercel pull` **no descarga las variables de entorno marcadas como "Sensitive"** en Vercel (como `INSFORGE_API_KEY`, `GOOGLE_CLIENT_SECRET`, etc.). Al correr `vercel build` localmente sin esas variables, el build falla con:

```
Error: Missing env.INSFORGE_API_KEY
Error: Failed to collect page data for /api/cron/generate-recurring
```

El deploy en Vercel sí funciona correctamente porque su infraestructura nativa tiene acceso completo a todas las variables.

## Solución

Reemplazar el patrón de 3 pasos por un único `vercel deploy --prod` (sin `--prebuilt`). Esto sube el código fuente a los servidores de Vercel, donde el build ocurre con todas las variables disponibles.

Lo mismo se aplica al job `deploy-preview` para consistencia.

## Cambios

- `deploy-production`: elimina `vercel pull` + `vercel build --prod` + `vercel deploy --prebuilt --prod` → reemplazado por `vercel deploy --prod`
- `deploy-preview`: elimina `vercel pull` + `vercel build` + `vercel deploy --prebuilt` → reemplazado por `vercel deploy`

## Test plan

- [ ] Hacer merge a `develop` y verificar que el preview deploy del push a `develop` pasa sin errores
- [ ] Hacer merge a `main` y verificar que el production deploy del action pasa sin errores

---
_Generated by [Claude Code](https://claude.ai/code/session_01XPgXLQwAtTpgt2K7VWVnAw)_