### PR TITLE
feat(recordatorios): pin today's reminders with Pagar action

### DIFF
--- a/app/(dashboard)/movimientos/MovimientosPageClient.tsx
+++ b/app/(dashboard)/movimientos/MovimientosPageClient.tsx
@@ -165,6 +165,7 @@ export function MovimientosPageClient({
             <RecordatoriosTab
               userId={userId}
               categories={categories}
+              accounts={accounts}
               initialReminders={initialReminders}
             />
           )}

--- a/components/calendar/RemindersCalendar.tsx
+++ b/components/calendar/RemindersCalendar.tsx
@@ -26,6 +26,7 @@ import { FiPlus, FiX } from 'react-icons/fi'
 import type { ReminderWithCategory, RecurringTransactionWithCategory, Account, Category } from '@/types/database.types'
 import { formatCurrency } from '@/lib/utils/currency'
 import { getLocalDateString } from '@/lib/utils/dates'
+import { reminderMatchesDate } from '@/lib/reminders/matches-date'
 import { TransactionForm } from '@/components/transactions/TransactionForm'
 import { ReminderForm } from '@/components/reminders/ReminderForm'
 import { RecurringTransactionForm } from '@/components/recurring/RecurringTransactionForm'
@@ -58,23 +59,7 @@ function getItemsForDay(
   const items: DayItem[] = []
 
   for (const r of reminders) {
-    if (!r.is_active) continue
-    let matches = false
-    switch (r.frequency) {
-      case 'once':
-        matches = r.specific_date === dateStr
-        break
-      case 'weekly':
-        matches = r.day_of_week === dayOfWeek
-        break
-      case 'monthly':
-        matches = r.day_of_month === day
-        break
-      case 'yearly':
-        matches = r.day_of_month === day && r.month_of_year === (month + 1)
-        break
-    }
-    if (matches) {
+    if (reminderMatchesDate(r, date)) {
       items.push({
         type: 'reminder',
         label: r.description,

--- a/components/reminders/RecordatoriosTab.tsx
+++ b/components/reminders/RecordatoriosTab.tsx
@@ -1,24 +1,36 @@
 'use client'
 
-import { VStack, HStack, Heading, Button } from '@chakra-ui/react'
-import { useState } from 'react'
+import { VStack, HStack, Heading, Button, Box, Text, Badge } from '@chakra-ui/react'
+import { useMemo, useState } from 'react'
 import { useRouter } from 'next/navigation'
-import { FiPlus } from 'react-icons/fi'
+import { FiPlus, FiCheckCircle } from 'react-icons/fi'
 import { ReminderForm } from '@/components/reminders/ReminderForm'
 import { RemindersList } from '@/components/reminders/RemindersList'
-import type { Category, ReminderWithCategory } from '@/types/database.types'
+import { TransactionForm } from '@/components/transactions/TransactionForm'
+import { remindersForDate } from '@/lib/reminders/matches-date'
+import { getLocalDateString } from '@/lib/utils/dates'
+import type { Account, Category, ReminderWithCategory } from '@/types/database.types'
 
 interface Props {
   userId: string
   categories: Category[]
+  accounts: Account[]
   initialReminders: ReminderWithCategory[]
 }
 
-export function RecordatoriosTab({ userId, categories, initialReminders }: Props) {
+export function RecordatoriosTab({ userId, categories, accounts, initialReminders }: Props) {
   const router = useRouter()
   const [isFormOpen, setIsFormOpen] = useState(false)
+  const [payingReminder, setPayingReminder] = useState<ReminderWithCategory | null>(null)
 
   const refresh = () => router.refresh()
+  const today = useMemo(() => new Date(), [])
+  const todayStr = getLocalDateString(today)
+
+  const pinnedToday = useMemo(
+    () => remindersForDate(initialReminders, today),
+    [initialReminders, today],
+  )
 
   return (
     <VStack alignItems="flex-start" gap={{ base: 4, md: 6 }} w="full">
@@ -35,6 +47,50 @@ export function RecordatoriosTab({ userId, categories, initialReminders }: Props
           Nuevo recordatorio
         </Button>
       </HStack>
+
+      {pinnedToday.length > 0 && (
+        <VStack gap={2} align="stretch" w="full">
+          <Text fontSize="sm" color="#B0B0B0">
+            📌 Para hoy
+          </Text>
+          {pinnedToday.map((r) => (
+            <Box
+              key={r.id}
+              borderWidth="1px"
+              borderRadius="xl"
+              borderColor="#4F46E5"
+              bg="#1a1a2e"
+              px={4}
+              py={3}
+            >
+              <HStack justify="space-between" align="center" flexWrap="wrap" gap={3}>
+                <VStack align="start" gap={1} flex={1} minW={0}>
+                  <Text fontWeight="semibold" color="white">
+                    {r.category?.icon ?? '🔔'} {r.description}
+                  </Text>
+                  <HStack gap={2} flexWrap="wrap">
+                    <Badge size="sm" variant="outline" colorPalette="purple">Hoy</Badge>
+                    {r.category && (
+                      <Text fontSize="xs" color="#B0B0B0">{r.category.name}</Text>
+                    )}
+                  </HStack>
+                </VStack>
+                <Button
+                  size="sm"
+                  bg="#10B981"
+                  color="white"
+                  _hover={{ bg: '#059669' }}
+                  onClick={() => setPayingReminder(r)}
+                  flexShrink={0}
+                >
+                  <FiCheckCircle />
+                  Pagar
+                </Button>
+              </HStack>
+            </Box>
+          ))}
+        </VStack>
+      )}
 
       <RemindersList
         userId={userId}
@@ -53,6 +109,24 @@ export function RecordatoriosTab({ userId, categories, initialReminders }: Props
           refresh()
         }}
       />
+
+      {payingReminder && (
+        <TransactionForm
+          isOpen
+          onClose={() => setPayingReminder(null)}
+          userId={userId}
+          categories={categories}
+          accounts={accounts}
+          initialDate={todayStr}
+          lockedDate
+          prefillDescription={payingReminder.description}
+          prefillCategoryId={payingReminder.category_id ?? undefined}
+          onSuccess={() => {
+            setPayingReminder(null)
+            refresh()
+          }}
+        />
+      )}
     </VStack>
   )
 }

--- a/lib/reminders/matches-date.ts
+++ b/lib/reminders/matches-date.ts
@@ -1,0 +1,31 @@
+import type { ReminderWithCategory } from '@/types/database.types'
+import { getLocalDateString } from '@/lib/utils/dates'
+
+export function reminderMatchesDate(reminder: ReminderWithCategory, date: Date): boolean {
+  if (!reminder.is_active) return false
+
+  const dayOfWeek = date.getDay()
+  const day = date.getDate()
+  const month = date.getMonth()
+  const dateStr = getLocalDateString(date)
+
+  switch (reminder.frequency) {
+    case 'once':
+      return reminder.specific_date === dateStr
+    case 'weekly':
+      return reminder.day_of_week === dayOfWeek
+    case 'monthly':
+      return reminder.day_of_month === day
+    case 'yearly':
+      return reminder.day_of_month === day && reminder.month_of_year === month + 1
+    default:
+      return false
+  }
+}
+
+export function remindersForDate(
+  reminders: ReminderWithCategory[],
+  date: Date,
+): ReminderWithCategory[] {
+  return reminders.filter((r) => reminderMatchesDate(r, date))
+}


### PR DESCRIPTION
## Summary

- Nueva util `lib/reminders/matches-date.ts` con `reminderMatchesDate` y `remindersForDate` — single source of truth para el matching.
- `RemindersCalendar` ahora consume el helper en su loop de reminders.
- `RecordatoriosTab` muestra arriba como tarjetas fijadas los recordatorios cuyo día coincide con hoy.
- Botón "Pagar" abre `TransactionForm` con `initialDate=hoy`, `lockedDate`, `prefillDescription` y `prefillCategoryId` (mismos prefills que el flujo de calendario).
- Tras pagar, `router.refresh()` repinta lista y pin.

## Test plan

- [x] `pnpm type-check` y lint limpios en archivos tocados (error pre-existente en `MovimientosPageClient.tsx` no introducido aquí).
- [ ] Manual: crear recordatorio mensual con `day_of_month` = hoy → ver tarjeta fijada en la tab.
- [ ] Manual: pulsar "Pagar", guardar transacción → se registra correctamente.
- [ ] Manual: cambiar el día del recordatorio → ya no aparece como fijado.

> El comportamiento de "ocultar el pin tras pagar hoy" se entrega en #434.

Closes #433
Part of #430

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fk4EciPsQP5wLxcSV39d8q)_