### PR TITLE
Grilla 'Mis Recordatorios' multi-columna en desktop

### DIFF
--- a/components/reminders/RemindersList.tsx
+++ b/components/reminders/RemindersList.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { VStack, HStack, Box, Text, Badge, IconButton } from '@chakra-ui/react'
+import { VStack, HStack, Box, Text, Badge, IconButton, SimpleGrid } from '@chakra-ui/react'
 import { useState } from 'react'
 import { FiEdit2, FiTrash2 } from 'react-icons/fi'
 import { deleteReminder } from '@/lib/actions/reminders.actions'
@@ -69,7 +69,7 @@ export function RemindersList({ userId, reminders, categories, accounts = [], on
       {reminders.length === 0 ? (
         <Text color="#B0B0B0" fontSize="sm">No tienes recordatorios. Crea uno para verlo en el calendario.</Text>
       ) : (
-        <VStack gap={2} align="stretch">
+        <SimpleGrid columns={{ base: 1, md: 2, xl: 3 }} gap={2}>
           {reminders.map((r) => (
             <Box
               key={r.id}
@@ -120,7 +120,7 @@ export function RemindersList({ userId, reminders, categories, accounts = [], on
               </HStack>
             </Box>
           ))}
-        </VStack>
+        </SimpleGrid>
       )}
 
       <ReminderForm


### PR DESCRIPTION
## Cambios
- `components/reminders/RemindersList.tsx`: la lista 'Mis Recordatorios' pasa de un `VStack` de una columna a un `SimpleGrid` responsivo (`base: 1`, `md: 2`, `xl: 3`), aprovechando el ancho completo en desktop.

## Testing
- ✅ `pnpm type-check` sin errores
- Probar en `/movimientos?tab=recordatorios`: varias columnas en desktop, 1 columna en móvil

Closes #474
Related to #473