### PR TITLE
fix(gmail): nuevo remitente Bancolombia, transferencias por botón y merchants con */()

### DIFF
--- a/lib/gmail/parsers/bancolombia.ts
+++ b/lib/gmail/parsers/bancolombia.ts
@@ -6,11 +6,15 @@ const BANCOLOMBIA_SENDERS = [
   'alertasynotificaciones@notificacionesbancolombia.com',
   'alertasynotificaciones@bancolombia.com.co',
   'alertasynotificaciones@an.notificacionesbancolombia.com',
+  'alertasynotificaciones@ayn.ayn.notificacionesbancolombia.com',
 ]
+
+const BANCOLOMBIA_DOMAIN_PATTERN = /(?:^|[@.])(?:notificacionesbancolombia\.com|bancolombia\.com\.co)\b/i
 
 export function isBancolombiaSender(fromHeader: string): boolean {
   const lower = fromHeader.toLowerCase()
-  return BANCOLOMBIA_SENDERS.some((s) => lower.includes(s))
+  if (BANCOLOMBIA_SENDERS.some((s) => lower.includes(s))) return true
+  return BANCOLOMBIA_DOMAIN_PATTERN.test(lower)
 }
 
 function parseAmount(raw: string): number | null {
@@ -65,7 +69,7 @@ const RULES: Array<{
   {
     name: 'compra_tarjeta_v2',
     pattern:
-      /compraste\s+\$?\s*([\d.,]+)\s+en\s+([A-Z0-9 .,&'\-/]+?)\s+con\s+tu\s+t\.?\s*(?:deb|cred)\s*\*?(\d{4})/i,
+      /compraste\s+\$?\s*([\d.,]+)\s+en\s+([A-Z0-9 .,&'\-/*()]+?)\s+con\s+tu\s+t\.?\s*(?:deb|cred)\s*\*?(\d{4})/i,
     build: (m) => ({
       type: 'expense',
       amountRaw: m[1],
@@ -95,7 +99,7 @@ const RULES: Array<{
   {
     name: 'compra_tarjeta',
     pattern:
-      /compra(?:ste)?\s+por\s+\$?\s*([\d.,]+)\s+(?:con\s+tarjeta\s+)?(?:de\s+cr[eé]dito|de\s+d[eé]bito|t\.?\s*(?:cred|deb))?[^.]*?en\s+([A-Z0-9 .,&'\-/*]+?)(?:\s+el\s|\s+\.|\.|\s+t\.?\s*(?:cred|deb)\b|\s+tarjeta\b)/i,
+      /compra(?:ste)?\s+por\s+\$?\s*([\d.,]+)\s+(?:con\s+tarjeta\s+)?(?:de\s+cr[eé]dito|de\s+d[eé]bito|t\.?\s*(?:cred|deb))?[^.]*?en\s+([A-Z0-9 .,&'\-/*()]+?)(?:\s+el\s|\s+\.|\.|\s+t\.?\s*(?:cred|deb)\b|\s+tarjeta\b)/i,
     build: (m) => {
       const lastFourMatch = m.input?.match(/\*+\s*(\d{4})\b|tarjeta[^\d]{0,15}(\d{4})\b/i)
       const lastFour = lastFourMatch?.[1] ?? lastFourMatch?.[2] ?? null
@@ -107,6 +111,24 @@ const RULES: Array<{
         lastFour,
         description: `Compra en ${merchant}`,
         matchedRule: 'compra_tarjeta',
+      }
+    },
+  },
+  {
+    name: 'transferencia_boton',
+    pattern:
+      /transferiste\s+\$?\s*([\d.,]+)\s+por\s+([A-Za-z0-9 .,&'\-/]+?)\s+a\s+([A-Z0-9 .,&'\-/]+?)\s+desde\s+(?:producto|cuenta)\s+\*?(\d{4,})/i,
+    build: (m) => {
+      const method = m[2].trim().replace(/\s+/g, ' ')
+      const merchant = m[3].trim().replace(/\s+/g, ' ')
+      const lastFour = m[4].slice(-4)
+      return {
+        type: 'expense',
+        amountRaw: m[1],
+        merchant,
+        lastFour,
+        description: `Transferencia a ${merchant} (${method})`,
+        matchedRule: 'transferencia_boton',
       }
     },
   },

--- a/lib/gmail/process.ts
+++ b/lib/gmail/process.ts
@@ -6,7 +6,7 @@ import { getParserForSender, type ParsedTransaction } from './parsers'
 const DEFAULT_LOOKBACK_DAYS = 7
 
 const COMBINED_QUERY =
-  'from:(notificacionesbancolombia@bancolombia.com.co OR alertasynotificaciones@notificacionesbancolombia.com OR alertasynotificaciones@bancolombia.com.co OR alertasynotificaciones@an.notificacionesbancolombia.com OR do-not-reply@ses.binance.com OR notificaciones@bancomercantil.com)'
+  'from:(notificacionesbancolombia@bancolombia.com.co OR alertasynotificaciones@notificacionesbancolombia.com OR alertasynotificaciones@bancolombia.com.co OR alertasynotificaciones@an.notificacionesbancolombia.com OR alertasynotificaciones@ayn.ayn.notificacionesbancolombia.com OR do-not-reply@ses.binance.com OR notificaciones@bancomercantil.com)'
 
 export interface ParsedItem extends ParsedTransaction {
   gmailMessageId: string


### PR DESCRIPTION
## Summary
- Acepta el remitente `alertasynotificaciones@ayn.ayn.notificacionesbancolombia.com` (lista + query de Gmail) y añade un fallback por dominio para tolerar futuros subdominios.
- Permite `*`, `(`, `)` en la clase de merchant de las reglas `compra_tarjeta_v2` y `compra_tarjeta` (p. ej. `DLO*DiDi CO Payin (R`).
- Nueva regla `transferencia_boton` para `Transferiste $X por <método> a <destino> desde producto *NNNN` (Botón Bancolombia, etc.).

Fixes 3 correos que la sync marcaba como "omitidos".

## Test plan
- [ ] Re-sincronizar Gmail tras resetear `gmail_last_synced_at` y verificar que los 3 correos previamente omitidos se registran.
- [ ] Confirmar `matchedRule` en `transactions.notes` para cada caso (`compra_tarjeta_v2`, `transferencia_boton`).
- [ ] Probar que correos del remitente nuevo se descargan en el query de Gmail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)