### PR TITLE
fix(recurring): set is_active=true on create and revalidate /calendar

### DIFF
--- a/lib/actions/recurring.actions.ts
+++ b/lib/actions/recurring.actions.ts
@@ -34,6 +34,7 @@ export async function createRecurringTransaction(
         frequency: validated.frequency,
         start_date: validated.start_date,
         end_date: validated.end_date || null,
+        is_active: true,
       }])
       .select('*, category:categories(*)')
       .single()
@@ -42,6 +43,7 @@ export async function createRecurringTransaction(
 
     revalidatePath('/recurring-transactions')
     revalidatePath('/movimientos')
+    revalidatePath('/calendar')
     return { success: true, data: transaction as RecurringTransactionWithCategory }
   } catch (error) {
     console.error('Create recurring transaction error:', error)
@@ -91,6 +93,7 @@ export async function updateRecurringTransaction(
 
     revalidatePath('/recurring-transactions')
     revalidatePath('/movimientos')
+    revalidatePath('/calendar')
     return { success: true, data: transaction as RecurringTransactionWithCategory }
   } catch (error) {
     console.error('Update recurring transaction error:', error)
@@ -110,6 +113,7 @@ export async function deleteRecurringTransaction(id: string, userId: string) {
 
     revalidatePath('/recurring-transactions')
     revalidatePath('/movimientos')
+    revalidatePath('/calendar')
     return { success: true }
   } catch (error) {
     console.error('Delete recurring transaction error:', error)
@@ -131,6 +135,7 @@ export async function toggleRecurringTransaction(id: string, userId: string, isA
 
     revalidatePath('/recurring-transactions')
     revalidatePath('/movimientos')
+    revalidatePath('/calendar')
     return { success: true, data: data as RecurringTransactionWithCategory }
   } catch (error) {
     console.error('Toggle recurring transaction error:', error)


### PR DESCRIPTION
## Summary

- `createRecurringTransaction` no establecía `is_active: true` en el insert. El calendario filtra por `if (!rt.is_active) continue`, así que cada recurrente nueva quedaba oculta.
- Tampoco se revalidaba `/calendar` en create/update/delete/toggle, por lo que la página seguía sirviendo datos viejos.

## Test plan

- [x] `pnpm lint lib/actions/recurring.actions.ts` limpio
- [ ] Manual: crear una recurrente con `start_date` = hoy → aparece en `/calendar` tab "Programado" sin recarga manual
- [ ] Manual: editar/eliminar una recurrente → el calendario refleja el cambio

Closes #425
Part of #424

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fk4EciPsQP5wLxcSV39d8q)_