### PR TITLE
feat(movimientos): add Recordatorios tab with list and CRUD

### DIFF
--- a/app/(dashboard)/movimientos/MovimientosPageClient.tsx
+++ b/app/(dashboard)/movimientos/MovimientosPageClient.tsx
@@ -3,19 +3,21 @@
 import { useTransition, useState, useEffect } from 'react'
 import { Box, Heading, Tabs, Spinner, Icon } from '@chakra-ui/react'
 import { useRouter } from 'next/navigation'
-import { FiList, FiRepeat, FiCreditCard } from 'react-icons/fi'
+import { FiList, FiRepeat, FiCreditCard, FiBell } from 'react-icons/fi'
 import { TransactionsPageClient } from '../transactions/TransactionsPageClient'
 import { RecurringTransactionsPageContent } from '@/components/recurring/RecurringTransactionsPageContent'
 import { LoansPageClient } from '../loans/LoansPageClient'
+import { RecordatoriosTab } from '@/components/reminders/RecordatoriosTab'
 import type {
   Account,
   Category,
   TransactionWithCategory,
   LoanWithAccount,
   RecurringTransactionWithCategory,
+  ReminderWithCategory,
 } from '@/types/database.types'
 
-type Tab = 'transacciones' | 'recurrentes' | 'prestamos'
+type Tab = 'transacciones' | 'recurrentes' | 'prestamos' | 'recordatorios'
 
 interface Props {
   userId: string
@@ -25,6 +27,7 @@ interface Props {
   initialTransactions: TransactionWithCategory[] | null
   initialRecurring: RecurringTransactionWithCategory[] | null
   initialLoans: LoanWithAccount[] | null
+  initialReminders: ReminderWithCategory[] | null
 }
 
 export function MovimientosPageClient({
@@ -35,6 +38,7 @@ export function MovimientosPageClient({
   initialTransactions,
   initialRecurring,
   initialLoans,
+  initialReminders,
 }: Props) {
   const router = useRouter()
   const [isPending, startTransition] = useTransition()
@@ -111,6 +115,17 @@ export function MovimientosPageClient({
             {tabIcon('prestamos', FiCreditCard)}
             Préstamos
           </Tabs.Trigger>
+          <Tabs.Trigger
+            value="recordatorios"
+            display="flex"
+            alignItems="center"
+            gap={2}
+            color="#B0B0B0"
+            _selected={{ color: 'white', borderBottomColor: '#6366f1' }}
+          >
+            {tabIcon('recordatorios', FiBell)}
+            Recordatorios
+          </Tabs.Trigger>
         </Tabs.List>
 
         <Tabs.Content value="transacciones">
@@ -141,6 +156,16 @@ export function MovimientosPageClient({
               userId={userId}
               initialLoans={initialLoans}
               accounts={accounts}
+            />
+          )}
+        </Tabs.Content>
+
+        <Tabs.Content value="recordatorios">
+          {initialReminders !== null && (
+            <RecordatoriosTab
+              userId={userId}
+              categories={categories}
+              initialReminders={initialReminders}
             />
           )}
         </Tabs.Content>

--- a/app/(dashboard)/movimientos/page.tsx
+++ b/app/(dashboard)/movimientos/page.tsx
@@ -7,10 +7,11 @@ import { getAccounts } from '@/lib/actions/accounts.actions'
 import { getTransactions } from '@/lib/actions/transactions.actions'
 import { getRecurringTransactions } from '@/lib/actions/recurring.actions'
 import { getLoans } from '@/lib/actions/loans.actions'
+import { getReminders } from '@/lib/actions/reminders.actions'
 import { MovimientosPageClient } from './MovimientosPageClient'
-import type { TransactionWithCategory, Account } from '@/types/database.types'
+import type { TransactionWithCategory, Account, ReminderWithCategory } from '@/types/database.types'
 
-type Tab = 'transacciones' | 'recurrentes' | 'prestamos'
+type Tab = 'transacciones' | 'recurrentes' | 'prestamos' | 'recordatorios'
 
 export default async function MovimientosPage({
   searchParams,
@@ -48,6 +49,7 @@ export default async function MovimientosPage({
   let initialRecurring: any[] | null = null
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let initialLoans: any[] | null = null
+  let initialReminders: ReminderWithCategory[] | null = null
 
   if (tab === 'transacciones') {
     const result = await getTransactions(user.id, 500)
@@ -58,6 +60,9 @@ export default async function MovimientosPage({
   } else if (tab === 'prestamos') {
     const result = await getLoans(user.id)
     initialLoans = result.success && result.data ? result.data : []
+  } else if (tab === 'recordatorios') {
+    const result = await getReminders(user.id)
+    initialReminders = result.success ? ((result.data ?? []) as ReminderWithCategory[]) : []
   }
 
   return (
@@ -69,6 +74,7 @@ export default async function MovimientosPage({
       initialTransactions={initialTransactions}
       initialRecurring={initialRecurring}
       initialLoans={initialLoans}
+      initialReminders={initialReminders}
     />
   )
 }

--- a/components/reminders/RecordatoriosTab.tsx
+++ b/components/reminders/RecordatoriosTab.tsx
@@ -1,0 +1,58 @@
+'use client'
+
+import { VStack, HStack, Heading, Button } from '@chakra-ui/react'
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { FiPlus } from 'react-icons/fi'
+import { ReminderForm } from '@/components/reminders/ReminderForm'
+import { RemindersList } from '@/components/reminders/RemindersList'
+import type { Category, ReminderWithCategory } from '@/types/database.types'
+
+interface Props {
+  userId: string
+  categories: Category[]
+  initialReminders: ReminderWithCategory[]
+}
+
+export function RecordatoriosTab({ userId, categories, initialReminders }: Props) {
+  const router = useRouter()
+  const [isFormOpen, setIsFormOpen] = useState(false)
+
+  const refresh = () => router.refresh()
+
+  return (
+    <VStack alignItems="flex-start" gap={{ base: 4, md: 6 }} w="full">
+      <HStack justifyContent="space-between" width="100%">
+        <Heading size={{ base: 'md', md: 'lg' }}>Recordatorios</Heading>
+        <Button
+          bg="#4F46E5"
+          color="white"
+          _hover={{ bg: '#4338CA' }}
+          onClick={() => setIsFormOpen(true)}
+          size={{ base: 'sm', md: 'md' }}
+        >
+          <FiPlus />
+          Nuevo recordatorio
+        </Button>
+      </HStack>
+
+      <RemindersList
+        userId={userId}
+        reminders={initialReminders}
+        categories={categories}
+        onRefresh={refresh}
+      />
+
+      <ReminderForm
+        isOpen={isFormOpen}
+        onClose={() => setIsFormOpen(false)}
+        userId={userId}
+        categories={categories}
+        onSuccess={() => {
+          setIsFormOpen(false)
+          refresh()
+        }}
+      />
+    </VStack>
+  )
+}


### PR DESCRIPTION
## Summary

- Nueva tab "Recordatorios" en `/movimientos` (icono `FiBell`) con CRUD completo.
- `page.tsx` server-fetchea `getReminders(user.id)` solo cuando la tab activa es `recordatorios`.
- Nuevo componente `RecordatoriosTab` que reusa `ReminderForm` (crear) y `RemindersList` (editar/eliminar).
- URL `?tab=recordatorios` soportada como las demás tabs.

> Nota: el pin del día y el botón "Pagar" se entregan por separado en #433. Este PR es el cimiento.

## Test plan

- [x] `pnpm type-check` y `pnpm lint` limpios en archivos tocados (el único error de lint en `MovimientosPageClient.tsx` es pre-existente).
- [ ] Manual: navegar a `/movimientos?tab=recordatorios` → ver tab y listado.
- [ ] Manual: crear, editar y eliminar recordatorios → la lista se actualiza sin recarga.

Closes #432
Part of #430

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fk4EciPsQP5wLxcSV39d8q)_