### PR TITLE
Release v3.2.0 — develop → main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## [3.2.0] — 2026-05-21
+
+### Fixed
+
+- **Recurrentes en el calendario**: las transacciones recurrentes recién creadas no aparecían en el calendario de programados porque el insert no establecía `is_active`. Adicionalmente, todas las mutaciones de recurrentes (crear/editar/eliminar/toggle) ahora revalidan `/calendar`.
+
+### Added
+
+- **Crear recurrentes desde el calendario**: el diálogo de día en la tab "Programado" incluye un botón "Nueva recurrente" además del existente "Nuevo recordatorio", con la fecha clickeada prellenada como `start_date`.
+- **Nueva tab "Recordatorios" en /movimientos**: listado completo de recordatorios con crear, editar y eliminar reutilizando los componentes del calendario. Soporta `?tab=recordatorios` en la URL.
+- **Recordatorios fijados del día**: en la nueva tab, los recordatorios cuya frecuencia coincide con hoy se muestran como tarjetas fijadas arriba del listado con un botón "Pagar" que abre el formulario de transacción con descripción, categoría y fecha prellenadas (mismo flujo que en el calendario).
+- **Ocultar pin tras pagar**: cuando se registra una transacción para un recordatorio del día con la misma descripción y categoría, deja de aparecer como fijado en la tab.
+
+### Changed
+
+- Lógica de matching de recordatorios extraída a `lib/reminders/matches-date.ts` como única fuente de verdad para el calendario y la nueva tab de recordatorios.
+- Las server actions de recordatorios ahora revalidan también `/movimientos`.
+
 ## [1.3.0] — 2026-05-13
 
 ### Added

--- a/app/(dashboard)/movimientos/MovimientosPageClient.tsx
+++ b/app/(dashboard)/movimientos/MovimientosPageClient.tsx
@@ -3,19 +3,21 @@
 import { useTransition, useState, useEffect } from 'react'
 import { Box, Heading, Tabs, Spinner, Icon } from '@chakra-ui/react'
 import { useRouter } from 'next/navigation'
-import { FiList, FiRepeat, FiCreditCard } from 'react-icons/fi'
+import { FiList, FiRepeat, FiCreditCard, FiBell } from 'react-icons/fi'
 import { TransactionsPageClient } from '../transactions/TransactionsPageClient'
 import { RecurringTransactionsPageContent } from '@/components/recurring/RecurringTransactionsPageContent'
 import { LoansPageClient } from '../loans/LoansPageClient'
+import { RecordatoriosTab } from '@/components/reminders/RecordatoriosTab'
 import type {
   Account,
   Category,
   TransactionWithCategory,
   LoanWithAccount,
   RecurringTransactionWithCategory,
+  ReminderWithCategory,
 } from '@/types/database.types'
 
-type Tab = 'transacciones' | 'recurrentes' | 'prestamos'
+type Tab = 'transacciones' | 'recurrentes' | 'prestamos' | 'recordatorios'
 
 interface Props {
   userId: string
@@ -25,6 +27,7 @@ interface Props {
   initialTransactions: TransactionWithCategory[] | null
   initialRecurring: RecurringTransactionWithCategory[] | null
   initialLoans: LoanWithAccount[] | null
+  initialReminders: ReminderWithCategory[] | null
 }
 
 export function MovimientosPageClient({
@@ -35,6 +38,7 @@ export function MovimientosPageClient({
   initialTransactions,
   initialRecurring,
   initialLoans,
+  initialReminders,
 }: Props) {
   const router = useRouter()
   const [isPending, startTransition] = useTransition()
@@ -111,6 +115,17 @@ export function MovimientosPageClient({
             {tabIcon('prestamos', FiCreditCard)}
             Préstamos
           </Tabs.Trigger>
+          <Tabs.Trigger
+            value="recordatorios"
+            display="flex"
+            alignItems="center"
+            gap={2}
+            color="#B0B0B0"
+            _selected={{ color: 'white', borderBottomColor: '#6366f1' }}
+          >
+            {tabIcon('recordatorios', FiBell)}
+            Recordatorios
+          </Tabs.Trigger>
         </Tabs.List>
 
         <Tabs.Content value="transacciones">
@@ -141,6 +156,16 @@ export function MovimientosPageClient({
               userId={userId}
               initialLoans={initialLoans}
               accounts={accounts}
+            />
+          )}
+        </Tabs.Content>
+
+        <Tabs.Content value="recordatorios">
+          {initialReminders !== null && (
+            <RecordatoriosTab
+              userId={userId}
+              categories={categories}
+              initialReminders={initialReminders}
             />
           )}
         </Tabs.Content>

--- a/app/(dashboard)/movimientos/MovimientosPageClient.tsx
+++ b/app/(dashboard)/movimientos/MovimientosPageClient.tsx
@@ -28,6 +28,7 @@ interface Props {
   initialRecurring: RecurringTransactionWithCategory[] | null
   initialLoans: LoanWithAccount[] | null
   initialReminders: ReminderWithCategory[] | null
+  todaysTransactions: { description: string; category_id: string | null }[]
 }
 
 export function MovimientosPageClient({
@@ -39,6 +40,7 @@ export function MovimientosPageClient({
   initialRecurring,
   initialLoans,
   initialReminders,
+  todaysTransactions,
 }: Props) {
   const router = useRouter()
   const [isPending, startTransition] = useTransition()
@@ -167,6 +169,7 @@ export function MovimientosPageClient({
               categories={categories}
               accounts={accounts}
               initialReminders={initialReminders}
+              todaysTransactions={todaysTransactions}
             />
           )}
         </Tabs.Content>

--- a/app/(dashboard)/movimientos/MovimientosPageClient.tsx
+++ b/app/(dashboard)/movimientos/MovimientosPageClient.tsx
@@ -165,6 +165,7 @@ export function MovimientosPageClient({
             <RecordatoriosTab
               userId={userId}
               categories={categories}
+              accounts={accounts}
               initialReminders={initialReminders}
             />
           )}

--- a/app/(dashboard)/movimientos/page.tsx
+++ b/app/(dashboard)/movimientos/page.tsx
@@ -4,7 +4,8 @@ import { redirect } from 'next/navigation'
 import { insforgeAdmin } from '@/lib/insforge-admin'
 import { getCategories } from '@/lib/actions/categories.actions'
 import { getAccounts } from '@/lib/actions/accounts.actions'
-import { getTransactions } from '@/lib/actions/transactions.actions'
+import { getTransactions, getTransactionsByDate } from '@/lib/actions/transactions.actions'
+import { getLocalDateString } from '@/lib/utils/dates'
 import { getRecurringTransactions } from '@/lib/actions/recurring.actions'
 import { getLoans } from '@/lib/actions/loans.actions'
 import { getReminders } from '@/lib/actions/reminders.actions'
@@ -50,6 +51,7 @@ export default async function MovimientosPage({
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let initialLoans: any[] | null = null
   let initialReminders: ReminderWithCategory[] | null = null
+  let todaysTransactions: { description: string; category_id: string | null }[] = []
 
   if (tab === 'transacciones') {
     const result = await getTransactions(user.id, 500)
@@ -61,8 +63,17 @@ export default async function MovimientosPage({
     const result = await getLoans(user.id)
     initialLoans = result.success && result.data ? result.data : []
   } else if (tab === 'recordatorios') {
-    const result = await getReminders(user.id)
-    initialReminders = result.success ? ((result.data ?? []) as ReminderWithCategory[]) : []
+    const today = getLocalDateString()
+    const [remindersResult, txResult] = await Promise.all([
+      getReminders(user.id),
+      getTransactionsByDate(user.id, today),
+    ])
+    initialReminders = remindersResult.success
+      ? ((remindersResult.data ?? []) as ReminderWithCategory[])
+      : []
+    todaysTransactions = txResult.success
+      ? (txResult.data as { description: string; category_id: string | null }[])
+      : []
   }
 
   return (
@@ -75,6 +86,7 @@ export default async function MovimientosPage({
       initialRecurring={initialRecurring}
       initialLoans={initialLoans}
       initialReminders={initialReminders}
+      todaysTransactions={todaysTransactions}
     />
   )
 }

--- a/app/(dashboard)/movimientos/page.tsx
+++ b/app/(dashboard)/movimientos/page.tsx
@@ -7,10 +7,11 @@ import { getAccounts } from '@/lib/actions/accounts.actions'
 import { getTransactions } from '@/lib/actions/transactions.actions'
 import { getRecurringTransactions } from '@/lib/actions/recurring.actions'
 import { getLoans } from '@/lib/actions/loans.actions'
+import { getReminders } from '@/lib/actions/reminders.actions'
 import { MovimientosPageClient } from './MovimientosPageClient'
-import type { TransactionWithCategory, Account } from '@/types/database.types'
+import type { TransactionWithCategory, Account, ReminderWithCategory } from '@/types/database.types'
 
-type Tab = 'transacciones' | 'recurrentes' | 'prestamos'
+type Tab = 'transacciones' | 'recurrentes' | 'prestamos' | 'recordatorios'
 
 export default async function MovimientosPage({
   searchParams,
@@ -48,6 +49,7 @@ export default async function MovimientosPage({
   let initialRecurring: any[] | null = null
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let initialLoans: any[] | null = null
+  let initialReminders: ReminderWithCategory[] | null = null
 
   if (tab === 'transacciones') {
     const result = await getTransactions(user.id, 500)
@@ -58,6 +60,9 @@ export default async function MovimientosPage({
   } else if (tab === 'prestamos') {
     const result = await getLoans(user.id)
     initialLoans = result.success && result.data ? result.data : []
+  } else if (tab === 'recordatorios') {
+    const result = await getReminders(user.id)
+    initialReminders = result.success ? ((result.data ?? []) as ReminderWithCategory[]) : []
   }
 
   return (
@@ -69,6 +74,7 @@ export default async function MovimientosPage({
       initialTransactions={initialTransactions}
       initialRecurring={initialRecurring}
       initialLoans={initialLoans}
+      initialReminders={initialReminders}
     />
   )
 }

--- a/components/calendar/RemindersCalendar.tsx
+++ b/components/calendar/RemindersCalendar.tsx
@@ -28,6 +28,7 @@ import { formatCurrency } from '@/lib/utils/currency'
 import { getLocalDateString } from '@/lib/utils/dates'
 import { TransactionForm } from '@/components/transactions/TransactionForm'
 import { ReminderForm } from '@/components/reminders/ReminderForm'
+import { RecurringTransactionForm } from '@/components/recurring/RecurringTransactionForm'
 
 const WEEKDAYS = ['Dom', 'Lun', 'Mar', 'Mié', 'Jue', 'Vie', 'Sáb']
 const MONTHS = ['Enero', 'Febrero', 'Marzo', 'Abril', 'Mayo', 'Junio', 'Julio', 'Agosto', 'Septiembre', 'Octubre', 'Noviembre', 'Diciembre']
@@ -132,6 +133,7 @@ export function RemindersCalendar({ userId, reminders, recurringTransactions, ca
   const [selectedDay, setSelectedDay] = useState<{ date: string; items: DayItem[] } | null>(null)
   const [registerFor, setRegisterFor] = useState<{ date: string; reminder: ReminderWithCategory } | null>(null)
   const [createReminderDate, setCreateReminderDate] = useState<string | null>(null)
+  const [createRecurringDate, setCreateRecurringDate] = useState<string | null>(null)
   const isMobile = useBreakpointValue({ base: true, md: false })
 
   const year = currentDate.getFullYear()
@@ -319,7 +321,7 @@ export function RemindersCalendar({ userId, reminders, recurringTransactions, ca
               <Box w={2} h={2} borderRadius="full" bg={RECURRING_COLOR} />
               <Text fontSize="xs" color="#B0B0B0">Suscripción recurrente</Text>
             </HStack>
-            <Text fontSize="xs" color="#B0B0B0">· Haz clic en un día para ver detalles o crear un recordatorio</Text>
+            <Text fontSize="xs" color="#B0B0B0">· Haz clic en un día para ver detalles o crear un recordatorio/recurrente</Text>
           </HStack>
 
           {isMobile ? mobileView : desktopView}
@@ -414,21 +416,38 @@ export function RemindersCalendar({ userId, reminders, recurringTransactions, ca
               </VStack>
             </DialogBody>
             <DialogFooter borderTopWidth="1px" borderColor="#2d2d35" pt={4}>
-              <Button
-                bg="#4F46E5"
-                color="white"
-                _hover={{ bg: '#4338CA' }}
-                width="full"
-                onClick={() => {
-                  if (dialogDate) {
-                    setCreateReminderDate(dialogDate)
-                    setSelectedDay(null)
-                  }
-                }}
-              >
-                <FiPlus />
-                Nuevo recordatorio
-              </Button>
+              <VStack gap={2} width="full">
+                <Button
+                  bg="#4F46E5"
+                  color="white"
+                  _hover={{ bg: '#4338CA' }}
+                  width="full"
+                  onClick={() => {
+                    if (dialogDate) {
+                      setCreateReminderDate(dialogDate)
+                      setSelectedDay(null)
+                    }
+                  }}
+                >
+                  <FiPlus />
+                  Nuevo recordatorio
+                </Button>
+                <Button
+                  bg={RECURRING_COLOR}
+                  color="white"
+                  _hover={{ bg: '#059669' }}
+                  width="full"
+                  onClick={() => {
+                    if (dialogDate) {
+                      setCreateRecurringDate(dialogDate)
+                      setSelectedDay(null)
+                    }
+                  }}
+                >
+                  <FiPlus />
+                  Nueva recurrente
+                </Button>
+              </VStack>
             </DialogFooter>
           </DialogContent>
         </DialogPositioner>
@@ -462,6 +481,20 @@ export function RemindersCalendar({ userId, reminders, recurringTransactions, ca
         prefillDate={createReminderDate ?? undefined}
         onSuccess={() => {
           setCreateReminderDate(null)
+          onRefresh?.()
+        }}
+      />
+
+      {/* New recurring transaction from calendar */}
+      <RecurringTransactionForm
+        isOpen={createRecurringDate !== null}
+        onClose={() => setCreateRecurringDate(null)}
+        userId={userId}
+        categories={categories}
+        accounts={accounts}
+        prefillStartDate={createRecurringDate ?? undefined}
+        onSuccess={() => {
+          setCreateRecurringDate(null)
           onRefresh?.()
         }}
       />

--- a/components/calendar/RemindersCalendar.tsx
+++ b/components/calendar/RemindersCalendar.tsx
@@ -26,6 +26,7 @@ import { FiPlus, FiX } from 'react-icons/fi'
 import type { ReminderWithCategory, RecurringTransactionWithCategory, Account, Category } from '@/types/database.types'
 import { formatCurrency } from '@/lib/utils/currency'
 import { getLocalDateString } from '@/lib/utils/dates'
+import { reminderMatchesDate } from '@/lib/reminders/matches-date'
 import { TransactionForm } from '@/components/transactions/TransactionForm'
 import { ReminderForm } from '@/components/reminders/ReminderForm'
 import { RecurringTransactionForm } from '@/components/recurring/RecurringTransactionForm'
@@ -58,23 +59,7 @@ function getItemsForDay(
   const items: DayItem[] = []
 
   for (const r of reminders) {
-    if (!r.is_active) continue
-    let matches = false
-    switch (r.frequency) {
-      case 'once':
-        matches = r.specific_date === dateStr
-        break
-      case 'weekly':
-        matches = r.day_of_week === dayOfWeek
-        break
-      case 'monthly':
-        matches = r.day_of_month === day
-        break
-      case 'yearly':
-        matches = r.day_of_month === day && r.month_of_year === (month + 1)
-        break
-    }
-    if (matches) {
+    if (reminderMatchesDate(r, date)) {
       items.push({
         type: 'reminder',
         label: r.description,

--- a/components/recurring/RecurringTransactionForm.tsx
+++ b/components/recurring/RecurringTransactionForm.tsx
@@ -31,6 +31,7 @@ interface Props {
   onSuccess: () => void
   initialData?: RecurringTransactionWithCategory
   transactionId?: string
+  prefillStartDate?: string
 }
 
 const defaultForm = {
@@ -54,6 +55,7 @@ export function RecurringTransactionForm({
   onSuccess,
   initialData,
   transactionId,
+  prefillStartDate,
 }: Props) {
   const [form, setForm] = useState(defaultForm)
   const [loading, setLoading] = useState(false)
@@ -71,10 +73,12 @@ export function RecurringTransactionForm({
         start_date: initialData.start_date,
         end_date: initialData.end_date ?? '',
       })
+    } else if (prefillStartDate) {
+      setForm({ ...defaultForm, start_date: prefillStartDate })
     } else {
       setForm(defaultForm)
     }
-  }, [initialData])
+  }, [initialData, prefillStartDate, isOpen])
 
   const handleSubmit = async () => {
     if (!form.amount || !form.category_id || !form.description) {

--- a/components/reminders/RecordatoriosTab.tsx
+++ b/components/reminders/RecordatoriosTab.tsx
@@ -16,9 +16,16 @@ interface Props {
   categories: Category[]
   accounts: Account[]
   initialReminders: ReminderWithCategory[]
+  todaysTransactions: { description: string; category_id: string | null }[]
 }
 
-export function RecordatoriosTab({ userId, categories, accounts, initialReminders }: Props) {
+export function RecordatoriosTab({
+  userId,
+  categories,
+  accounts,
+  initialReminders,
+  todaysTransactions,
+}: Props) {
   const router = useRouter()
   const [isFormOpen, setIsFormOpen] = useState(false)
   const [payingReminder, setPayingReminder] = useState<ReminderWithCategory | null>(null)
@@ -27,10 +34,15 @@ export function RecordatoriosTab({ userId, categories, accounts, initialReminder
   const today = useMemo(() => new Date(), [])
   const todayStr = getLocalDateString(today)
 
-  const pinnedToday = useMemo(
-    () => remindersForDate(initialReminders, today),
-    [initialReminders, today],
-  )
+  const pinnedToday = useMemo(() => {
+    const matches = remindersForDate(initialReminders, today)
+    return matches.filter(
+      (r) =>
+        !todaysTransactions.some(
+          (tx) => tx.description === r.description && tx.category_id === r.category_id,
+        ),
+    )
+  }, [initialReminders, today, todaysTransactions])
 
   return (
     <VStack alignItems="flex-start" gap={{ base: 4, md: 6 }} w="full">

--- a/components/reminders/RecordatoriosTab.tsx
+++ b/components/reminders/RecordatoriosTab.tsx
@@ -1,24 +1,36 @@
 'use client'
 
-import { VStack, HStack, Heading, Button } from '@chakra-ui/react'
-import { useState } from 'react'
+import { VStack, HStack, Heading, Button, Box, Text, Badge } from '@chakra-ui/react'
+import { useMemo, useState } from 'react'
 import { useRouter } from 'next/navigation'
-import { FiPlus } from 'react-icons/fi'
+import { FiPlus, FiCheckCircle } from 'react-icons/fi'
 import { ReminderForm } from '@/components/reminders/ReminderForm'
 import { RemindersList } from '@/components/reminders/RemindersList'
-import type { Category, ReminderWithCategory } from '@/types/database.types'
+import { TransactionForm } from '@/components/transactions/TransactionForm'
+import { remindersForDate } from '@/lib/reminders/matches-date'
+import { getLocalDateString } from '@/lib/utils/dates'
+import type { Account, Category, ReminderWithCategory } from '@/types/database.types'
 
 interface Props {
   userId: string
   categories: Category[]
+  accounts: Account[]
   initialReminders: ReminderWithCategory[]
 }
 
-export function RecordatoriosTab({ userId, categories, initialReminders }: Props) {
+export function RecordatoriosTab({ userId, categories, accounts, initialReminders }: Props) {
   const router = useRouter()
   const [isFormOpen, setIsFormOpen] = useState(false)
+  const [payingReminder, setPayingReminder] = useState<ReminderWithCategory | null>(null)
 
   const refresh = () => router.refresh()
+  const today = useMemo(() => new Date(), [])
+  const todayStr = getLocalDateString(today)
+
+  const pinnedToday = useMemo(
+    () => remindersForDate(initialReminders, today),
+    [initialReminders, today],
+  )
 
   return (
     <VStack alignItems="flex-start" gap={{ base: 4, md: 6 }} w="full">
@@ -35,6 +47,50 @@ export function RecordatoriosTab({ userId, categories, initialReminders }: Props
           Nuevo recordatorio
         </Button>
       </HStack>
+
+      {pinnedToday.length > 0 && (
+        <VStack gap={2} align="stretch" w="full">
+          <Text fontSize="sm" color="#B0B0B0">
+            📌 Para hoy
+          </Text>
+          {pinnedToday.map((r) => (
+            <Box
+              key={r.id}
+              borderWidth="1px"
+              borderRadius="xl"
+              borderColor="#4F46E5"
+              bg="#1a1a2e"
+              px={4}
+              py={3}
+            >
+              <HStack justify="space-between" align="center" flexWrap="wrap" gap={3}>
+                <VStack align="start" gap={1} flex={1} minW={0}>
+                  <Text fontWeight="semibold" color="white">
+                    {r.category?.icon ?? '🔔'} {r.description}
+                  </Text>
+                  <HStack gap={2} flexWrap="wrap">
+                    <Badge size="sm" variant="outline" colorPalette="purple">Hoy</Badge>
+                    {r.category && (
+                      <Text fontSize="xs" color="#B0B0B0">{r.category.name}</Text>
+                    )}
+                  </HStack>
+                </VStack>
+                <Button
+                  size="sm"
+                  bg="#10B981"
+                  color="white"
+                  _hover={{ bg: '#059669' }}
+                  onClick={() => setPayingReminder(r)}
+                  flexShrink={0}
+                >
+                  <FiCheckCircle />
+                  Pagar
+                </Button>
+              </HStack>
+            </Box>
+          ))}
+        </VStack>
+      )}
 
       <RemindersList
         userId={userId}
@@ -53,6 +109,24 @@ export function RecordatoriosTab({ userId, categories, initialReminders }: Props
           refresh()
         }}
       />
+
+      {payingReminder && (
+        <TransactionForm
+          isOpen
+          onClose={() => setPayingReminder(null)}
+          userId={userId}
+          categories={categories}
+          accounts={accounts}
+          initialDate={todayStr}
+          lockedDate
+          prefillDescription={payingReminder.description}
+          prefillCategoryId={payingReminder.category_id ?? undefined}
+          onSuccess={() => {
+            setPayingReminder(null)
+            refresh()
+          }}
+        />
+      )}
     </VStack>
   )
 }

--- a/components/reminders/RecordatoriosTab.tsx
+++ b/components/reminders/RecordatoriosTab.tsx
@@ -1,0 +1,58 @@
+'use client'
+
+import { VStack, HStack, Heading, Button } from '@chakra-ui/react'
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { FiPlus } from 'react-icons/fi'
+import { ReminderForm } from '@/components/reminders/ReminderForm'
+import { RemindersList } from '@/components/reminders/RemindersList'
+import type { Category, ReminderWithCategory } from '@/types/database.types'
+
+interface Props {
+  userId: string
+  categories: Category[]
+  initialReminders: ReminderWithCategory[]
+}
+
+export function RecordatoriosTab({ userId, categories, initialReminders }: Props) {
+  const router = useRouter()
+  const [isFormOpen, setIsFormOpen] = useState(false)
+
+  const refresh = () => router.refresh()
+
+  return (
+    <VStack alignItems="flex-start" gap={{ base: 4, md: 6 }} w="full">
+      <HStack justifyContent="space-between" width="100%">
+        <Heading size={{ base: 'md', md: 'lg' }}>Recordatorios</Heading>
+        <Button
+          bg="#4F46E5"
+          color="white"
+          _hover={{ bg: '#4338CA' }}
+          onClick={() => setIsFormOpen(true)}
+          size={{ base: 'sm', md: 'md' }}
+        >
+          <FiPlus />
+          Nuevo recordatorio
+        </Button>
+      </HStack>
+
+      <RemindersList
+        userId={userId}
+        reminders={initialReminders}
+        categories={categories}
+        onRefresh={refresh}
+      />
+
+      <ReminderForm
+        isOpen={isFormOpen}
+        onClose={() => setIsFormOpen(false)}
+        userId={userId}
+        categories={categories}
+        onSuccess={() => {
+          setIsFormOpen(false)
+          refresh()
+        }}
+      />
+    </VStack>
+  )
+}

--- a/lib/actions/recurring.actions.ts
+++ b/lib/actions/recurring.actions.ts
@@ -34,6 +34,7 @@ export async function createRecurringTransaction(
         frequency: validated.frequency,
         start_date: validated.start_date,
         end_date: validated.end_date || null,
+        is_active: true,
       }])
       .select('*, category:categories(*)')
       .single()
@@ -42,6 +43,7 @@ export async function createRecurringTransaction(
 
     revalidatePath('/recurring-transactions')
     revalidatePath('/movimientos')
+    revalidatePath('/calendar')
     return { success: true, data: transaction as RecurringTransactionWithCategory }
   } catch (error) {
     console.error('Create recurring transaction error:', error)
@@ -91,6 +93,7 @@ export async function updateRecurringTransaction(
 
     revalidatePath('/recurring-transactions')
     revalidatePath('/movimientos')
+    revalidatePath('/calendar')
     return { success: true, data: transaction as RecurringTransactionWithCategory }
   } catch (error) {
     console.error('Update recurring transaction error:', error)
@@ -110,6 +113,7 @@ export async function deleteRecurringTransaction(id: string, userId: string) {
 
     revalidatePath('/recurring-transactions')
     revalidatePath('/movimientos')
+    revalidatePath('/calendar')
     return { success: true }
   } catch (error) {
     console.error('Delete recurring transaction error:', error)
@@ -131,6 +135,7 @@ export async function toggleRecurringTransaction(id: string, userId: string, isA
 
     revalidatePath('/recurring-transactions')
     revalidatePath('/movimientos')
+    revalidatePath('/calendar')
     return { success: true, data: data as RecurringTransactionWithCategory }
   } catch (error) {
     console.error('Toggle recurring transaction error:', error)

--- a/lib/actions/reminders.actions.ts
+++ b/lib/actions/reminders.actions.ts
@@ -28,6 +28,7 @@ export async function createReminder(userId: string, input: ReminderFormData) {
   if (error) return { success: false, error: error.message }
 
   revalidatePath('/calendar')
+  revalidatePath('/movimientos')
   return { success: true, data }
 }
 
@@ -46,6 +47,7 @@ export async function updateReminder(userId: string, id: string, input: Reminder
   if (error) return { success: false, error: error.message }
 
   revalidatePath('/calendar')
+  revalidatePath('/movimientos')
   return { success: true, data }
 }
 
@@ -59,5 +61,6 @@ export async function deleteReminder(userId: string, id: string) {
   if (error) return { success: false, error: error.message }
 
   revalidatePath('/calendar')
+  revalidatePath('/movimientos')
   return { success: true }
 }

--- a/lib/actions/transactions.actions.ts
+++ b/lib/actions/transactions.actions.ts
@@ -42,6 +42,23 @@ export async function createTransaction(
   }
 }
 
+export async function getTransactionsByDate(userId: string, date: string) {
+  if (!userId) return { success: false, error: 'User ID is required' }
+  try {
+    const { data, error } = await insforgeAdmin.database
+      .from('transactions')
+      .select('id, description, category_id, date')
+      .eq('user_id', userId)
+      .eq('date', date)
+
+    if (error) throw error
+    return { success: true, data: data ?? [] }
+  } catch (error) {
+    console.error('Get transactions by date error:', error)
+    return { success: false, error: 'Failed to fetch transactions' }
+  }
+}
+
 export async function getTransactions(userId: string, limit = 50) {
   if (!userId) {
     console.error('getTransactions: userId is missing')

--- a/lib/reminders/matches-date.ts
+++ b/lib/reminders/matches-date.ts
@@ -1,0 +1,31 @@
+import type { ReminderWithCategory } from '@/types/database.types'
+import { getLocalDateString } from '@/lib/utils/dates'
+
+export function reminderMatchesDate(reminder: ReminderWithCategory, date: Date): boolean {
+  if (!reminder.is_active) return false
+
+  const dayOfWeek = date.getDay()
+  const day = date.getDate()
+  const month = date.getMonth()
+  const dateStr = getLocalDateString(date)
+
+  switch (reminder.frequency) {
+    case 'once':
+      return reminder.specific_date === dateStr
+    case 'weekly':
+      return reminder.day_of_week === dayOfWeek
+    case 'monthly':
+      return reminder.day_of_month === day
+    case 'yearly':
+      return reminder.day_of_month === day && reminder.month_of_year === month + 1
+    default:
+      return false
+  }
+}
+
+export function remindersForDate(
+  reminders: ReminderWithCategory[],
+  date: Date,
+): ReminderWithCategory[] {
+  return reminders.filter((r) => reminderMatchesDate(r, date))
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expense-manager",
-  "version": "2.5.0",
+  "version": "3.2.0",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary

PR de release `develop → main` para tu **revisión y merge manual**. Cuando lo mergees, crearé el tag `v3.2.0` y publicaré el release.

### Fase 1 — Calendar
- **#425** fix(recurring): set `is_active=true` on create + `revalidatePath('/calendar')` en todas las mutaciones de recurrentes.
- **#426** feat(calendar): botón "Nueva recurrente" en el diálogo de día con `prefillStartDate`.

### Fase 2 — Movimientos
- **#431** chore(reminders): revalidate `/movimientos` en CRUD.
- **#432** feat(movimientos): nueva tab "Recordatorios" con listado + CRUD.
- **#433** feat(recordatorios): pin del día con botón "Pagar" + extracción de matching a `lib/reminders/matches-date.ts`.
- **#434** feat(recordatorios): ocultar pin tras pagar hoy (`getTransactionsByDate`).

### Fase 3 — Release
- **#440** chore(release): bump a `3.2.0` + sección de changelog `[3.2.0] — 2026-05-21`.

## Test plan

- [ ] Crear una recurrente nueva → aparece en `/calendar` tab "Programado".
- [ ] `/calendar` día → "Nueva recurrente" funciona con `start_date` prellenada.
- [ ] `/movimientos?tab=recordatorios` → ver listado, crear/editar/eliminar refresca sin reload.
- [ ] Recordatorio cuyo día = hoy → aparece fijado arriba con botón "Pagar".
- [ ] Pulsar "Pagar" registra transacción y el pin desaparece.
- [ ] Otros recordatorios del mismo día no pagados siguen apareciendo.
- [ ] `package.json` y `CHANGELOG.md` reflejan v3.2.0.

Closes #424
Closes #430
Closes #439