### PR TITLE
feat(recordatorios): hide pinned reminder once paid today

### DIFF
--- a/app/(dashboard)/movimientos/MovimientosPageClient.tsx
+++ b/app/(dashboard)/movimientos/MovimientosPageClient.tsx
@@ -28,6 +28,7 @@ interface Props {
   initialRecurring: RecurringTransactionWithCategory[] | null
   initialLoans: LoanWithAccount[] | null
   initialReminders: ReminderWithCategory[] | null
+  todaysTransactions: { description: string; category_id: string | null }[]
 }
 
 export function MovimientosPageClient({
@@ -39,6 +40,7 @@ export function MovimientosPageClient({
   initialRecurring,
   initialLoans,
   initialReminders,
+  todaysTransactions,
 }: Props) {
   const router = useRouter()
   const [isPending, startTransition] = useTransition()
@@ -167,6 +169,7 @@ export function MovimientosPageClient({
               categories={categories}
               accounts={accounts}
               initialReminders={initialReminders}
+              todaysTransactions={todaysTransactions}
             />
           )}
         </Tabs.Content>

--- a/app/(dashboard)/movimientos/page.tsx
+++ b/app/(dashboard)/movimientos/page.tsx
@@ -4,7 +4,8 @@ import { redirect } from 'next/navigation'
 import { insforgeAdmin } from '@/lib/insforge-admin'
 import { getCategories } from '@/lib/actions/categories.actions'
 import { getAccounts } from '@/lib/actions/accounts.actions'
-import { getTransactions } from '@/lib/actions/transactions.actions'
+import { getTransactions, getTransactionsByDate } from '@/lib/actions/transactions.actions'
+import { getLocalDateString } from '@/lib/utils/dates'
 import { getRecurringTransactions } from '@/lib/actions/recurring.actions'
 import { getLoans } from '@/lib/actions/loans.actions'
 import { getReminders } from '@/lib/actions/reminders.actions'
@@ -50,6 +51,7 @@ export default async function MovimientosPage({
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let initialLoans: any[] | null = null
   let initialReminders: ReminderWithCategory[] | null = null
+  let todaysTransactions: { description: string; category_id: string | null }[] = []
 
   if (tab === 'transacciones') {
     const result = await getTransactions(user.id, 500)
@@ -61,8 +63,17 @@ export default async function MovimientosPage({
     const result = await getLoans(user.id)
     initialLoans = result.success && result.data ? result.data : []
   } else if (tab === 'recordatorios') {
-    const result = await getReminders(user.id)
-    initialReminders = result.success ? ((result.data ?? []) as ReminderWithCategory[]) : []
+    const today = getLocalDateString()
+    const [remindersResult, txResult] = await Promise.all([
+      getReminders(user.id),
+      getTransactionsByDate(user.id, today),
+    ])
+    initialReminders = remindersResult.success
+      ? ((remindersResult.data ?? []) as ReminderWithCategory[])
+      : []
+    todaysTransactions = txResult.success
+      ? (txResult.data as { description: string; category_id: string | null }[])
+      : []
   }
 
   return (
@@ -75,6 +86,7 @@ export default async function MovimientosPage({
       initialRecurring={initialRecurring}
       initialLoans={initialLoans}
       initialReminders={initialReminders}
+      todaysTransactions={todaysTransactions}
     />
   )
 }

--- a/components/reminders/RecordatoriosTab.tsx
+++ b/components/reminders/RecordatoriosTab.tsx
@@ -16,9 +16,16 @@ interface Props {
   categories: Category[]
   accounts: Account[]
   initialReminders: ReminderWithCategory[]
+  todaysTransactions: { description: string; category_id: string | null }[]
 }
 
-export function RecordatoriosTab({ userId, categories, accounts, initialReminders }: Props) {
+export function RecordatoriosTab({
+  userId,
+  categories,
+  accounts,
+  initialReminders,
+  todaysTransactions,
+}: Props) {
   const router = useRouter()
   const [isFormOpen, setIsFormOpen] = useState(false)
   const [payingReminder, setPayingReminder] = useState<ReminderWithCategory | null>(null)
@@ -27,10 +34,15 @@ export function RecordatoriosTab({ userId, categories, accounts, initialReminder
   const today = useMemo(() => new Date(), [])
   const todayStr = getLocalDateString(today)
 
-  const pinnedToday = useMemo(
-    () => remindersForDate(initialReminders, today),
-    [initialReminders, today],
-  )
+  const pinnedToday = useMemo(() => {
+    const matches = remindersForDate(initialReminders, today)
+    return matches.filter(
+      (r) =>
+        !todaysTransactions.some(
+          (tx) => tx.description === r.description && tx.category_id === r.category_id,
+        ),
+    )
+  }, [initialReminders, today, todaysTransactions])
 
   return (
     <VStack alignItems="flex-start" gap={{ base: 4, md: 6 }} w="full">

--- a/lib/actions/transactions.actions.ts
+++ b/lib/actions/transactions.actions.ts
@@ -42,6 +42,23 @@ export async function createTransaction(
   }
 }
 
+export async function getTransactionsByDate(userId: string, date: string) {
+  if (!userId) return { success: false, error: 'User ID is required' }
+  try {
+    const { data, error } = await insforgeAdmin.database
+      .from('transactions')
+      .select('id, description, category_id, date')
+      .eq('user_id', userId)
+      .eq('date', date)
+
+    if (error) throw error
+    return { success: true, data: data ?? [] }
+  } catch (error) {
+    console.error('Get transactions by date error:', error)
+    return { success: false, error: 'Failed to fetch transactions' }
+  }
+}
+
 export async function getTransactions(userId: string, limit = 50) {
   if (!userId) {
     console.error('getTransactions: userId is missing')


### PR DESCRIPTION
## Summary

- Nueva server action `getTransactionsByDate(userId, date)` que devuelve `id, description, category_id, date` para la fecha pedida (consulta indexada por `date`).
- `movimientos/page.tsx` la invoca en paralelo con `getReminders` cuando la tab es `recordatorios`, pasando `todaysTransactions` a `RecordatoriosTab`.
- `RecordatoriosTab` filtra el array de pin descartando recordatorios que ya tienen una transacción del día con la misma `description` y `category_id` (mismos campos que prefillan `TransactionForm` al "Pagar").

## Test plan

- [x] `pnpm type-check` y `pnpm lint` limpios en archivos tocados.
- [ ] Manual: pinned aparece → pulsar "Pagar" → guardar → el pin desaparece de la tab tras `router.refresh()`.
- [ ] Manual: otro recordatorio del mismo día (distinta descripción o categoría) sigue apareciendo.
- [ ] Manual: una transacción manual no relacionada no afecta a los pines.

Closes #434
Part of #430

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fk4EciPsQP5wLxcSV39d8q)_