### PR TITLE
feat(accounts): asociar número de tarjeta a la cuenta (matching Gmail)

### DIFF
--- a/components/settings/AccountForm.tsx
+++ b/components/settings/AccountForm.tsx
@@ -39,6 +39,7 @@ const defaultForm = {
   icon: '💳',
   color: '#6366f1',
   last_four: '',
+  card_number: '',
   is_default: false,
 }
 
@@ -57,6 +58,7 @@ export function AccountForm({ isOpen, onClose, userId, editingAccount, onSuccess
         icon: editingAccount.icon ?? '💳',
         color: editingAccount.color ?? '#6366f1',
         last_four: editingAccount.last_four ?? '',
+        card_number: editingAccount.card_number ?? '',
         is_default: editingAccount.is_default ?? false,
       })
     } else {
@@ -80,6 +82,19 @@ export function AccountForm({ isOpen, onClose, userId, editingAccount, onSuccess
       setLoading(false)
       return
     }
+    // Card number only applies to non-card accounts (a card that shares the
+    // account's fund). Card-type accounts use last_four for their own card.
+    const trimmedCardNumber = isCard ? '' : formData.card_number.trim()
+    if (trimmedCardNumber && !/^[0-9]{4}$/.test(trimmedCardNumber)) {
+      toaster.create({
+        title: 'Número de tarjeta inválido',
+        description: 'Debe ser exactamente 4 dígitos numéricos',
+        type: 'error',
+        duration: 4000,
+      })
+      setLoading(false)
+      return
+    }
     const data = {
       name: formData.name,
       type: formData.type,
@@ -89,6 +104,7 @@ export function AccountForm({ isOpen, onClose, userId, editingAccount, onSuccess
       icon: formData.icon || null,
       color: formData.color || null,
       last_four: trimmedLastFour || null,
+      card_number: trimmedCardNumber || null,
       is_default: formData.is_default,
     }
 
@@ -164,6 +180,15 @@ export function AccountForm({ isOpen, onClose, userId, editingAccount, onSuccess
             onChange={(v) => setFormData({ ...formData, last_four: v.replace(/[^0-9]/g, '').slice(0, 4) })}
             placeholder="1234"
           />
+
+          {!isCard && (
+            <FormInput
+              label="Número de tarjeta asociada (para integración Gmail)"
+              value={formData.card_number}
+              onChange={(v) => setFormData({ ...formData, card_number: v.replace(/[^0-9]/g, '').slice(0, 4) })}
+              placeholder="5678"
+            />
+          )}
 
           <HStack gap={4} w="full">
             <FieldRoot>

--- a/components/transactions/GmailSyncReviewModal.tsx
+++ b/components/transactions/GmailSyncReviewModal.tsx
@@ -38,7 +38,9 @@ const SOURCE_STYLES: Record<ParserSource, { bg: string; color: string; label: st
 
 function findAccountByLastFour(accounts: Account[], lastFour: string | null): string | null {
   if (!lastFour) return null
-  const match = accounts.find((a) => a.last_four === lastFour && a.is_active)
+  const match = accounts.find(
+    (a) => (a.last_four === lastFour || a.card_number === lastFour) && a.is_active
+  )
   return match?.id ?? null
 }
 

--- a/lib/gmail/process.ts
+++ b/lib/gmail/process.ts
@@ -38,14 +38,18 @@ interface AccountRow {
   id: string
   currency: string
   last_four: string | null
+  card_number: string | null
 }
 
+// Matches the parsed 4-digit number against either the account's own number
+// (last_four) or its linked card number (card_number). Some accounts and cards
+// share the same fund, and bank emails sometimes reference the card number.
 async function findAccountByLastFour(userId: string, lastFour: string): Promise<AccountRow | null> {
   const { data } = await insforgeAdmin.database
     .from('accounts')
-    .select('id, currency, last_four')
+    .select('id, currency, last_four, card_number')
     .eq('user_id', userId)
-    .eq('last_four', lastFour)
+    .or(`last_four.eq.${lastFour},card_number.eq.${lastFour}`)
     .eq('is_active', true)
     .limit(1)
     .maybeSingle()

--- a/lib/validations/account.ts
+++ b/lib/validations/account.ts
@@ -13,6 +13,11 @@ export const createAccountSchema = z.object({
     .regex(/^[0-9]{4}$/, 'Deben ser 4 dígitos')
     .nullable()
     .optional(),
+  card_number: z
+    .string()
+    .regex(/^[0-9]{4}$/, 'Deben ser 4 dígitos')
+    .nullable()
+    .optional(),
   is_default: z.boolean().optional(),
 })
 

--- a/supabase/seeds/account-card-number-v3.5.0.sql
+++ b/supabase/seeds/account-card-number-v3.5.0.sql
@@ -1,0 +1,15 @@
+-- Migration: associate a card number with an account
+-- Run this against your InsForge/Supabase database
+--
+-- Some accounts and cards share the same fund. Bank emails sometimes reference
+-- the card number instead of the account number, so we let an account also
+-- store the last 4 digits of its linked card. Gmail matching then resolves a
+-- transaction by either last_four (the account's own number) or card_number.
+
+ALTER TABLE accounts
+  ADD COLUMN IF NOT EXISTS card_number varchar(4) NULL
+    CHECK (card_number IS NULL OR card_number ~ '^[0-9]{4}$');
+
+CREATE INDEX IF NOT EXISTS accounts_user_card_number_idx
+  ON accounts(user_id, card_number)
+  WHERE card_number IS NOT NULL;

--- a/types/database.types.ts
+++ b/types/database.types.ts
@@ -46,6 +46,7 @@ export interface Account {
   color: string | null
   icon: string | null
   last_four: string | null
+  card_number: string | null
   is_active: boolean
   is_default: boolean
   created_at: string


### PR DESCRIPTION
## Cambios
Algunas cuentas y tarjetas comparten el mismo fondo. Los correos de Gmail a veces traen el **número de tarjeta** en lugar del **número de cuenta**, lo que impedía asociar la transacción a la cuenta correcta. Se agrega un campo `card_number` a la cuenta y el matching ahora resuelve por `last_four` **OR** `card_number`.

- Migración SQL `supabase/seeds/account-card-number-v3.5.0.sql` (columna `card_number varchar(4)` + índice)
- Tipo `Account.card_number` y validación zod
- Campo nuevo en `AccountForm` (visible solo en cuentas que no son tipo tarjeta de crédito)
- Matching ampliado en server (`lib/gmail/process.ts`) y cliente (`GmailSyncReviewModal`)

## Testing
- ✅ `pnpm build` exitoso
- ⚠️ Requiere aplicar la migración SQL al backend InsForge antes de probar el matching

## Nota
La migración en `supabase/seeds/` se aplica manualmente contra la base.

Closes #451
Related to #450