### PR TITLE
FASE 2: Consejos de Ahorro IA — panel (insights + sugerencias de presupuesto)

### DIFF
--- a/app/(dashboard)/consejos-ahorro/ConsejosAhorroPageClient.tsx
+++ b/app/(dashboard)/consejos-ahorro/ConsejosAhorroPageClient.tsx
@@ -1,0 +1,155 @@
+'use client'
+
+import { Box, Heading, Text, HStack, VStack, SimpleGrid, Icon, Spinner } from '@chakra-ui/react'
+import { useState, useTransition } from 'react'
+import { useRouter } from 'next/navigation'
+import { FiZap, FiRefreshCw, FiInbox } from 'react-icons/fi'
+import { Card } from '@/components/ui/Card'
+import { StatCard } from '@/components/ui/StatCard'
+import { PrimaryButton } from '@/components/ui/PrimaryButton'
+import { InsightsList } from '@/components/savings/InsightsList'
+import { BudgetSuggestionsList, type ExistingBudget } from '@/components/savings/BudgetSuggestionsList'
+import { generateSavingsAdvice } from '@/lib/actions/savingsAdvice.actions'
+import { formatCurrency } from '@/lib/utils/currency'
+import { toaster } from '@/lib/toaster'
+import type { AiSavingsAdvice, Category } from '@/types/database.types'
+import type { SpendingSummary } from '@/lib/actions/savingsAdvice.actions'
+
+interface Props {
+  userId: string
+  period: string
+  advice: AiSavingsAdvice | null
+  summary: SpendingSummary
+  budgets: ExistingBudget[]
+  categories: Category[]
+}
+
+function periodLabel(period: string): string {
+  const [y, m] = period.split('-').map(Number)
+  const date = new Date(y, m - 1, 1)
+  const label = date.toLocaleDateString('es-CO', { month: 'long', year: 'numeric' })
+  return label.charAt(0).toUpperCase() + label.slice(1)
+}
+
+export function ConsejosAhorroPageClient({ userId, period, advice, summary, budgets, categories }: Props) {
+  const router = useRouter()
+  const [isPending, startTransition] = useTransition()
+  const [generating, setGenerating] = useState(false)
+  const { currency } = summary
+
+  const handleGenerate = async () => {
+    setGenerating(true)
+    const result = await generateSavingsAdvice(userId, period)
+    setGenerating(false)
+
+    if (!result.success) {
+      toaster.create({ title: 'Error', description: result.error, type: 'error', duration: 4000 })
+      return
+    }
+    if (result.skipped) {
+      toaster.create({
+        title: 'Sin movimientos',
+        description: 'No hay gastos este mes para analizar.',
+        type: 'info',
+        duration: 4000,
+      })
+      return
+    }
+    toaster.create({ title: 'Consejos actualizados', type: 'success', duration: 3000 })
+    startTransition(() => router.refresh())
+  }
+
+  const loading = generating || isPending
+  const hasAdvice = advice != null && (advice.insights.length > 0 || advice.budget_suggestions.length > 0)
+
+  return (
+    <Box>
+      <HStack justify="space-between" align="start" mb={6} flexWrap="wrap" gap={3}>
+        <Box>
+          <HStack gap={2}>
+            <Icon as={FiZap} color="#6366f1" boxSize={6} />
+            <Heading size="lg" color="white">
+              Consejos de Ahorro
+            </Heading>
+          </HStack>
+          <Text color="#B0B0B0" mt={1}>
+            {periodLabel(period)}
+            {advice?.generated_at && (
+              <> · actualizado {new Date(advice.generated_at).toLocaleDateString('es-CO')}</>
+            )}
+          </Text>
+        </Box>
+
+        {summary.hasData && (
+          <PrimaryButton onClick={handleGenerate} loading={loading}>
+            <HStack gap={2}>
+              <Icon as={FiRefreshCw} />
+              {hasAdvice ? 'Actualizar' : 'Generar consejos'}
+            </HStack>
+          </PrimaryButton>
+        )}
+      </HStack>
+
+      {/* Resumen del mes */}
+      <SimpleGrid columns={{ base: 1, sm: 3 }} gap={4} mb={8}>
+        <StatCard label="Ingresos" value={formatCurrency(summary.totals.income, currency)} />
+        <StatCard label="Gastos" value={formatCurrency(summary.totals.expense, currency)} />
+        <StatCard label="Balance" value={formatCurrency(summary.totals.net, currency)} />
+      </SimpleGrid>
+
+      {/* Estados vacíos */}
+      {!summary.hasData ? (
+        <Card>
+          <VStack gap={3} py={6} color="#B0B0B0">
+            <Icon as={FiInbox} boxSize={8} />
+            <Text textAlign="center">
+              No hay movimientos registrados este mes para analizar. Registra tus gastos y vuelve para
+              obtener consejos personalizados.
+            </Text>
+          </VStack>
+        </Card>
+      ) : !hasAdvice ? (
+        <Card>
+          <VStack gap={4} py={6}>
+            <Icon as={FiZap} boxSize={8} color="#6366f1" />
+            <Text textAlign="center" color="#B0B0B0">
+              Aún no has generado consejos para este mes. Genera un análisis de tus gastos con IA.
+            </Text>
+            <PrimaryButton onClick={handleGenerate} loading={loading}>
+              Generar consejos
+            </PrimaryButton>
+          </VStack>
+        </Card>
+      ) : (
+        <VStack gap={8} align="stretch">
+          <Box>
+            <Heading size="md" color="white" mb={4}>
+              Diagnóstico
+            </Heading>
+            <InsightsList insights={advice.insights} />
+          </Box>
+
+          <Box>
+            <Heading size="md" color="white" mb={4}>
+              Sugerencias de presupuesto
+            </Heading>
+            <BudgetSuggestionsList
+              userId={userId}
+              suggestions={advice.budget_suggestions}
+              budgets={budgets}
+              categories={categories}
+              currency={currency}
+            />
+          </Box>
+        </VStack>
+      )}
+
+      {loading && (
+        <HStack justify="center" mt={6} color="#B0B0B0" gap={2}>
+          <Spinner size="sm" />
+          <Text fontSize="sm">Analizando tus gastos…</Text>
+        </HStack>
+      )}
+    </Box>
+  )
+}

--- a/app/(dashboard)/consejos-ahorro/page.tsx
+++ b/app/(dashboard)/consejos-ahorro/page.tsx
@@ -1,0 +1,58 @@
+import { getServerSession } from 'next-auth'
+import { authOptions } from '@/lib/auth'
+import { redirect } from 'next/navigation'
+import { insforgeAdmin } from '@/lib/insforge-admin'
+import { getSavingsAdvice, buildSpendingSummary } from '@/lib/actions/savingsAdvice.actions'
+import { getBudgets } from '@/lib/actions/budgets.actions'
+import { getCategories } from '@/lib/actions/categories.actions'
+import { ConsejosAhorroPageClient } from './ConsejosAhorroPageClient'
+import type { ExistingBudget } from '@/components/savings/BudgetSuggestionsList'
+import type { Category } from '@/types/database.types'
+
+export default async function ConsejosAhorroPage() {
+  const session = await getServerSession(authOptions)
+  if (!session?.user?.email) {
+    redirect('/login')
+  }
+
+  const { data: user, error: userError } = await insforgeAdmin.database
+    .from('users')
+    .select('id')
+    .eq('email', session.user.email)
+    .single()
+
+  if (!user?.id || userError) {
+    redirect('/login')
+  }
+
+  const period = new Date().toISOString().slice(0, 7)
+
+  const [adviceRes, summary, budgetsRes, categoriesRes] = await Promise.all([
+    getSavingsAdvice(user.id, period),
+    buildSpendingSummary(user.id, period),
+    getBudgets(user.id),
+    getCategories(user.id),
+  ])
+
+  const advice = adviceRes.success ? (adviceRes.data ?? null) : null
+  const budgets = ((budgetsRes.success ? budgetsRes.data ?? [] : []) as ExistingBudget[]).map((b) => ({
+    id: b.id,
+    category_id: b.category_id,
+    amount: b.amount,
+    currency: b.currency,
+    period: b.period,
+    start_date: b.start_date,
+  }))
+  const categories = (categoriesRes.success ? categoriesRes.data ?? [] : []) as Category[]
+
+  return (
+    <ConsejosAhorroPageClient
+      userId={user.id}
+      period={period}
+      advice={advice}
+      summary={summary}
+      budgets={budgets}
+      categories={categories}
+    />
+  )
+}

--- a/components/budgets/BudgetForm.tsx
+++ b/components/budgets/BudgetForm.tsx
@@ -34,6 +34,12 @@ interface Budget {
   start_date: string
 }
 
+interface PrefillBudget {
+  category_id?: string
+  amount?: number
+  currency?: Currency
+}
+
 interface Props {
   isOpen: boolean
   onClose: () => void
@@ -41,6 +47,9 @@ interface Props {
   categories: Category[]
   onSuccess: () => void
   editingBudget?: Budget | null
+  // Pre-fills the create form (e.g. from an AI budget suggestion). Ignored when
+  // editingBudget is set.
+  prefill?: PrefillBudget | null
 }
 
 const defaultForm = {
@@ -52,7 +61,7 @@ const defaultForm = {
   start_date: getLocalDateString(),
 }
 
-export function BudgetForm({ isOpen, onClose, userId, categories, onSuccess, editingBudget }: Props) {
+export function BudgetForm({ isOpen, onClose, userId, categories, onSuccess, editingBudget, prefill }: Props) {
   const [loading, setLoading] = useState(false)
   const [formData, setFormData] = useState(defaultForm)
 
@@ -68,11 +77,20 @@ export function BudgetForm({ isOpen, onClose, userId, categories, onSuccess, edi
           period: editingBudget.period,
           start_date: editingBudget.start_date,
         })
+      } else if (prefill) {
+        const category = categories.find((c) => c.id === prefill.category_id)
+        setFormData({
+          ...defaultForm,
+          type: category?.type === 'income' ? 'income' : 'expense',
+          category_id: prefill.category_id ?? '',
+          amount: prefill.amount,
+          currency: prefill.currency ?? defaultForm.currency,
+        })
       } else {
         setFormData(defaultForm)
       }
     }
-  }, [isOpen, editingBudget, categories])
+  }, [isOpen, editingBudget, prefill, categories])
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()

--- a/components/dashboard/MobileNav.tsx
+++ b/components/dashboard/MobileNav.tsx
@@ -22,6 +22,7 @@ import {
   FiTarget,
   FiCalendar,
   FiLayers,
+  FiZap,
 } from 'react-icons/fi'
 import { IconType } from 'react-icons'
 import { useNavigation } from '@/hooks/useNavigation'
@@ -32,6 +33,7 @@ const navItems: { href: string; label: string; icon: IconType }[] = [
   { href: '/planificacion', label: 'Planificación', icon: FiTarget },
   { href: '/calendar', label: 'Calendario', icon: FiCalendar },
   { href: '/reports', label: 'Reportes', icon: FiBarChart2 },
+  { href: '/consejos-ahorro', label: 'Consejos de Ahorro', icon: FiZap },
   { href: '/settings', label: 'Configuración', icon: FiSettings },
 ]
 

--- a/components/dashboard/Sidebar.tsx
+++ b/components/dashboard/Sidebar.tsx
@@ -11,6 +11,7 @@ import {
   FiTarget,
   FiCalendar,
   FiLayers,
+  FiZap,
   FiChevronsLeft,
   FiChevronsRight,
 } from 'react-icons/fi'
@@ -23,6 +24,7 @@ const navItems: { href: string; label: string; icon: IconType }[] = [
   { href: '/planificacion', label: 'Planificación', icon: FiTarget },
   { href: '/calendar', label: 'Calendario', icon: FiCalendar },
   { href: '/reports', label: 'Reportes', icon: FiBarChart2 },
+  { href: '/consejos-ahorro', label: 'Consejos de Ahorro', icon: FiZap },
   { href: '/settings', label: 'Configuración', icon: FiSettings },
 ]
 

--- a/components/savings/BudgetSuggestionsList.tsx
+++ b/components/savings/BudgetSuggestionsList.tsx
@@ -1,0 +1,114 @@
+'use client'
+
+import { VStack, HStack, Box, Text, Button, useDisclosure } from '@chakra-ui/react'
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { BudgetForm } from '@/components/budgets/BudgetForm'
+import { formatCurrency } from '@/lib/utils/currency'
+import type { Category, Currency, SavingsBudgetSuggestion } from '@/types/database.types'
+
+export interface ExistingBudget {
+  id: string
+  category_id: string
+  amount: number
+  currency: Currency
+  period: 'monthly' | 'yearly'
+  start_date: string
+}
+
+interface Props {
+  userId: string
+  suggestions: SavingsBudgetSuggestion[]
+  budgets: ExistingBudget[]
+  categories: Category[]
+  currency: Currency
+}
+
+export function BudgetSuggestionsList({ userId, suggestions, budgets, categories, currency }: Props) {
+  const router = useRouter()
+  const { open, onOpen, onClose } = useDisclosure()
+  const [editingBudget, setEditingBudget] = useState<ExistingBudget | null>(null)
+  const [prefill, setPrefill] = useState<{ category_id: string; amount: number; currency: Currency } | null>(null)
+
+  const handleApply = (suggestion: SavingsBudgetSuggestion) => {
+    const existing = budgets.find((b) => b.category_id === suggestion.category_id)
+    if (existing) {
+      // Edit the existing budget, pre-loading the suggested amount.
+      setEditingBudget({ ...existing, amount: suggestion.suggested_amount })
+      setPrefill(null)
+    } else {
+      setEditingBudget(null)
+      setPrefill({
+        category_id: suggestion.category_id,
+        amount: suggestion.suggested_amount,
+        currency,
+      })
+    }
+    onOpen()
+  }
+
+  if (suggestions.length === 0) {
+    return <Text color="#B0B0B0">No hay sugerencias de presupuesto para este periodo.</Text>
+  }
+
+  return (
+    <>
+      <VStack gap={3} align="stretch">
+        {suggestions.map((s, i) => {
+          const hasBudget = s.current_budget_amount != null
+          return (
+            <Box
+              key={i}
+              borderWidth="1px"
+              borderRadius="lg"
+              borderColor="#2d2d35"
+              bg="#1a1a23"
+              p={4}
+            >
+              <HStack justify="space-between" align="start" gap={4} flexWrap="wrap">
+                <Box flex={1} minW="200px">
+                  <Text fontWeight="semibold" color="white">
+                    {s.category_name}
+                  </Text>
+                  <Text fontSize="sm" color="#B0B0B0" mt={1}>
+                    {s.rationale}
+                  </Text>
+                  <HStack gap={4} mt={2} flexWrap="wrap">
+                    <Text fontSize="sm" color="#4ade80" fontWeight="medium">
+                      Sugerido: {formatCurrency(s.suggested_amount, currency)}
+                    </Text>
+                    {hasBudget && (
+                      <Text fontSize="sm" color="#B0B0B0">
+                        Actual: {formatCurrency(s.current_budget_amount as number, currency)}
+                      </Text>
+                    )}
+                  </HStack>
+                </Box>
+                <Button
+                  size="sm"
+                  bg="#4F46E5"
+                  color="white"
+                  _hover={{ bg: '#4338CA' }}
+                  flexShrink={0}
+                  onClick={() => handleApply(s)}
+                >
+                  {hasBudget ? 'Ajustar y editar' : 'Aplicar y editar'}
+                </Button>
+              </HStack>
+            </Box>
+          )
+        })}
+      </VStack>
+
+      <BudgetForm
+        isOpen={open}
+        onClose={onClose}
+        userId={userId}
+        categories={categories}
+        onSuccess={() => router.refresh()}
+        editingBudget={editingBudget}
+        prefill={prefill}
+      />
+    </>
+  )
+}

--- a/components/savings/InsightsList.tsx
+++ b/components/savings/InsightsList.tsx
@@ -1,0 +1,54 @@
+'use client'
+
+import { VStack, HStack, Box, Text, Icon } from '@chakra-ui/react'
+import { FiInfo, FiAlertTriangle, FiAlertOctagon } from 'react-icons/fi'
+import type { IconType } from 'react-icons'
+import type { SavingsInsight, AdviceSeverity } from '@/types/database.types'
+
+const SEVERITY: Record<AdviceSeverity, { color: string; icon: IconType; label: string }> = {
+  info: { color: '#6366f1', icon: FiInfo, label: 'Info' },
+  warning: { color: '#d97706', icon: FiAlertTriangle, label: 'Atención' },
+  critical: { color: '#dc2626', icon: FiAlertOctagon, label: 'Crítico' },
+}
+
+interface Props {
+  insights: SavingsInsight[]
+}
+
+export function InsightsList({ insights }: Props) {
+  if (insights.length === 0) {
+    return <Text color="#B0B0B0">No hay observaciones para este periodo.</Text>
+  }
+
+  return (
+    <VStack gap={3} align="stretch">
+      {insights.map((insight, i) => {
+        const s = SEVERITY[insight.severity] ?? SEVERITY.info
+        return (
+          <Box
+            key={i}
+            borderWidth="1px"
+            borderLeftWidth="4px"
+            borderRadius="lg"
+            borderColor="#2d2d35"
+            borderLeftColor={s.color}
+            bg="#1a1a23"
+            p={4}
+          >
+            <HStack align="start" gap={3}>
+              <Icon as={s.icon} color={s.color} boxSize={5} mt={0.5} flexShrink={0} />
+              <Box>
+                <Text fontWeight="semibold" color="white">
+                  {insight.title}
+                </Text>
+                <Text fontSize="sm" color="#B0B0B0" mt={1}>
+                  {insight.detail}
+                </Text>
+              </Box>
+            </HStack>
+          </Box>
+        )
+      })}
+    </VStack>
+  )
+}


### PR DESCRIPTION
## Resumen
Segunda fase de **"Consejos de Ahorro con IA"**: la UI del panel en `/consejos-ahorro` con los bloques de **diagnóstico** y **sugerencias de presupuesto**. (El coach conversacional llega en Fase 3.)

Construido sobre el backend de la Fase 1 (PR #460, ya en develop).

## Cambios
- **Página** `app/(dashboard)/consejos-ahorro/page.tsx` (server): resuelve el usuario de la sesión y carga en paralelo el cache de consejos (`getSavingsAdvice`), el resumen del mes (`buildSpendingSummary`), presupuestos y categorías.
- **`ConsejosAhorroPageClient.tsx`**: encabezado con el mes y fecha de última actualización, resumen (ingresos/gastos/balance), botón **Generar/Actualizar** (llama a `generateSavingsAdvice` y refresca), y estados vacíos (sin movimientos / sin consejos aún).
- **`components/savings/InsightsList.tsx`**: tarjetas de diagnóstico con color por severidad (info/warning/critical).
- **`components/savings/BudgetSuggestionsList.tsx`**: cada sugerencia con botón **"Aplicar y editar"** que abre el `BudgetForm` prellenado — **crea** si la categoría no tiene presupuesto, **edita** (con el monto sugerido) si ya existe.
- **`components/budgets/BudgetForm.tsx`**: nuevo prop opcional `prefill` para precargar el formulario de creación. No cambia el flujo de edición existente.
- **Navegación**: entrada "Consejos de Ahorro" (icono FiZap) en `Sidebar` y `MobileNav`.

## Testing
- ✅ `pnpm type-check` sin errores
- ✅ `pnpm build` exitoso (ruta `/consejos-ahorro` registrada)
- ✅ `eslint` limpio en los archivos nuevos (los 2 errores que toca el linter en `BudgetForm`/`Sidebar` son preexistentes — `setState` en `useEffect` que ya estaba)

## Cómo probar localmente
1. Tener aplicada la migración de Fase 1 (`supabase/seeds/savings-advice-v3.6.0.sql`).
2. `pnpm dev` → entrar a **Consejos de Ahorro** en el menú.
3. Con gastos en el mes: tocar **Generar consejos** → deben aparecer el diagnóstico y las sugerencias.
4. En una sugerencia, **Aplicar y editar** → el `BudgetForm` abre prellenado; al guardar crea/actualiza el presupuesto (verificar en Planificación → Presupuestos).
5. Caso borde: usuario sin movimientos del mes → estado vacío sin llamar a la IA.

Parte del panel "Consejos de Ahorro" (plan aprobado en sesión).