### PR TITLE
feat(consejos-ahorro): 2 tabs, layout 40/60 y categorías en tarjetas

### DIFF
--- a/app/(dashboard)/consejos-ahorro/ConsejosAhorroPageClient.tsx
+++ b/app/(dashboard)/consejos-ahorro/ConsejosAhorroPageClient.tsx
@@ -1,9 +1,22 @@
 'use client'
 
-import { Box, Heading, Text, HStack, VStack, SimpleGrid, Icon, Spinner } from '@chakra-ui/react'
+import {
+  Box,
+  Heading,
+  Text,
+  HStack,
+  VStack,
+  SimpleGrid,
+  Grid,
+  GridItem,
+  Flex,
+  Icon,
+  Spinner,
+  Tabs,
+} from '@chakra-ui/react'
 import { useState, useTransition } from 'react'
 import { useRouter } from 'next/navigation'
-import { FiZap, FiRefreshCw, FiInbox } from 'react-icons/fi'
+import { FiZap, FiRefreshCw, FiInbox, FiMessageCircle } from 'react-icons/fi'
 import { Card } from '@/components/ui/Card'
 import { StatCard } from '@/components/ui/StatCard'
 import { PrimaryButton } from '@/components/ui/PrimaryButton'
@@ -25,6 +38,9 @@ interface Props {
   categories: Category[]
 }
 
+// Fixed height for each scrollable column on desktop.
+const COLUMN_HEIGHT = '600px'
+
 function periodLabel(period: string): string {
   const [y, m] = period.split('-').map(Number)
   const date = new Date(y, m - 1, 1)
@@ -36,6 +52,7 @@ export function ConsejosAhorroPageClient({ userId, period, advice, summary, budg
   const router = useRouter()
   const [isPending, startTransition] = useTransition()
   const [generating, setGenerating] = useState(false)
+  const [tab, setTab] = useState('consejos')
   const { currency } = summary
 
   const handleGenerate = async () => {
@@ -91,14 +108,6 @@ export function ConsejosAhorroPageClient({ userId, period, advice, summary, budg
         )}
       </HStack>
 
-      {/* Resumen del mes */}
-      <SimpleGrid columns={{ base: 1, sm: 3 }} gap={4} mb={8}>
-        <StatCard label="Ingresos" value={formatCurrency(summary.totals.income, currency)} />
-        <StatCard label="Gastos" value={formatCurrency(summary.totals.expense, currency)} />
-        <StatCard label="Balance" value={formatCurrency(summary.totals.net, currency)} />
-      </SimpleGrid>
-
-      {/* Estados vacíos / contenido */}
       {!summary.hasData ? (
         <Card>
           <VStack gap={3} py={6} color="#B0B0B0">
@@ -110,57 +119,97 @@ export function ConsejosAhorroPageClient({ userId, period, advice, summary, budg
           </VStack>
         </Card>
       ) : (
-        <VStack gap={8} align="stretch">
-          {!hasAdvice ? (
-            <Card>
-              <VStack gap={4} py={6}>
-                <Icon as={FiZap} boxSize={8} color="#6366f1" />
-                <Text textAlign="center" color="#B0B0B0">
-                  Aún no has generado consejos para este mes. Genera un análisis de tus gastos con IA.
-                </Text>
-                <PrimaryButton onClick={handleGenerate} loading={loading}>
-                  Generar consejos
-                </PrimaryButton>
-              </VStack>
-            </Card>
-          ) : (
-            <>
-              <Box>
-                <Heading size="md" color="white" mb={4}>
-                  Diagnóstico
-                </Heading>
-                <InsightsList insights={advice.insights} />
-              </Box>
-
-              <Box>
-                <Heading size="md" color="white" mb={4}>
-                  Sugerencias de presupuesto
-                </Heading>
-                <BudgetSuggestionsList
-                  userId={userId}
-                  suggestions={advice.budget_suggestions}
-                  budgets={budgets}
-                  categories={categories}
-                  currency={currency}
-                />
-              </Box>
-            </>
-          )}
-
-          <Box>
-            <Heading size="md" color="white" mb={4}>
+        <Tabs.Root value={tab} onValueChange={({ value }) => setTab(value)} colorPalette="brand">
+          <Tabs.List mb={6} borderBottomWidth="1px" borderColor="#2d2d35">
+            <Tabs.Trigger
+              value="consejos"
+              display="flex"
+              alignItems="center"
+              gap={2}
+              color="#B0B0B0"
+              _selected={{ color: 'white', borderBottomColor: '#6366f1' }}
+            >
+              <FiZap />
+              Consejos de ahorro
+            </Tabs.Trigger>
+            <Tabs.Trigger
+              value="coach"
+              display="flex"
+              alignItems="center"
+              gap={2}
+              color="#B0B0B0"
+              _selected={{ color: 'white', borderBottomColor: '#6366f1' }}
+            >
+              <FiMessageCircle />
               Coach de ahorro
-            </Heading>
-            <SavingsCoachChat userId={userId} />
-          </Box>
-        </VStack>
-      )}
+            </Tabs.Trigger>
+          </Tabs.List>
 
-      {loading && (
-        <HStack justify="center" mt={6} color="#B0B0B0" gap={2}>
-          <Spinner size="sm" />
-          <Text fontSize="sm">Analizando tus gastos…</Text>
-        </HStack>
+          <Tabs.Content value="consejos">
+            <SimpleGrid columns={{ base: 1, sm: 3 }} gap={4} mb={6}>
+              <StatCard label="Ingresos" value={formatCurrency(summary.totals.income, currency)} />
+              <StatCard label="Gastos" value={formatCurrency(summary.totals.expense, currency)} />
+              <StatCard label="Balance" value={formatCurrency(summary.totals.net, currency)} />
+            </SimpleGrid>
+
+            {!hasAdvice ? (
+              <Card>
+                <VStack gap={4} py={6}>
+                  <Icon as={FiZap} boxSize={8} color="#6366f1" />
+                  <Text textAlign="center" color="#B0B0B0">
+                    Aún no has generado consejos para este mes. Genera un análisis de tus gastos con IA.
+                  </Text>
+                  <PrimaryButton onClick={handleGenerate} loading={loading}>
+                    Generar consejos
+                  </PrimaryButton>
+                </VStack>
+              </Card>
+            ) : (
+              <Grid templateColumns={{ base: '1fr', lg: '2fr 3fr' }} gap={6}>
+                {/* Diagnóstico — 40% */}
+                <GridItem>
+                  <Flex direction="column" h={{ base: 'auto', lg: COLUMN_HEIGHT }}>
+                    <Heading size="md" color="white" mb={4} flexShrink={0}>
+                      Diagnóstico
+                    </Heading>
+                    <Box flex="1" minH={0} overflowY={{ base: 'visible', lg: 'auto' }} pr={{ lg: 2 }}>
+                      <InsightsList insights={advice.insights} categories={categories} />
+                    </Box>
+                  </Flex>
+                </GridItem>
+
+                {/* Sugerencias de presupuesto — 60% */}
+                <GridItem>
+                  <Flex direction="column" h={{ base: 'auto', lg: COLUMN_HEIGHT }}>
+                    <Heading size="md" color="white" mb={4} flexShrink={0}>
+                      Sugerencias de presupuesto
+                    </Heading>
+                    <Box flex="1" minH={0} overflowY={{ base: 'visible', lg: 'auto' }} pr={{ lg: 2 }}>
+                      <BudgetSuggestionsList
+                        userId={userId}
+                        suggestions={advice.budget_suggestions}
+                        budgets={budgets}
+                        categories={categories}
+                        currency={currency}
+                      />
+                    </Box>
+                  </Flex>
+                </GridItem>
+              </Grid>
+            )}
+
+            {loading && (
+              <HStack justify="center" mt={6} color="#B0B0B0" gap={2}>
+                <Spinner size="sm" />
+                <Text fontSize="sm">Analizando tus gastos…</Text>
+              </HStack>
+            )}
+          </Tabs.Content>
+
+          <Tabs.Content value="coach">
+            <SavingsCoachChat userId={userId} />
+          </Tabs.Content>
+        </Tabs.Root>
       )}
     </Box>
   )

--- a/components/savings/BudgetSuggestionsList.tsx
+++ b/components/savings/BudgetSuggestionsList.tsx
@@ -1,8 +1,9 @@
 'use client'
 
-import { VStack, HStack, Box, Text, Button, useDisclosure } from '@chakra-ui/react'
-import { useState } from 'react'
+import { VStack, HStack, Box, Text, Button, Icon, useDisclosure } from '@chakra-ui/react'
+import { useMemo, useState } from 'react'
 import { useRouter } from 'next/navigation'
+import { FiCheck } from 'react-icons/fi'
 import { BudgetForm } from '@/components/budgets/BudgetForm'
 import { formatCurrency } from '@/lib/utils/currency'
 import type { Category, Currency, SavingsBudgetSuggestion } from '@/types/database.types'
@@ -29,11 +30,21 @@ export function BudgetSuggestionsList({ userId, suggestions, budgets, categories
   const { open, onOpen, onClose } = useDisclosure()
   const [editingBudget, setEditingBudget] = useState<ExistingBudget | null>(null)
   const [prefill, setPrefill] = useState<{ category_id: string; amount: number; currency: Currency } | null>(null)
+  const [pendingCategoryId, setPendingCategoryId] = useState<string | null>(null)
+  // Categories marked applied during this session (instant feedback before refresh).
+  const [sessionApplied, setSessionApplied] = useState<Set<string>>(new Set())
+
+  const categoryMap = useMemo(() => new Map(categories.map((c) => [c.id, c])), [categories])
+  // A category counts as "applied" once it has a live budget.
+  const budgetedCategoryIds = useMemo(() => new Set(budgets.map((b) => b.category_id)), [budgets])
+
+  const isApplied = (categoryId: string) =>
+    budgetedCategoryIds.has(categoryId) || sessionApplied.has(categoryId)
 
   const handleApply = (suggestion: SavingsBudgetSuggestion) => {
     const existing = budgets.find((b) => b.category_id === suggestion.category_id)
+    setPendingCategoryId(suggestion.category_id)
     if (existing) {
-      // Edit the existing budget, pre-loading the suggested amount.
       setEditingBudget({ ...existing, amount: suggestion.suggested_amount })
       setPrefill(null)
     } else {
@@ -47,6 +58,13 @@ export function BudgetSuggestionsList({ userId, suggestions, budgets, categories
     onOpen()
   }
 
+  const handleSuccess = () => {
+    if (pendingCategoryId) {
+      setSessionApplied((prev) => new Set(prev).add(pendingCategoryId))
+    }
+    router.refresh()
+  }
+
   if (suggestions.length === 0) {
     return <Text color="#B0B0B0">No hay sugerencias de presupuesto para este periodo.</Text>
   }
@@ -55,21 +73,28 @@ export function BudgetSuggestionsList({ userId, suggestions, budgets, categories
     <>
       <VStack gap={3} align="stretch">
         {suggestions.map((s, i) => {
-          const hasBudget = s.current_budget_amount != null
+          const category = categoryMap.get(s.category_id)
+          const accent = category?.color ?? '#2d2d35'
+          const applied = isApplied(s.category_id)
           return (
             <Box
               key={i}
               borderWidth="1px"
+              borderLeftWidth="4px"
               borderRadius="lg"
               borderColor="#2d2d35"
+              borderLeftColor={accent}
               bg="#1a1a23"
               p={4}
             >
               <HStack justify="space-between" align="start" gap={4} flexWrap="wrap">
                 <Box flex={1} minW="200px">
-                  <Text fontWeight="semibold" color="white">
-                    {s.category_name}
-                  </Text>
+                  <HStack gap={2}>
+                    {category?.icon && <Text fontSize="lg">{category.icon}</Text>}
+                    <Text fontWeight="semibold" color="white">
+                      {s.category_name}
+                    </Text>
+                  </HStack>
                   <Text fontSize="sm" color="#B0B0B0" mt={1}>
                     {s.rationale}
                   </Text>
@@ -77,23 +102,31 @@ export function BudgetSuggestionsList({ userId, suggestions, budgets, categories
                     <Text fontSize="sm" color="#4ade80" fontWeight="medium">
                       Sugerido: {formatCurrency(s.suggested_amount, currency)}
                     </Text>
-                    {hasBudget && (
+                    {s.current_budget_amount != null && (
                       <Text fontSize="sm" color="#B0B0B0">
-                        Actual: {formatCurrency(s.current_budget_amount as number, currency)}
+                        Actual: {formatCurrency(s.current_budget_amount, currency)}
                       </Text>
                     )}
                   </HStack>
                 </Box>
-                <Button
-                  size="sm"
-                  bg="#4F46E5"
-                  color="white"
-                  _hover={{ bg: '#4338CA' }}
-                  flexShrink={0}
-                  onClick={() => handleApply(s)}
-                >
-                  {hasBudget ? 'Ajustar y editar' : 'Aplicar y editar'}
-                </Button>
+
+                {applied ? (
+                  <Button size="sm" variant="outline" colorPalette="green" disabled flexShrink={0}>
+                    <Icon as={FiCheck} />
+                    Aplicado
+                  </Button>
+                ) : (
+                  <Button
+                    size="sm"
+                    bg="#4F46E5"
+                    color="white"
+                    _hover={{ bg: '#4338CA' }}
+                    flexShrink={0}
+                    onClick={() => handleApply(s)}
+                  >
+                    Aplicar y editar
+                  </Button>
+                )}
               </HStack>
             </Box>
           )
@@ -105,7 +138,7 @@ export function BudgetSuggestionsList({ userId, suggestions, budgets, categories
         onClose={onClose}
         userId={userId}
         categories={categories}
-        onSuccess={() => router.refresh()}
+        onSuccess={handleSuccess}
         editingBudget={editingBudget}
         prefill={prefill}
       />

--- a/components/savings/InsightsList.tsx
+++ b/components/savings/InsightsList.tsx
@@ -1,9 +1,10 @@
 'use client'
 
 import { VStack, HStack, Box, Text, Icon } from '@chakra-ui/react'
+import { useMemo } from 'react'
 import { FiInfo, FiAlertTriangle, FiAlertOctagon } from 'react-icons/fi'
 import type { IconType } from 'react-icons'
-import type { SavingsInsight, AdviceSeverity } from '@/types/database.types'
+import type { Category, SavingsInsight, AdviceSeverity } from '@/types/database.types'
 
 const SEVERITY: Record<AdviceSeverity, { color: string; icon: IconType; label: string }> = {
   info: { color: '#6366f1', icon: FiInfo, label: 'Info' },
@@ -13,9 +14,12 @@ const SEVERITY: Record<AdviceSeverity, { color: string; icon: IconType; label: s
 
 interface Props {
   insights: SavingsInsight[]
+  categories?: Category[]
 }
 
-export function InsightsList({ insights }: Props) {
+export function InsightsList({ insights, categories = [] }: Props) {
+  const categoryMap = useMemo(() => new Map(categories.map((c) => [c.id, c])), [categories])
+
   if (insights.length === 0) {
     return <Text color="#B0B0B0">No hay observaciones para este periodo.</Text>
   }
@@ -24,6 +28,7 @@ export function InsightsList({ insights }: Props) {
     <VStack gap={3} align="stretch">
       {insights.map((insight, i) => {
         const s = SEVERITY[insight.severity] ?? SEVERITY.info
+        const category = insight.category_id ? categoryMap.get(insight.category_id) : undefined
         return (
           <Box
             key={i}
@@ -38,9 +43,12 @@ export function InsightsList({ insights }: Props) {
             <HStack align="start" gap={3}>
               <Icon as={s.icon} color={s.color} boxSize={5} mt={0.5} flexShrink={0} />
               <Box>
-                <Text fontWeight="semibold" color="white">
-                  {insight.title}
-                </Text>
+                <HStack gap={2}>
+                  {category?.icon && <Text fontSize="md">{category.icon}</Text>}
+                  <Text fontWeight="semibold" color="white">
+                    {insight.title}
+                  </Text>
+                </HStack>
                 <Text fontSize="sm" color="#B0B0B0" mt={1}>
                   {insight.detail}
                 </Text>


### PR DESCRIPTION
## Resumen
Mejoras de UI al panel **Consejos de Ahorro** pedidas tras la v3.6.0.

## Cambios
- **2 tabs** en la misma página: **"Consejos de ahorro"** (diagnóstico + sugerencias) y **"Coach de ahorro"** (el chat, que antes era un tercer bloque apilado).
- **Layout 40/60** en la tab de consejos (desktop): **diagnóstico a la izquierda (40%)** y **sugerencias de presupuesto a la derecha (60%)**, cada columna con **alto fijo (600px) y scroll propio**. En móvil se apilan con altura natural.
- **Icono + color de la categoría** en las tarjetas de sugerencia (borde izquierdo con el color de la categoría + emoji) y, cuando aplica, también en las de diagnóstico.
- **Estado "Aplicado"**: cuando una categoría ya tiene presupuesto (incluyendo recién creado desde la sugerencia), la tarjeta muestra un botón **"Aplicado" deshabilitado** con check, en vez de "Aplicar y editar". Combina detección en vivo (presupuestos cargados) + feedback optimista de la sesión.

## Testing
- ✅ `pnpm type-check` · ✅ `pnpm build` · ✅ `eslint` limpio en archivos modificados.
- ⏳ Revisión visual recomendada en desktop y móvil (no pude correr la app autenticada localmente).

## Notas
- Decisión de producto confirmada en sesión: sugerencia aplicada → se **marca como 'Aplicado'** (no se elimina).