### PR TITLE
chore(reminders): revalidate /movimientos after create/update/delete

### DIFF
--- a/lib/actions/reminders.actions.ts
+++ b/lib/actions/reminders.actions.ts
@@ -28,6 +28,7 @@ export async function createReminder(userId: string, input: ReminderFormData) {
   if (error) return { success: false, error: error.message }
 
   revalidatePath('/calendar')
+  revalidatePath('/movimientos')
   return { success: true, data }
 }
 
@@ -46,6 +47,7 @@ export async function updateReminder(userId: string, id: string, input: Reminder
   if (error) return { success: false, error: error.message }
 
   revalidatePath('/calendar')
+  revalidatePath('/movimientos')
   return { success: true, data }
 }
 
@@ -59,5 +61,6 @@ export async function deleteReminder(userId: string, id: string) {
   if (error) return { success: false, error: error.message }
 
   revalidatePath('/calendar')
+  revalidatePath('/movimientos')
   return { success: true }
 }


### PR DESCRIPTION
## Summary

Las server actions de recordatorios ahora revalidan también `/movimientos`, en preparación para la nueva tab "Recordatorios". `/calendar` se mantiene.

## Test plan

- [x] Lint limpio
- [ ] Tras los siguientes PRs de la fase 2, verificar manualmente que create/edit/delete refrescan la nueva tab sin recarga.

Closes #431
Part of #430

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fk4EciPsQP5wLxcSV39d8q)_