### PR TITLE
feat(calendar): day-click modal in scheduled tab

### DIFF
--- a/components/calendar/CalendarPageContent.tsx
+++ b/components/calendar/CalendarPageContent.tsx
@@ -71,7 +71,7 @@ export function CalendarPageContent({ userId, initialTransactions, categories, a
       {activeTab === 'scheduled' && (
         <VStack gap={6} align="stretch" w="full">
           <Text fontSize="sm" color="#B0B0B0">
-            Visualiza tus recordatorios y suscripciones recurrentes. Haz clic en un recordatorio del día de hoy para registrar la transacción.
+            Haz clic en un día para ver detalles, registrar un pago de un recordatorio o crear uno nuevo.
           </Text>
 
           <RemindersCalendar
@@ -80,6 +80,7 @@ export function CalendarPageContent({ userId, initialTransactions, categories, a
             recurringTransactions={recurringTransactions}
             categories={categories}
             accounts={accounts}
+            onRefresh={() => router.refresh()}
           />
 
           <RemindersList

--- a/components/calendar/RemindersCalendar.tsx
+++ b/components/calendar/RemindersCalendar.tsx
@@ -8,17 +8,32 @@ import {
   Text,
   VStack,
   Badge,
+  DialogRoot,
+  DialogBackdrop,
+  DialogPositioner,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogBody,
+  DialogFooter,
+  DialogCloseTrigger,
+  IconButton,
+  Icon,
   useBreakpointValue,
 } from '@chakra-ui/react'
 import { useState } from 'react'
-import { FiPlus } from 'react-icons/fi'
+import { FiPlus, FiX } from 'react-icons/fi'
 import type { ReminderWithCategory, RecurringTransactionWithCategory, Account, Category } from '@/types/database.types'
 import { formatCurrency } from '@/lib/utils/currency'
 import { getLocalDateString } from '@/lib/utils/dates'
 import { TransactionForm } from '@/components/transactions/TransactionForm'
+import { ReminderForm } from '@/components/reminders/ReminderForm'
 
 const WEEKDAYS = ['Dom', 'Lun', 'Mar', 'Mié', 'Jue', 'Vie', 'Sáb']
 const MONTHS = ['Enero', 'Febrero', 'Marzo', 'Abril', 'Mayo', 'Junio', 'Julio', 'Agosto', 'Septiembre', 'Octubre', 'Noviembre', 'Diciembre']
+
+const REMINDER_COLOR = '#6366f1'
+const RECURRING_COLOR = '#10B981'
 
 interface DayItem {
   type: 'reminder' | 'recurring'
@@ -63,7 +78,7 @@ function getItemsForDay(
         type: 'reminder',
         label: r.description,
         icon: r.category?.icon ?? '🔔',
-        color: r.category?.color ?? '#6366f1',
+        color: REMINDER_COLOR,
         reminder: r,
       })
     }
@@ -94,7 +109,7 @@ function getItemsForDay(
         type: 'recurring',
         label: rt.description,
         icon: rt.category?.icon ?? '🔄',
-        color: rt.category?.color ?? '#10B981',
+        color: RECURRING_COLOR,
         recurring: rt,
       })
     }
@@ -109,11 +124,14 @@ interface Props {
   recurringTransactions: RecurringTransactionWithCategory[]
   categories: Category[]
   accounts: Account[]
+  onRefresh?: () => void
 }
 
-export function RemindersCalendar({ userId, reminders, recurringTransactions, categories, accounts }: Props) {
+export function RemindersCalendar({ userId, reminders, recurringTransactions, categories, accounts, onRefresh }: Props) {
   const [currentDate, setCurrentDate] = useState(new Date())
+  const [selectedDay, setSelectedDay] = useState<{ date: string; items: DayItem[] } | null>(null)
   const [registerFor, setRegisterFor] = useState<{ date: string; reminder: ReminderWithCategory } | null>(null)
+  const [createReminderDate, setCreateReminderDate] = useState<string | null>(null)
   const isMobile = useBreakpointValue({ base: true, md: false })
 
   const year = currentDate.getFullYear()
@@ -125,6 +143,10 @@ export function RemindersCalendar({ userId, reminders, recurringTransactions, ca
   const handlePrevMonth = () => setCurrentDate(new Date(year, month - 1))
   const handleNextMonth = () => setCurrentDate(new Date(year, month + 1))
 
+  const openDayDialog = (dateStr: string, items: DayItem[]) => {
+    setSelectedDay({ date: dateStr, items })
+  }
+
   const monthHeader = (
     <HStack justifyContent="space-between" alignItems="center">
       <Button onClick={handlePrevMonth} variant="ghost" size={{ base: 'sm', md: 'md' }}>← Anterior</Button>
@@ -135,7 +157,6 @@ export function RemindersCalendar({ userId, reminders, recurringTransactions, ca
     </HStack>
   )
 
-  // Desktop grid
   const desktopView = (() => {
     const days: (number | null)[] = []
     for (let i = 0; i < firstDay; i++) days.push(null)
@@ -160,9 +181,12 @@ export function RemindersCalendar({ userId, reminders, recurringTransactions, ca
                 borderWidth="1px"
                 borderRadius="md"
                 p="2"
+                cursor="pointer"
                 bg={items.length > 0 ? '#1a1a27' : 'transparent'}
                 borderColor={isToday ? '#4F46E5' : items.length > 0 ? '#3b3b4f' : '#2d2d35'}
-                transition="background 0.2s"
+                _hover={{ borderColor: '#4F46E5' }}
+                transition="background 0.2s, border-color 0.2s"
+                onClick={() => openDayDialog(dateStr, items)}
               >
                 <VStack alignItems="flex-start" gap="1" height="100%">
                   <HStack justify="space-between" w="full">
@@ -171,26 +195,8 @@ export function RemindersCalendar({ userId, reminders, recurringTransactions, ca
                   </HStack>
                   <VStack alignItems="flex-start" gap="0.5" width="100%" flex="1" overflowY="auto">
                     {items.slice(0, 3).map((item, i) => (
-                      <HStack
-                        key={i}
-                        w="full"
-                        gap={1}
-                        cursor={item.type === 'reminder' && isToday ? 'pointer' : 'default'}
-                        onClick={() => {
-                          if (item.type === 'reminder' && item.reminder) {
-                            setRegisterFor({ date: dateStr, reminder: item.reminder })
-                          }
-                        }}
-                        _hover={item.type === 'reminder' && isToday ? { opacity: 0.8 } : {}}
-                      >
-                        <Box
-                          w={2}
-                          h={2}
-                          borderRadius="full"
-                          bg={item.color}
-                          flexShrink={0}
-                          mt="1px"
-                        />
+                      <HStack key={i} w="full" gap={1}>
+                        <Box w={2} h={2} borderRadius="full" bg={item.color} flexShrink={0} mt="1px" />
                         <Text fontSize="xs" color="#D0D0D0" lineClamp={1}>
                           {item.icon} {item.label}
                         </Text>
@@ -209,7 +215,6 @@ export function RemindersCalendar({ userId, reminders, recurringTransactions, ca
     )
   })()
 
-  // Mobile list
   const mobileView = (() => {
     const daysWithItems: { day: number; dateStr: string; items: DayItem[] }[] = []
     for (let d = 1; d <= daysInMonth; d++) {
@@ -220,9 +225,20 @@ export function RemindersCalendar({ userId, reminders, recurringTransactions, ca
 
     if (daysWithItems.length === 0) {
       return (
-        <Box py={8} textAlign="center">
-          <Text color="#808080">Sin recordatorios ni suscripciones este mes</Text>
-        </Box>
+        <VStack gap={3}>
+          <Box py={8} textAlign="center" w="full">
+            <Text color="#808080">Sin recordatorios ni suscripciones este mes</Text>
+          </Box>
+          <Button
+            bg="#4F46E5"
+            color="white"
+            _hover={{ bg: '#4338CA' }}
+            onClick={() => setCreateReminderDate(today)}
+            w="full"
+          >
+            <FiPlus /> Nuevo recordatorio
+          </Button>
+        </VStack>
       )
     }
 
@@ -231,7 +247,17 @@ export function RemindersCalendar({ userId, reminders, recurringTransactions, ca
         {daysWithItems.map(({ day, dateStr, items }) => {
           const isToday = dateStr === today
           return (
-            <Box key={day} borderWidth="1px" borderRadius="lg" borderColor={isToday ? '#4F46E5' : '#2d2d35'} overflow="hidden">
+            <Box
+              key={day}
+              borderWidth="1px"
+              borderRadius="lg"
+              borderColor={isToday ? '#4F46E5' : '#2d2d35'}
+              overflow="hidden"
+              cursor="pointer"
+              onClick={() => openDayDialog(dateStr, items)}
+              _hover={{ borderColor: '#4F46E5' }}
+              transition="border-color 0.2s"
+            >
               <HStack px={4} py={3} bg="#1a1a27" justify="space-between">
                 <HStack gap={3}>
                   <Box
@@ -252,45 +278,20 @@ export function RemindersCalendar({ userId, reminders, recurringTransactions, ca
                 </HStack>
               </HStack>
               <VStack gap={0} align="stretch" px={4} py={2} bg="#18181d">
-                {items.map((item, i) => (
-                  <HStack
-                    key={i}
-                    justify="space-between"
-                    py={2}
-                    borderTopWidth={i > 0 ? '1px' : '0'}
-                    borderColor="#2d2d35"
-                  >
-                    <HStack gap={2} flex={1}>
-                      <Box w={2} h={2} borderRadius="full" bg={item.color} flexShrink={0} />
-                      <VStack align="flex-start" gap={0} flex={1}>
-                        <Text fontSize="sm" color="white">{item.icon} {item.label}</Text>
-                        <HStack gap={1}>
-                          <Badge size="xs" variant="outline" colorPalette={item.type === 'reminder' ? 'purple' : 'green'}>
-                            {item.type === 'reminder' ? 'Recordatorio' : 'Suscripción'}
-                          </Badge>
-                          {item.recurring && (
-                            <Text fontSize="xs" color="#808080">
-                              {formatCurrency(Number(item.recurring.amount), item.recurring.currency)}
-                            </Text>
-                          )}
-                        </HStack>
-                      </VStack>
-                    </HStack>
-                    {item.type === 'reminder' && isToday && item.reminder && (
-                      <Button
-                        size="xs"
-                        bg="#4F46E5"
-                        color="white"
-                        _hover={{ bg: '#4338CA' }}
-                        flexShrink={0}
-                        onClick={() => setRegisterFor({ date: dateStr, reminder: item.reminder! })}
-                      >
-                        <FiPlus />
-                        Registrar
-                      </Button>
-                    )}
+                {items.slice(0, 3).map((item, i) => (
+                  <HStack key={i} py={2} gap={2} borderTopWidth={i > 0 ? '1px' : '0'} borderColor="#2d2d35">
+                    <Box w={2} h={2} borderRadius="full" bg={item.color} flexShrink={0} />
+                    <Text fontSize="sm" color="white" lineClamp={1} flex={1}>
+                      {item.icon} {item.label}
+                    </Text>
+                    <Badge size="xs" variant="outline" colorPalette={item.type === 'reminder' ? 'purple' : 'green'}>
+                      {item.type === 'reminder' ? 'Recordatorio' : 'Suscripción'}
+                    </Badge>
                   </HStack>
                 ))}
+                {items.length > 3 && (
+                  <Text fontSize="xs" color="#808080" py={1}>+{items.length - 3} más</Text>
+                )}
               </VStack>
             </Box>
           )
@@ -298,6 +299,9 @@ export function RemindersCalendar({ userId, reminders, recurringTransactions, ca
       </VStack>
     )
   })()
+
+  const dialogDate = selectedDay?.date
+  const dialogItems = selectedDay?.items ?? []
 
   return (
     <>
@@ -308,20 +312,129 @@ export function RemindersCalendar({ userId, reminders, recurringTransactions, ca
           {/* Legend */}
           <HStack gap={4} flexWrap="wrap">
             <HStack gap={1}>
-              <Box w={2} h={2} borderRadius="full" bg="#6366f1" />
+              <Box w={2} h={2} borderRadius="full" bg={REMINDER_COLOR} />
               <Text fontSize="xs" color="#B0B0B0">Recordatorio</Text>
             </HStack>
             <HStack gap={1}>
-              <Box w={2} h={2} borderRadius="full" bg="#10B981" />
+              <Box w={2} h={2} borderRadius="full" bg={RECURRING_COLOR} />
               <Text fontSize="xs" color="#B0B0B0">Suscripción recurrente</Text>
             </HStack>
-            <Text fontSize="xs" color="#B0B0B0">· Haz clic en un recordatorio de hoy para registrar la transacción</Text>
+            <Text fontSize="xs" color="#B0B0B0">· Haz clic en un día para ver detalles o crear un recordatorio</Text>
           </HStack>
 
           {isMobile ? mobileView : desktopView}
         </VStack>
       </Box>
 
+      {/* Day details dialog */}
+      <DialogRoot
+        open={selectedDay !== null}
+        onOpenChange={(details) => !details.open && setSelectedDay(null)}
+        size="md"
+        placement="center"
+        lazyMount
+        unmountOnExit
+        closeOnInteractOutside={false}
+      >
+        <DialogBackdrop />
+        <DialogPositioner>
+          <DialogContent tabIndex={-1} mx={{ base: 3, md: 0 }} maxH={{ base: '85vh', md: '90vh' }} display="flex" flexDirection="column">
+            <DialogHeader borderBottomWidth="1px" borderColor="#2d2d35" py={4} flexShrink={0}>
+              <HStack justify="space-between" align="center">
+                <DialogTitle color="white">
+                  {dialogDate
+                    ? new Date(dialogDate + 'T12:00:00').toLocaleDateString('es-ES', { day: 'numeric', month: 'long', year: 'numeric' })
+                    : 'Programado del día'}
+                </DialogTitle>
+                <DialogCloseTrigger asChild>
+                  <IconButton
+                    aria-label="Cerrar"
+                    size="sm"
+                    variant="ghost"
+                    color="#B0B0B0"
+                    _hover={{ color: 'white', bg: '#2d2d35' }}
+                    onClick={() => setSelectedDay(null)}
+                  >
+                    <Icon as={FiX} />
+                  </IconButton>
+                </DialogCloseTrigger>
+              </HStack>
+            </DialogHeader>
+            <DialogBody flex="1" minH="0" overflowY="auto">
+              <VStack alignItems="stretch" gap="2">
+                {dialogItems.length === 0 ? (
+                  <Text color="fg.muted">Sin recordatorios ni suscripciones este día.</Text>
+                ) : (
+                  dialogItems.map((item, i) => (
+                    <Box
+                      key={i}
+                      width="100%"
+                      p="3"
+                      borderWidth="1px"
+                      borderRadius="md"
+                      bg="bg.muted"
+                    >
+                      <HStack justify="space-between" mb="2" align="flex-start">
+                        <HStack gap={2} flex={1}>
+                          <Box w={2} h={2} borderRadius="full" bg={item.color} flexShrink={0} mt="6px" />
+                          <VStack align="flex-start" gap={0} flex={1}>
+                            <Text fontWeight="bold" color="white">{item.icon} {item.label}</Text>
+                            <HStack gap={2} flexWrap="wrap">
+                              <Badge size="xs" variant="outline" colorPalette={item.type === 'reminder' ? 'purple' : 'green'}>
+                                {item.type === 'reminder' ? 'Recordatorio' : 'Suscripción'}
+                              </Badge>
+                              {item.recurring && (
+                                <Text fontSize="xs" color="#B0B0B0">
+                                  {formatCurrency(Number(item.recurring.amount), item.recurring.currency)}
+                                </Text>
+                              )}
+                            </HStack>
+                          </VStack>
+                        </HStack>
+                      </HStack>
+                      {item.type === 'reminder' && item.reminder && dialogDate && (
+                        <Button
+                          size="sm"
+                          bg="#4F46E5"
+                          color="white"
+                          _hover={{ bg: '#4338CA' }}
+                          width="full"
+                          onClick={() => {
+                            setRegisterFor({ date: dialogDate, reminder: item.reminder! })
+                            setSelectedDay(null)
+                          }}
+                        >
+                          <FiPlus />
+                          Registrar pago
+                        </Button>
+                      )}
+                    </Box>
+                  ))
+                )}
+              </VStack>
+            </DialogBody>
+            <DialogFooter borderTopWidth="1px" borderColor="#2d2d35" pt={4}>
+              <Button
+                bg="#4F46E5"
+                color="white"
+                _hover={{ bg: '#4338CA' }}
+                width="full"
+                onClick={() => {
+                  if (dialogDate) {
+                    setCreateReminderDate(dialogDate)
+                    setSelectedDay(null)
+                  }
+                }}
+              >
+                <FiPlus />
+                Nuevo recordatorio
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </DialogPositioner>
+      </DialogRoot>
+
+      {/* Transaction creation from reminder */}
       {registerFor && (
         <TransactionForm
           isOpen
@@ -331,11 +444,27 @@ export function RemindersCalendar({ userId, reminders, recurringTransactions, ca
           accounts={accounts}
           initialDate={registerFor.date}
           lockedDate
-          onSuccess={() => setRegisterFor(null)}
+          onSuccess={() => {
+            setRegisterFor(null)
+            onRefresh?.()
+          }}
           prefillDescription={registerFor.reminder.description}
           prefillCategoryId={registerFor.reminder.category_id ?? undefined}
         />
       )}
+
+      {/* New reminder from calendar */}
+      <ReminderForm
+        isOpen={createReminderDate !== null}
+        onClose={() => setCreateReminderDate(null)}
+        userId={userId}
+        categories={categories}
+        prefillDate={createReminderDate ?? undefined}
+        onSuccess={() => {
+          setCreateReminderDate(null)
+          onRefresh?.()
+        }}
+      />
     </>
   )
 }

--- a/components/reminders/ReminderForm.tsx
+++ b/components/reminders/ReminderForm.tsx
@@ -46,6 +46,7 @@ interface Props {
   categories: Category[]
   editingReminder?: Reminder | null
   onSuccess: () => void
+  prefillDate?: string
 }
 
 const defaultForm = {
@@ -58,7 +59,7 @@ const defaultForm = {
   specific_date: getLocalDateString(),
 }
 
-export function ReminderForm({ isOpen, onClose, userId, categories, editingReminder, onSuccess }: Props) {
+export function ReminderForm({ isOpen, onClose, userId, categories, editingReminder, onSuccess, prefillDate }: Props) {
   const [loading, setLoading] = useState(false)
   const [formData, setFormData] = useState(defaultForm)
 
@@ -73,10 +74,20 @@ export function ReminderForm({ isOpen, onClose, userId, categories, editingRemin
         month_of_year: editingReminder.month_of_year ?? 1,
         specific_date: editingReminder.specific_date ?? getLocalDateString(),
       })
+    } else if (prefillDate) {
+      const d = new Date(prefillDate + 'T12:00:00')
+      setFormData({
+        ...defaultForm,
+        frequency: 'once',
+        specific_date: prefillDate,
+        day_of_week: d.getDay(),
+        day_of_month: d.getDate(),
+        month_of_year: d.getMonth() + 1,
+      })
     } else {
       setFormData(defaultForm)
     }
-  }, [editingReminder, isOpen])
+  }, [editingReminder, isOpen, prefillDate])
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()

--- a/components/reminders/RemindersList.tsx
+++ b/components/reminders/RemindersList.tsx
@@ -1,8 +1,8 @@
 'use client'
 
-import { VStack, HStack, Box, Text, Badge, IconButton, Button } from '@chakra-ui/react'
+import { VStack, HStack, Box, Text, Badge, IconButton } from '@chakra-ui/react'
 import { useState } from 'react'
-import { FiEdit2, FiTrash2, FiPlus } from 'react-icons/fi'
+import { FiEdit2, FiTrash2 } from 'react-icons/fi'
 import { deleteReminder } from '@/lib/actions/reminders.actions'
 import { toaster } from '@/lib/toaster'
 import { ConfirmDialog } from '@/components/ui/ConfirmDialog'
@@ -63,19 +63,7 @@ export function RemindersList({ userId, reminders, categories, onRefresh }: Prop
 
   return (
     <VStack gap={4} align="stretch">
-      <HStack justify="space-between">
-        <Text fontWeight="semibold" color="white">Mis Recordatorios</Text>
-        <Button
-          size="sm"
-          bg="#4F46E5"
-          color="white"
-          _hover={{ bg: '#4338CA' }}
-          onClick={() => { setEditingReminder(null); setIsFormOpen(true) }}
-        >
-          <FiPlus />
-          Nuevo
-        </Button>
-      </HStack>
+      <Text fontWeight="semibold" color="white">Mis Recordatorios</Text>
 
       {reminders.length === 0 ? (
         <Text color="#B0B0B0" fontSize="sm">No tienes recordatorios. Crea uno para verlo en el calendario.</Text>


### PR DESCRIPTION
## Cambios
- `RemindersCalendar` ahora abre un dialog al hacer click en cualquier día
- En el dialog, cada recordatorio tiene botón "Registrar pago" → abre `TransactionForm` prellenado (descripción, categoría, fecha bloqueada)
- Footer del dialog: botón "Nuevo recordatorio" → abre `ReminderForm` con la fecha prellenada
- `ReminderForm` ahora acepta `prefillDate` (setea frequency=once + specific_date)
- Quitado botón "Nuevo" del header de `RemindersList` (la creación se hace desde el calendario)
- `RemindersCalendar` ahora acepta `onRefresh` para reload tras crear/registrar
- Bullets en el calendario y leyenda usan colores fijos (Recordatorio: #6366f1, Suscripción: #10B981), ignorando color de categoría — incluye fix del bug #7 del plan

## Testing
- ✅ TypeScript compila sin errores
- ✅ Pendiente verificación manual

Closes #418
Related to #417

---
_Generated by [Claude Code](https://claude.ai/code/session_01XPgXLQwAtTpgt2K7VWVnAw)_