### PR TITLE
feat(calendar): allow creating a recurring transaction from the day dialog

### DIFF
--- a/components/calendar/RemindersCalendar.tsx
+++ b/components/calendar/RemindersCalendar.tsx
@@ -28,6 +28,7 @@ import { formatCurrency } from '@/lib/utils/currency'
 import { getLocalDateString } from '@/lib/utils/dates'
 import { TransactionForm } from '@/components/transactions/TransactionForm'
 import { ReminderForm } from '@/components/reminders/ReminderForm'
+import { RecurringTransactionForm } from '@/components/recurring/RecurringTransactionForm'
 
 const WEEKDAYS = ['Dom', 'Lun', 'Mar', 'Mié', 'Jue', 'Vie', 'Sáb']
 const MONTHS = ['Enero', 'Febrero', 'Marzo', 'Abril', 'Mayo', 'Junio', 'Julio', 'Agosto', 'Septiembre', 'Octubre', 'Noviembre', 'Diciembre']
@@ -132,6 +133,7 @@ export function RemindersCalendar({ userId, reminders, recurringTransactions, ca
   const [selectedDay, setSelectedDay] = useState<{ date: string; items: DayItem[] } | null>(null)
   const [registerFor, setRegisterFor] = useState<{ date: string; reminder: ReminderWithCategory } | null>(null)
   const [createReminderDate, setCreateReminderDate] = useState<string | null>(null)
+  const [createRecurringDate, setCreateRecurringDate] = useState<string | null>(null)
   const isMobile = useBreakpointValue({ base: true, md: false })
 
   const year = currentDate.getFullYear()
@@ -319,7 +321,7 @@ export function RemindersCalendar({ userId, reminders, recurringTransactions, ca
               <Box w={2} h={2} borderRadius="full" bg={RECURRING_COLOR} />
               <Text fontSize="xs" color="#B0B0B0">Suscripción recurrente</Text>
             </HStack>
-            <Text fontSize="xs" color="#B0B0B0">· Haz clic en un día para ver detalles o crear un recordatorio</Text>
+            <Text fontSize="xs" color="#B0B0B0">· Haz clic en un día para ver detalles o crear un recordatorio/recurrente</Text>
           </HStack>
 
           {isMobile ? mobileView : desktopView}
@@ -414,21 +416,38 @@ export function RemindersCalendar({ userId, reminders, recurringTransactions, ca
               </VStack>
             </DialogBody>
             <DialogFooter borderTopWidth="1px" borderColor="#2d2d35" pt={4}>
-              <Button
-                bg="#4F46E5"
-                color="white"
-                _hover={{ bg: '#4338CA' }}
-                width="full"
-                onClick={() => {
-                  if (dialogDate) {
-                    setCreateReminderDate(dialogDate)
-                    setSelectedDay(null)
-                  }
-                }}
-              >
-                <FiPlus />
-                Nuevo recordatorio
-              </Button>
+              <VStack gap={2} width="full">
+                <Button
+                  bg="#4F46E5"
+                  color="white"
+                  _hover={{ bg: '#4338CA' }}
+                  width="full"
+                  onClick={() => {
+                    if (dialogDate) {
+                      setCreateReminderDate(dialogDate)
+                      setSelectedDay(null)
+                    }
+                  }}
+                >
+                  <FiPlus />
+                  Nuevo recordatorio
+                </Button>
+                <Button
+                  bg={RECURRING_COLOR}
+                  color="white"
+                  _hover={{ bg: '#059669' }}
+                  width="full"
+                  onClick={() => {
+                    if (dialogDate) {
+                      setCreateRecurringDate(dialogDate)
+                      setSelectedDay(null)
+                    }
+                  }}
+                >
+                  <FiPlus />
+                  Nueva recurrente
+                </Button>
+              </VStack>
             </DialogFooter>
           </DialogContent>
         </DialogPositioner>
@@ -462,6 +481,20 @@ export function RemindersCalendar({ userId, reminders, recurringTransactions, ca
         prefillDate={createReminderDate ?? undefined}
         onSuccess={() => {
           setCreateReminderDate(null)
+          onRefresh?.()
+        }}
+      />
+
+      {/* New recurring transaction from calendar */}
+      <RecurringTransactionForm
+        isOpen={createRecurringDate !== null}
+        onClose={() => setCreateRecurringDate(null)}
+        userId={userId}
+        categories={categories}
+        accounts={accounts}
+        prefillStartDate={createRecurringDate ?? undefined}
+        onSuccess={() => {
+          setCreateRecurringDate(null)
           onRefresh?.()
         }}
       />

--- a/components/recurring/RecurringTransactionForm.tsx
+++ b/components/recurring/RecurringTransactionForm.tsx
@@ -31,6 +31,7 @@ interface Props {
   onSuccess: () => void
   initialData?: RecurringTransactionWithCategory
   transactionId?: string
+  prefillStartDate?: string
 }
 
 const defaultForm = {
@@ -54,6 +55,7 @@ export function RecurringTransactionForm({
   onSuccess,
   initialData,
   transactionId,
+  prefillStartDate,
 }: Props) {
   const [form, setForm] = useState(defaultForm)
   const [loading, setLoading] = useState(false)
@@ -71,10 +73,12 @@ export function RecurringTransactionForm({
         start_date: initialData.start_date,
         end_date: initialData.end_date ?? '',
       })
+    } else if (prefillStartDate) {
+      setForm({ ...defaultForm, start_date: prefillStartDate })
     } else {
       setForm(defaultForm)
     }
-  }, [initialData])
+  }, [initialData, prefillStartDate, isOpen])
 
   const handleSubmit = async () => {
     if (!form.amount || !form.category_id || !form.description) {


### PR DESCRIPTION
## Summary

- Añade el botón "Nueva recurrente" en el footer del diálogo de día del calendario (junto al ya existente "Nuevo recordatorio").
- `RecurringTransactionForm` admite un nuevo prop opcional `prefillStartDate` que preselecciona el día clickeado como `start_date`.
- Al crear con éxito, se cierra el form y se dispara `onRefresh()` para repintar el calendario.
- Pequeño ajuste de leyenda: "crear recordatorio/recurrente".

## Test plan

- [x] `pnpm lint` no introduce nuevos errores (el único error en `RecurringTransactionForm.tsx` es pre-existente en `develop`)
- [x] `pnpm type-check` limpio en archivos tocados
- [ ] Manual: `/calendar` tab "Programado" → clic en un día futuro → ver dos botones; crear recurrente con esa fecha como `start_date` → tras guardar, aparece en el calendario sin recarga.

Closes #426
Part of #424

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fk4EciPsQP5wLxcSV39d8q)_