### PR TITLE
FASE 3: Consejos de Ahorro IA — coach conversacional

### DIFF
--- a/app/(dashboard)/consejos-ahorro/ConsejosAhorroPageClient.tsx
+++ b/app/(dashboard)/consejos-ahorro/ConsejosAhorroPageClient.tsx
@@ -9,6 +9,7 @@ import { StatCard } from '@/components/ui/StatCard'
 import { PrimaryButton } from '@/components/ui/PrimaryButton'
 import { InsightsList } from '@/components/savings/InsightsList'
 import { BudgetSuggestionsList, type ExistingBudget } from '@/components/savings/BudgetSuggestionsList'
+import { SavingsCoachChat } from '@/components/savings/SavingsCoachChat'
 import { generateSavingsAdvice } from '@/lib/actions/savingsAdvice.actions'
 import { formatCurrency } from '@/lib/utils/currency'
 import { toaster } from '@/lib/toaster'
@@ -97,7 +98,7 @@ export function ConsejosAhorroPageClient({ userId, period, advice, summary, budg
         <StatCard label="Balance" value={formatCurrency(summary.totals.net, currency)} />
       </SimpleGrid>
 
-      {/* Estados vacíos */}
+      {/* Estados vacíos / contenido */}
       {!summary.hasData ? (
         <Card>
           <VStack gap={3} py={6} color="#B0B0B0">
@@ -108,38 +109,49 @@ export function ConsejosAhorroPageClient({ userId, period, advice, summary, budg
             </Text>
           </VStack>
         </Card>
-      ) : !hasAdvice ? (
-        <Card>
-          <VStack gap={4} py={6}>
-            <Icon as={FiZap} boxSize={8} color="#6366f1" />
-            <Text textAlign="center" color="#B0B0B0">
-              Aún no has generado consejos para este mes. Genera un análisis de tus gastos con IA.
-            </Text>
-            <PrimaryButton onClick={handleGenerate} loading={loading}>
-              Generar consejos
-            </PrimaryButton>
-          </VStack>
-        </Card>
       ) : (
         <VStack gap={8} align="stretch">
-          <Box>
-            <Heading size="md" color="white" mb={4}>
-              Diagnóstico
-            </Heading>
-            <InsightsList insights={advice.insights} />
-          </Box>
+          {!hasAdvice ? (
+            <Card>
+              <VStack gap={4} py={6}>
+                <Icon as={FiZap} boxSize={8} color="#6366f1" />
+                <Text textAlign="center" color="#B0B0B0">
+                  Aún no has generado consejos para este mes. Genera un análisis de tus gastos con IA.
+                </Text>
+                <PrimaryButton onClick={handleGenerate} loading={loading}>
+                  Generar consejos
+                </PrimaryButton>
+              </VStack>
+            </Card>
+          ) : (
+            <>
+              <Box>
+                <Heading size="md" color="white" mb={4}>
+                  Diagnóstico
+                </Heading>
+                <InsightsList insights={advice.insights} />
+              </Box>
+
+              <Box>
+                <Heading size="md" color="white" mb={4}>
+                  Sugerencias de presupuesto
+                </Heading>
+                <BudgetSuggestionsList
+                  userId={userId}
+                  suggestions={advice.budget_suggestions}
+                  budgets={budgets}
+                  categories={categories}
+                  currency={currency}
+                />
+              </Box>
+            </>
+          )}
 
           <Box>
             <Heading size="md" color="white" mb={4}>
-              Sugerencias de presupuesto
+              Coach de ahorro
             </Heading>
-            <BudgetSuggestionsList
-              userId={userId}
-              suggestions={advice.budget_suggestions}
-              budgets={budgets}
-              categories={categories}
-              currency={currency}
-            />
+            <SavingsCoachChat userId={userId} />
           </Box>
         </VStack>
       )}

--- a/components/savings/SavingsCoachChat.tsx
+++ b/components/savings/SavingsCoachChat.tsx
@@ -1,0 +1,223 @@
+'use client'
+
+import { Box, VStack, HStack, Text, Input, Button, Icon, Spinner } from '@chakra-ui/react'
+import { useState, useRef, useEffect, useCallback } from 'react'
+import { FiSend, FiMessageCircle } from 'react-icons/fi'
+import { askSavingsCoach } from '@/lib/actions/savingsAdvice.actions'
+import { toaster } from '@/lib/toaster'
+
+interface CoachMessage {
+  id: string
+  role: 'user' | 'assistant'
+  text: string
+}
+
+const STORAGE_KEY = 'savings-coach-history'
+
+const SUGGESTIONS = [
+  '¿En qué estoy gastando de más?',
+  '¿Cómo puedo ahorrar este mes?',
+  '¿Voy bien con mis presupuestos?',
+]
+
+function loadHistory(): CoachMessage[] {
+  if (typeof window === 'undefined') return []
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    return raw ? (JSON.parse(raw) as CoachMessage[]) : []
+  } catch {
+    return []
+  }
+}
+
+function saveHistory(messages: CoachMessage[]) {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(messages.slice(-50)))
+  } catch {
+    // localStorage puede estar lleno
+  }
+}
+
+interface Props {
+  userId: string
+}
+
+export function SavingsCoachChat({ userId }: Props) {
+  const [messages, setMessages] = useState<CoachMessage[]>([])
+  const [input, setInput] = useState('')
+  const [loading, setLoading] = useState(false)
+  const bottomRef = useRef<HTMLDivElement>(null)
+
+  // Load on mount (not a lazy initializer) to avoid an SSR hydration mismatch.
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setMessages(loadHistory())
+  }, [])
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: 'smooth' })
+  }, [messages])
+
+  const handleSend = useCallback(
+    async (textOverride?: string) => {
+      const text = (textOverride ?? input).trim()
+      if (!text || loading) return
+
+      setInput('')
+      setLoading(true)
+
+      const userMsg: CoachMessage = { id: `${Date.now()}-u`, role: 'user', text }
+      const withUser = [...messages, userMsg]
+      setMessages(withUser)
+      saveHistory(withUser)
+
+      const result = await askSavingsCoach(
+        userId,
+        withUser.map((m) => ({ role: m.role, content: m.text }))
+      )
+
+      if (!result.success || !result.text) {
+        toaster.create({ title: 'Error', description: result.error, type: 'error', duration: 4000 })
+        setLoading(false)
+        return
+      }
+
+      const assistantMsg: CoachMessage = { id: `${Date.now()}-a`, role: 'assistant', text: result.text }
+      setMessages((prev) => {
+        const updated = [...prev, assistantMsg]
+        saveHistory(updated)
+        return updated
+      })
+      setLoading(false)
+    },
+    [input, loading, messages, userId]
+  )
+
+  const handleClear = () => {
+    localStorage.removeItem(STORAGE_KEY)
+    setMessages([])
+  }
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault()
+      handleSend()
+    }
+  }
+
+  const isEmpty = messages.length === 0
+
+  return (
+    <Box borderWidth="1px" borderColor="#2d2d35" borderRadius="lg" bg="#1a1a23" overflow="hidden">
+      <HStack justify="space-between" p={4} borderBottomWidth="1px" borderColor="#2d2d35" bg="#18181d">
+        <HStack gap={2}>
+          <Icon as={FiMessageCircle} color="#6366f1" boxSize={5} />
+          <Text fontWeight="semibold" color="white">
+            Coach de ahorro
+          </Text>
+        </HStack>
+        {!isEmpty && (
+          <Button size="xs" variant="ghost" colorPalette="gray" onClick={handleClear}>
+            Limpiar
+          </Button>
+        )}
+      </HStack>
+
+      <Box maxH="420px" overflowY="auto" p={4} bg="#0f0f13">
+        {isEmpty ? (
+          <VStack gap={3} align="stretch" py={2}>
+            <Text fontSize="sm" color="#B0B0B0">
+              Pregúntame sobre tus finanzas. Por ejemplo:
+            </Text>
+            {SUGGESTIONS.map((s) => (
+              <Button
+                key={s}
+                size="sm"
+                variant="outline"
+                borderColor="#2d2d35"
+                color="#B0B0B0"
+                justifyContent="flex-start"
+                _hover={{ borderColor: '#4F46E5', color: 'white' }}
+                onClick={() => handleSend(s)}
+              >
+                {s}
+              </Button>
+            ))}
+          </VStack>
+        ) : (
+          <VStack gap={3} align="stretch">
+            {messages.map((msg) =>
+              msg.role === 'user' ? (
+                <HStack key={msg.id} justify="flex-end">
+                  <Box
+                    bg="#4F46E5"
+                    color="white"
+                    px={4}
+                    py={2}
+                    borderRadius="2xl"
+                    borderBottomRightRadius="sm"
+                    maxW="80%"
+                  >
+                    <Text fontSize="sm">{msg.text}</Text>
+                  </Box>
+                </HStack>
+              ) : (
+                <HStack key={msg.id} justify="flex-start">
+                  <Box
+                    bg="#18181d"
+                    border="1px solid"
+                    borderColor="#2d2d35"
+                    px={4}
+                    py={2}
+                    borderRadius="2xl"
+                    borderBottomLeftRadius="sm"
+                    maxW="85%"
+                  >
+                    <Text fontSize="sm" color="white" whiteSpace="pre-wrap">
+                      {msg.text}
+                    </Text>
+                  </Box>
+                </HStack>
+              )
+            )}
+            {loading && (
+              <HStack justify="flex-start">
+                <Box bg="#18181d" border="1px solid" borderColor="#2d2d35" px={4} py={2} borderRadius="2xl">
+                  <HStack gap={2}>
+                    <Spinner size="xs" color="#6366f1" />
+                    <Text fontSize="sm" color="#B0B0B0">
+                      Pensando…
+                    </Text>
+                  </HStack>
+                </Box>
+              </HStack>
+            )}
+            <div ref={bottomRef} />
+          </VStack>
+        )}
+      </Box>
+
+      <HStack p={4} borderTopWidth="1px" borderColor="#2d2d35" bg="#18181d" gap={2}>
+        <Input
+          placeholder="Escribe tu pregunta…"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          onKeyDown={handleKeyDown}
+          disabled={loading}
+          flex="1"
+          size="md"
+        />
+        <Button
+          bg="#4F46E5"
+          color="white"
+          _hover={{ bg: '#4338CA' }}
+          onClick={() => handleSend()}
+          disabled={!input.trim() || loading}
+          size="md"
+        >
+          <Icon as={FiSend} />
+        </Button>
+      </HStack>
+    </Box>
+  )
+}

--- a/lib/actions/savingsAdvice.actions.ts
+++ b/lib/actions/savingsAdvice.actions.ts
@@ -301,6 +301,55 @@ export async function generateSavingsAdvice(
   }
 }
 
+// ---------------------------------------------------------------------------
+// Conversational coach (live Q&A grounded in the user's spending summary)
+// ---------------------------------------------------------------------------
+
+export interface CoachMessage {
+  role: 'user' | 'assistant'
+  content: string
+}
+
+export async function askSavingsCoach(
+  userId: string,
+  messages: CoachMessage[]
+): Promise<{ success: boolean; text?: string; error?: string }> {
+  if (!userId) return { success: false, error: 'User ID is required' }
+  if (!messages.length) return { success: false, error: 'No hay mensajes' }
+
+  try {
+    const summary = await buildSpendingSummary(userId)
+
+    const system = `Eres un coach de finanzas personales dentro de una app de gestión de gastos.
+Respondes en español, de forma breve, concreta y accionable, tuteando al usuario. Fundamenta tus
+respuestas en su resumen financiero; no inventes cifras que no estén ahí. Si te preguntan algo
+fuera de finanzas personales, redirige amablemente al tema. Los montos están en ${summary.currency}.
+
+Resumen financiero del usuario (periodo ${summary.period}):
+${JSON.stringify(summary)}`
+
+    // Keep only the last 10 turns to bound token usage.
+    const history = messages.slice(-10).map((m) => ({ role: m.role, content: m.content }))
+
+    const response = await client.messages.create({
+      model: 'claude-haiku-4-5',
+      max_tokens: 800,
+      system,
+      messages: history,
+    })
+
+    const textContent = response.content.find((b) => b.type === 'text')
+    if (!textContent || textContent.type !== 'text') {
+      return { success: false, error: 'No se recibió respuesta del modelo' }
+    }
+
+    return { success: true, text: textContent.text.trim() }
+  } catch (error) {
+    console.error('askSavingsCoach error:', error)
+    return { success: false, error: 'Error al consultar el coach de ahorro' }
+  }
+}
+
 /** Reads the cached advice for a user/period (used by the panel page). */
 export async function getSavingsAdvice(
   userId: string,


### PR DESCRIPTION
## Resumen
Tercera y última fase de **"Consejos de Ahorro con IA"**: el **coach conversacional** en vivo dentro del panel `/consejos-ahorro`. Con esto el panel queda completo (diagnóstico + sugerencias de presupuesto + coach).

Construido sobre Fase 1 (#460) y Fase 2 (#461), ya en develop.

## Cambios
- **`askSavingsCoach(userId, messages)`** en `lib/actions/savingsAdvice.actions.ts`: responde preguntas en vivo con `claude-haiku-4-5`, usando `buildSpendingSummary` como **contexto del sistema** (no inventa cifras). NO registra transacciones. Historial acotado a los últimos 10 turnos para controlar tokens.
- **`components/savings/SavingsCoachChat.tsx`**: panel de chat embebido — sugerencias iniciales ("¿En qué estoy gastando de más?", etc.), burbujas con el mismo estilo del chat existente, historial **efímero en localStorage** (v1), botón Limpiar.
- **Integración**: tercer bloque del panel, visible cuando hay movimientos del mes (con o sin consejos generados).

## Testing
- ✅ `pnpm type-check` sin errores
- ✅ `pnpm build` exitoso
- ✅ `eslint` limpio en los archivos nuevos (el `setState` en `useEffect` para cargar el historial va con `eslint-disable` puntual, igual que el `ChatInterface` existente, para evitar hydration mismatch)

## Cómo probar localmente
1. Migración de Fase 1 aplicada en InsForge.
2. `pnpm dev` → **Consejos de Ahorro** → bloque **Coach de ahorro**.
3. Preguntar p.ej. "¿en qué estoy gastando de más?" → responde coherente con tu data del mes.

Cierra el panel "Consejos de Ahorro". Tras aprobar esta fase: bump a v3.6.0, PR develop→main, tag + release.