### PR TITLE
feat(consejos-ahorro): sección de metas de ahorro + cron mensual

### DIFF
--- a/app/(dashboard)/consejos-ahorro/ConsejosAhorroPageClient.tsx
+++ b/app/(dashboard)/consejos-ahorro/ConsejosAhorroPageClient.tsx
@@ -22,6 +22,7 @@ import { StatCard } from '@/components/ui/StatCard'
 import { PrimaryButton } from '@/components/ui/PrimaryButton'
 import { InsightsList } from '@/components/savings/InsightsList'
 import { BudgetSuggestionsList, type ExistingBudget } from '@/components/savings/BudgetSuggestionsList'
+import { SavingsGoalSuggestions } from '@/components/savings/SavingsGoalSuggestions'
 import { SavingsCoachChat } from '@/components/savings/SavingsCoachChat'
 import { generateSavingsAdvice } from '@/lib/actions/savingsAdvice.actions'
 import { formatCurrency } from '@/lib/utils/currency'
@@ -165,6 +166,7 @@ export function ConsejosAhorroPageClient({ userId, period, advice, summary, budg
                 </VStack>
               </Card>
             ) : (
+              <VStack gap={8} align="stretch">
               <Grid templateColumns={{ base: '1fr', lg: '2fr 3fr' }} gap={6}>
                 {/* Diagnóstico — 40% */}
                 <GridItem>
@@ -196,6 +198,25 @@ export function ConsejosAhorroPageClient({ userId, period, advice, summary, budg
                   </Flex>
                 </GridItem>
               </Grid>
+
+              {/* Metas de ahorro (sección inferior, full width) */}
+              <Box>
+                <Heading size="md" color="white" mb={4}>
+                  Metas de ahorro
+                </Heading>
+                <SavingsGoalSuggestions
+                  userId={userId}
+                  suggestions={advice.goal_suggestions ?? []}
+                  capacity={{
+                    avgMonthlyIncome: summary.avgMonthlyIncome,
+                    avgMonthlyExpense: summary.avgMonthlyExpense,
+                    monthlySavingsCapacity: summary.monthlySavingsCapacity,
+                    monthsAnalyzed: summary.monthsAnalyzed,
+                  }}
+                  currency={currency}
+                />
+              </Box>
+              </VStack>
             )}
 
             {loading && (

--- a/components/savings/SavingsGoalSuggestions.tsx
+++ b/components/savings/SavingsGoalSuggestions.tsx
@@ -1,0 +1,138 @@
+'use client'
+
+import { VStack, HStack, Box, Text, Button, Icon, useDisclosure } from '@chakra-ui/react'
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { FiTarget, FiTrendingUp, FiTrendingDown } from 'react-icons/fi'
+import { SavingsGoalForm } from '@/components/savings/SavingsGoalForm'
+import { Card } from '@/components/ui/Card'
+import { formatCurrency } from '@/lib/utils/currency'
+import type { Currency, SavingsGoal, SavingsGoalSuggestion } from '@/types/database.types'
+
+interface Capacity {
+  avgMonthlyIncome: number
+  avgMonthlyExpense: number
+  monthlySavingsCapacity: number
+  monthsAnalyzed: number
+}
+
+interface Props {
+  userId: string
+  suggestions: SavingsGoalSuggestion[]
+  capacity: Capacity
+  currency: Currency
+}
+
+export function SavingsGoalSuggestions({ userId, suggestions, capacity, currency }: Props) {
+  const router = useRouter()
+  const { open, onOpen, onClose } = useDisclosure()
+  const [prefill, setPrefill] = useState<SavingsGoal | null>(null)
+
+  const positive = capacity.monthlySavingsCapacity > 0
+
+  const handleCreate = (s: SavingsGoalSuggestion) => {
+    setPrefill({
+      id: '',
+      user_id: userId,
+      name: s.name,
+      target_amount: s.target_amount,
+      current_amount: 0,
+      currency,
+      deadline: s.deadline ?? null,
+      is_completed: false,
+      created_at: '',
+    })
+    onOpen()
+  }
+
+  return (
+    <>
+      <VStack gap={4} align="stretch">
+        {/* Capacidad de ahorro */}
+        <Card borderLeftWidth="4px" borderLeftColor={positive ? '#4ade80' : '#dc2626'}>
+          <HStack gap={3} align="start">
+            <Icon as={positive ? FiTrendingUp : FiTrendingDown} color={positive ? '#4ade80' : '#dc2626'} boxSize={6} mt={1} />
+            <Box>
+              <Text fontSize="sm" color="#B0B0B0">
+                Capacidad de ahorro mensual estimada
+              </Text>
+              <Text fontSize="2xl" fontWeight="bold" color={positive ? '#4ade80' : '#dc2626'}>
+                {formatCurrency(capacity.monthlySavingsCapacity, currency)}
+              </Text>
+              <Text fontSize="xs" color="#B0B0B0" mt={1}>
+                Ingreso prom. {formatCurrency(capacity.avgMonthlyIncome, currency)} − Gasto prom.{' '}
+                {formatCurrency(capacity.avgMonthlyExpense, currency)} · {capacity.monthsAnalyzed}{' '}
+                {capacity.monthsAnalyzed === 1 ? 'mes analizado' : 'meses analizados'}
+              </Text>
+            </Box>
+          </HStack>
+        </Card>
+
+        {/* Metas sugeridas */}
+        {suggestions.length === 0 ? (
+          <Text color="#B0B0B0" fontSize="sm">
+            No hay metas sugeridas para este periodo.
+          </Text>
+        ) : (
+          suggestions.map((s, i) => (
+            <Box
+              key={i}
+              borderWidth="1px"
+              borderRadius="lg"
+              borderColor="#2d2d35"
+              bg="#1a1a23"
+              p={4}
+            >
+              <HStack justify="space-between" align="start" gap={4} flexWrap="wrap">
+                <Box flex={1} minW="200px">
+                  <HStack gap={2}>
+                    <Icon as={FiTarget} color="#6366f1" />
+                    <Text fontWeight="semibold" color="white">
+                      {s.name}
+                    </Text>
+                  </HStack>
+                  <Text fontSize="sm" color="#B0B0B0" mt={1}>
+                    {s.rationale}
+                  </Text>
+                  <HStack gap={4} mt={2} flexWrap="wrap">
+                    <Text fontSize="sm" color="#4ade80" fontWeight="medium">
+                      Objetivo: {formatCurrency(s.target_amount, currency)}
+                    </Text>
+                    {s.monthly_contribution != null && (
+                      <Text fontSize="sm" color="#B0B0B0">
+                        Aporte: {formatCurrency(s.monthly_contribution, currency)}/mes
+                      </Text>
+                    )}
+                    {s.deadline && (
+                      <Text fontSize="sm" color="#B0B0B0">
+                        Para: {s.deadline}
+                      </Text>
+                    )}
+                  </HStack>
+                </Box>
+                <Button
+                  size="sm"
+                  bg="#4F46E5"
+                  color="white"
+                  _hover={{ bg: '#4338CA' }}
+                  flexShrink={0}
+                  onClick={() => handleCreate(s)}
+                >
+                  Crear meta
+                </Button>
+              </HStack>
+            </Box>
+          ))
+        )}
+      </VStack>
+
+      <SavingsGoalForm
+        isOpen={open}
+        onClose={onClose}
+        userId={userId}
+        onSuccess={() => router.refresh()}
+        initialData={prefill ?? undefined}
+      />
+    </>
+  )
+}

--- a/lib/actions/savingsAdvice.actions.ts
+++ b/lib/actions/savingsAdvice.actions.ts
@@ -10,6 +10,7 @@ import type {
   Currency,
   SavingsInsight,
   SavingsBudgetSuggestion,
+  SavingsGoalSuggestion,
 } from '@/types/database.types'
 
 const client = new Anthropic({
@@ -55,12 +56,21 @@ function buildConverter(rates: RateRow[]) {
 // Aggregation — compact spending summary fed to the model (no raw rows)
 // ---------------------------------------------------------------------------
 
+// Number of months (including the current one) used to compute the averages
+// that feed the savings-capacity card and goal suggestions.
+const AVG_WINDOW_MONTHS = 6
+
 export interface SpendingSummary {
   period: string
   currency: Currency
   hasData: boolean
   transactionCount: number
   totals: { income: number; expense: number; net: number }
+  // Averages over the months with activity in the last AVG_WINDOW_MONTHS.
+  avgMonthlyIncome: number
+  avgMonthlyExpense: number
+  monthlySavingsCapacity: number
+  monthsAnalyzed: number
   categories: { category_id: string; name: string; current: number; previous: number; delta_pct: number | null }[]
   budgets: { category_id: string; name: string; budget_amount: number; spent: number; utilization_pct: number }[]
   goals: { name: string; target: number; current: number; progress_pct: number; deadline: string | null }[]
@@ -71,7 +81,9 @@ export async function buildSpendingSummary(
   period: string = currentPeriod()
 ): Promise<SpendingSummary> {
   const prevPeriod = shiftPeriod(period, -1)
-  const since = `${prevPeriod}-01`
+  // Fetch a wider window so we can compute monthly averages, not just the two
+  // most recent months used for the category breakdown.
+  const since = `${shiftPeriod(period, -(AVG_WINDOW_MONTHS - 1))}-01`
 
   // Resolve preferred currency
   const { data: user } = await insforgeAdmin.database
@@ -121,9 +133,20 @@ export async function buildSpendingSummary(
   // Per-category expense, current vs previous period
   const current = new Map<string, number>()
   const previous = new Map<string, number>()
+  // Income/expense per month within the window, for the averages.
+  const monthly = new Map<string, { income: number; expense: number }>()
 
   for (const t of transactions) {
     const amount = convert(t.amount || 0, t.currency, currency)
+
+    const monthKey = typeof t.date === 'string' ? t.date.slice(0, 7) : ''
+    if (monthKey && monthKey <= period) {
+      const bucket = monthly.get(monthKey) ?? { income: 0, expense: 0 }
+      if (t.type === 'income') bucket.income += amount
+      else bucket.expense += amount
+      monthly.set(monthKey, bucket)
+    }
+
     if (inPeriod(t.date, period)) {
       transactionCount++
       if (t.type === 'income') income += amount
@@ -137,6 +160,14 @@ export async function buildSpendingSummary(
       previous.set(key, (previous.get(key) ?? 0) + amount)
     }
   }
+
+  // Averages over the months that actually have activity in the window.
+  const monthsAnalyzed = monthly.size
+  const sumIncome = [...monthly.values()].reduce((s, m) => s + m.income, 0)
+  const sumExpense = [...monthly.values()].reduce((s, m) => s + m.expense, 0)
+  const avgMonthlyIncome = monthsAnalyzed > 0 ? Math.round(sumIncome / monthsAnalyzed) : 0
+  const avgMonthlyExpense = monthsAnalyzed > 0 ? Math.round(sumExpense / monthsAnalyzed) : 0
+  const monthlySavingsCapacity = avgMonthlyIncome - avgMonthlyExpense
 
   const categoryKeys = new Set<string>([...current.keys(), ...previous.keys()])
   const categories = [...categoryKeys]
@@ -190,6 +221,10 @@ export async function buildSpendingSummary(
     hasData: transactionCount > 0,
     transactionCount,
     totals: { income: Math.round(income), expense: Math.round(expense), net: Math.round(income - expense) },
+    avgMonthlyIncome,
+    avgMonthlyExpense,
+    monthlySavingsCapacity,
+    monthsAnalyzed,
     categories,
     budgets,
     goals,
@@ -216,6 +251,13 @@ Reglas:
 - Genera entre 1 y 5 "budget_suggestions": montos recomendados de presupuesto mensual por
   categoría, basados en el gasto real. Usa SOLO category_id y category_name que aparezcan en el
   resumen. Si la categoría ya tiene presupuesto, incluye "current_budget_amount".
+- Genera entre 1 y 3 "goal_suggestions": metas de ahorro realistas basadas en la capacidad de
+  ahorro mensual (campo "monthlySavingsCapacity" = ingreso prom. − gasto prom.) y en los promedios
+  mensuales. Cada meta lleva "name" (ej. "Fondo de emergencia", "Ahorro para vacaciones"),
+  "target_amount" (monto objetivo total), "monthly_contribution" (aporte mensual sugerido, que NO
+  debe exceder la capacidad de ahorro), "deadline" (fecha YYYY-MM-DD coherente con target/aporte) y
+  "rationale". Si la capacidad de ahorro es <= 0, propón primero reducir gastos y sugiere metas
+  pequeñas o ninguna.
 - Sé breve y claro. Habla de "tú". No inventes cifras que no estén en el resumen.
 
 Responde ÚNICAMENTE con un JSON válido (sin markdown, sin explicaciones) con esta forma:
@@ -225,6 +267,9 @@ Responde ÚNICAMENTE con un JSON válido (sin markdown, sin explicaciones) con e
   ],
   "budget_suggestions": [
     { "category_id": "...", "category_name": "...", "suggested_amount": <número>, "rationale": "...", "current_budget_amount": <opcional> }
+  ],
+  "goal_suggestions": [
+    { "name": "...", "target_amount": <número>, "monthly_contribution": <número>, "deadline": "YYYY-MM-DD", "rationale": "..." }
   ]
 }`
 }
@@ -233,7 +278,11 @@ interface GenerateResult {
   success: boolean
   error?: string
   skipped?: boolean
-  data?: { insights: SavingsInsight[]; budget_suggestions: SavingsBudgetSuggestion[] }
+  data?: {
+    insights: SavingsInsight[]
+    budget_suggestions: SavingsBudgetSuggestion[]
+    goal_suggestions: SavingsGoalSuggestion[]
+  }
 }
 
 export async function generateSavingsAdvice(
@@ -280,6 +329,7 @@ export async function generateSavingsAdvice(
         currency: summary.currency,
         insights: payload.insights,
         budget_suggestions: payload.budget_suggestions,
+        goal_suggestions: payload.goal_suggestions,
       })
 
     if (insertError) throw insertError
@@ -290,6 +340,7 @@ export async function generateSavingsAdvice(
       data: {
         insights: payload.insights as SavingsInsight[],
         budget_suggestions: payload.budget_suggestions as SavingsBudgetSuggestion[],
+        goal_suggestions: payload.goal_suggestions as SavingsGoalSuggestion[],
       },
     }
   } catch (error) {

--- a/lib/validations/savingsAdvice.ts
+++ b/lib/validations/savingsAdvice.ts
@@ -17,9 +17,18 @@ export const savingsBudgetSuggestionSchema = z.object({
   current_budget_amount: z.number().nullish(),
 })
 
+export const savingsGoalSuggestionSchema = z.object({
+  name: z.string().min(1),
+  target_amount: z.number().positive(),
+  monthly_contribution: z.number().positive().nullish(),
+  deadline: z.string().nullish(),
+  rationale: z.string().min(1),
+})
+
 export const savingsAdvicePayloadSchema = z.object({
   insights: z.array(savingsInsightSchema),
   budget_suggestions: z.array(savingsBudgetSuggestionSchema),
+  goal_suggestions: z.array(savingsGoalSuggestionSchema).default([]),
 })
 
 export type SavingsAdvicePayload = z.infer<typeof savingsAdvicePayloadSchema>

--- a/supabase/seeds/savings-goal-suggestions-v3.7.0.sql
+++ b/supabase/seeds/savings-goal-suggestions-v3.7.0.sql
@@ -1,0 +1,10 @@
+-- Migration: AI savings-goal suggestions
+-- Run this against your InsForge/Supabase database
+--
+-- Adds a column to ai_savings_advice to cache the AI-proposed savings goals
+-- (based on the user's average monthly income/expense). Existing rows default
+-- to an empty array; they get populated on the next generation.
+
+ALTER TABLE ai_savings_advice
+  ADD COLUMN IF NOT EXISTS goal_suggestions jsonb NOT NULL DEFAULT '[]'::jsonb;
+-- [{ name, target_amount, monthly_contribution?, deadline?, rationale }]

--- a/types/database.types.ts
+++ b/types/database.types.ts
@@ -214,6 +214,14 @@ export interface SavingsBudgetSuggestion {
   current_budget_amount?: number | null
 }
 
+export interface SavingsGoalSuggestion {
+  name: string
+  target_amount: number
+  monthly_contribution?: number | null
+  deadline?: string | null
+  rationale: string
+}
+
 export interface AiSavingsAdvice {
   id: string
   user_id: string
@@ -221,6 +229,7 @@ export interface AiSavingsAdvice {
   currency: Currency
   insights: SavingsInsight[]
   budget_suggestions: SavingsBudgetSuggestion[]
+  goal_suggestions: SavingsGoalSuggestion[]
   generated_at: string
 }
 

--- a/vercel.json
+++ b/vercel.json
@@ -10,7 +10,7 @@
     },
     {
       "path": "/api/cron/generate-savings-advice",
-      "schedule": "0 6 * * 1"
+      "schedule": "0 6 1 * *"
     }
   ]
 }


### PR DESCRIPTION
## Resumen
Nueva **sección inferior de Metas de Ahorro** en la tab de Consejos, basada en tu ingreso/gasto promedio mensual. Además, el cron de consejos vuelve a ser **mensual (día 1)**.

## Cambios
- **Capacidad de ahorro**: `buildSpendingSummary` ahora calcula promedios de ingreso y gasto sobre los **últimos 6 meses** (solo meses con actividad) y la **capacidad de ahorro mensual** (ingreso prom. − gasto prom.).
- **Metas sugeridas por IA**: `generateSavingsAdvice` añade `goal_suggestions` (nombre, monto objetivo, aporte mensual sugerido ≤ capacidad, fecha límite y justificación). Validadas con Zod.
- **UI** `SavingsGoalSuggestions`: tarjeta superior con la **capacidad de ahorro** (verde/rojo según signo) + tarjetas de metas con botón **"Crear meta"** que abre el `SavingsGoalForm` **prellenado** (consistente con "Aplicar y editar" de presupuestos). Se muestra como sección inferior full-width del tab Consejos.
- **Cron**: `/api/cron/generate-savings-advice` vuelve a **`0 6 1 * *`** (mensual, día 1 a las 06:00), como pediste.

## ⚠️ Base de datos (aplicar manualmente en InsForge)
- Nueva migración `supabase/seeds/savings-goal-suggestions-v3.7.0.sql`: agrega la columna `ai_savings_advice.goal_suggestions jsonb DEFAULT '[]'`. **Necesaria antes de regenerar consejos** (el insert escribe esa columna).

## Testing
- ✅ `pnpm type-check` · ✅ `pnpm build` · ✅ `eslint` limpio en archivos nuevos/modificados.
- ⏳ Revisión visual recomendada: aplicar la migración → **Actualizar** en el panel → ver la sección de metas y probar **Crear meta**.

## Notas de decisión (confirmadas en sesión)
- La sección combina **capacidad de ahorro + metas concretas de IA**.
- El botón **abre el formulario prellenado** (no crea directo).