### PR TITLE
fix(budgets): refresh list after create/edit/delete

### DIFF
--- a/components/budgets/BudgetList.tsx
+++ b/components/budgets/BudgetList.tsx
@@ -22,7 +22,7 @@ interface Props {
 
 export function BudgetList({ userId, initialBudgets, onEdit }: Props) {
   const router = useRouter()
-  const [budgets] = useState<BudgetWithSpent[]>(initialBudgets)
+  const budgets = initialBudgets
   const [selectedId, setSelectedId] = useState<string | null>(null)
   const { open, onOpen, onClose } = useDisclosure()
   const [isDeleting, setIsDeleting] = useState(false)


### PR DESCRIPTION
## Cambios

`BudgetList` capturaba `initialBudgets` en `useState`, por lo que después de `router.refresh()` la lista renderizada no reflejaba los datos nuevos del Server Component. Se reemplaza por uso directo del prop.

## Testing
- ✅ TypeScript compila sin errores
- ✅ Pendiente verificación manual

Closes #402
Related to #401

---
_Generated by [Claude Code](https://claude.ai/code/session_01XPgXLQwAtTpgt2K7VWVnAw)_