### PR TITLE
fix(reports): sync initial filter range with ReportFilters

### DIFF
--- a/components/ReportFilters.tsx
+++ b/components/ReportFilters.tsx
@@ -28,7 +28,7 @@ interface Props {
   onFilterChange: (filters: ReportFiltersState) => void
 }
 
-function getCurrentMonthRange(): { firstDay: string; lastDay: string } {
+export function getCurrentMonthRange(): { firstDay: string; lastDay: string } {
   const now = new Date()
   const y = now.getFullYear()
   const m = String(now.getMonth() + 1).padStart(2, '0')

--- a/components/ReportsContent.tsx
+++ b/components/ReportsContent.tsx
@@ -5,7 +5,7 @@ import { Box, Heading, SimpleGrid } from '@chakra-ui/react'
 import { ExpensesByCategoryChart } from '@/components/charts/ExpensesByCategoryChart'
 import { MonthlyComparisonChart } from '@/components/charts/MonthlyComparisonChart'
 import { AccumulatedBalanceChart } from '@/components/charts/AccumulatedBalanceChart'
-import { ReportFilters, type ReportFiltersState } from '@/components/ReportFilters'
+import { ReportFilters, getCurrentMonthRange, type ReportFiltersState } from '@/components/ReportFilters'
 import { ReportStatistics } from '@/components/ReportStatistics'
 
 interface Props {
@@ -14,11 +14,14 @@ interface Props {
 }
 
 export function ReportsContent({ userId, preferredCurrency }: Props) {
-  const [filters, setFilters] = useState<ReportFiltersState>({
-    startDate: '',
-    endDate: '',
-    categoryIds: [],
-    transactionType: 'all',
+  const [filters, setFilters] = useState<ReportFiltersState>(() => {
+    const { firstDay, lastDay } = getCurrentMonthRange()
+    return {
+      startDate: firstDay,
+      endDate: lastDay,
+      categoryIds: [],
+      transactionType: 'all',
+    }
   })
 
   return (


### PR DESCRIPTION
## Cambios
- Exporta `getCurrentMonthRange` desde `ReportFilters`
- `ReportsContent` inicializa `filters` con el mismo rango (mes corriente) via lazy initializer
- Las gráficas ahora respetan el rango desde el primer render

## Testing
- ✅ TypeScript compila sin errores
- ✅ Pendiente verificación manual

Closes #406
Related to #401

---
_Generated by [Claude Code](https://claude.ai/code/session_01XPgXLQwAtTpgt2K7VWVnAw)_