### PR TITLE
fix(transactions): pair Moneda with Categoría to eliminate blank space

### DIFF
--- a/components/transactions/TransactionForm.tsx
+++ b/components/transactions/TransactionForm.tsx
@@ -151,15 +151,38 @@ export function TransactionForm({ isOpen, onClose, userId, categories, accounts 
               )}
             </SimpleGrid>
 
-            {accounts.length > 0 && (
-              <CurrencySelect
-                value={formData.currency}
-                onChange={(v) => setFormData({ ...formData, currency: v })}
-                showFullLabel
-                required
-                disabled={accountLocksCurrency}
-              />
-            )}
+            <SimpleGrid columns={{ base: 1, md: 2 }} gap={4} w="full" alignItems="start">
+              {accounts.length > 0 && (
+                <CurrencySelect
+                  value={formData.currency}
+                  onChange={(v) => setFormData({ ...formData, currency: v })}
+                  showFullLabel
+                  required
+                  disabled={accountLocksCurrency}
+                />
+              )}
+              <Box w="full" gridColumn={accounts.length > 0 ? undefined : { base: 'auto', md: '1 / -1' }}>
+                <CategorySelect
+                  value={formData.category_id}
+                  onChange={(v) => setFormData({ ...formData, category_id: v })}
+                  categories={localCategories}
+                  filterByType={formData.type}
+                  required
+                />
+                <Button
+                  variant="ghost"
+                  size="xs"
+                  color="#6366f1"
+                  mt={1}
+                  px={0}
+                  _hover={{ color: '#818cf8', bg: 'transparent' }}
+                  onClick={() => setQuickCategoryOpen(true)}
+                >
+                  <FiPlus style={{ marginRight: 4 }} />
+                  Nueva categoría
+                </Button>
+              </Box>
+            </SimpleGrid>
 
             {cardOverLimit && (
               <Box w="full" bg="#7f1d1d" borderRadius="md" px={3} py={2}>
@@ -168,28 +191,6 @@ export function TransactionForm({ isOpen, onClose, userId, categories, accounts 
                 </Text>
               </Box>
             )}
-
-            <Box w="full">
-              <CategorySelect
-                value={formData.category_id}
-                onChange={(v) => setFormData({ ...formData, category_id: v })}
-                categories={localCategories}
-                filterByType={formData.type}
-                required
-              />
-              <Button
-                variant="ghost"
-                size="xs"
-                color="#6366f1"
-                mt={1}
-                px={0}
-                _hover={{ color: '#818cf8', bg: 'transparent' }}
-                onClick={() => setQuickCategoryOpen(true)}
-              >
-                <FiPlus style={{ marginRight: 4 }} />
-                Nueva categoría
-              </Button>
-            </Box>
 
             <SimpleGrid columns={{ base: 1, md: 2 }} gap={4} w="full">
               <FormInput

--- a/components/ui/CurrencySelect.tsx
+++ b/components/ui/CurrencySelect.tsx
@@ -19,9 +19,9 @@ const currencies: { value: Currency; short: string; full: string }[] = [
 
 export function CurrencySelect({ value, onChange, showFullLabel = false, required, disabled }: Props) {
   return (
-    <FieldRoot required={required}>
+    <FieldRoot required={required} w="full">
       <FieldLabel>Moneda</FieldLabel>
-      <Box opacity={disabled ? 0.6 : 1} cursor={disabled ? 'not-allowed' : undefined} pointerEvents={disabled ? 'none' : undefined}>
+      <Box w="full" opacity={disabled ? 0.6 : 1} cursor={disabled ? 'not-allowed' : undefined} pointerEvents={disabled ? 'none' : undefined}>
         <NativeSelectRoot>
           <NativeSelectField
             value={value}


### PR DESCRIPTION
## Cambios
- `CurrencySelect` ahora aplica `w="full"` en `FieldRoot` y Box interno
- `TransactionForm`: Moneda y Categoría comparten una fila de 2 columnas (desktop)
- En móvil ambas siguen colapsando a una columna
- Orden lógico preservado: Monto → Cuenta → Moneda → Categoría → Descripción/Fecha
- Si no hay cuentas configuradas, Categoría queda full width (no genera blank space porque ya no hay Moneda separada)

## Diseño aplicado
Skill `frontend-design` instalada e invocada para guiar el rebalance del grid. Cambio mínimo y respetuoso del sistema visual existente (oscuro + acento índigo).

## Testing
- ✅ TypeScript compila sin errores
- ✅ Pendiente verificación manual

Closes #422
Related to #417

---
_Generated by [Claude Code](https://claude.ai/code/session_01XPgXLQwAtTpgt2K7VWVnAw)_