### PR TITLE
fix(transactions): filtro de descripción full-width solo en mobile

### DIFF
--- a/components/transactions/TransactionsFilter.tsx
+++ b/components/transactions/TransactionsFilter.tsx
@@ -30,10 +30,11 @@ export function TransactionsFilter({ filters, onChange, categories }: Props) {
 
   return (
     <Box mb={3}>
-      {/* Search: full width */}
+      {/* Search: full width on mobile, constrained on desktop */}
       <Input
         placeholder="Buscar descripción..."
         mb={2}
+        w={{ base: '100%', md: '320px' }}
         value={filters.search}
         onChange={(e) => update({ search: e.target.value })}
         size="sm"


### PR DESCRIPTION
## Cambios
El input de búsqueda por descripción en `TransactionsFilter` ocupaba el 100% del ancho en desktop. Ahora usa `w={{ base: '100%', md: '320px' }}`: 100% en mobile y acotado (~320px) en desktop, alineado con los selects de filtros.

## Testing
- ✅ `pnpm build` exitoso
- ✅ Mobile: 100% / Desktop: acotado

Closes #453
Related to #450