### PR TITLE
chore: bump version to 3.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expense-manager",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
Bump de versión a 3.5.0 para el release de la FASE.

Related to #450