### PR TITLE
Descartar sugerencias de IA de presupuestos (persistente)

### DIFF
--- a/app/(dashboard)/consejos-ahorro/ConsejosAhorroPageClient.tsx
+++ b/app/(dashboard)/consejos-ahorro/ConsejosAhorroPageClient.tsx
@@ -189,6 +189,7 @@ export function ConsejosAhorroPageClient({ userId, period, advice, summary, budg
                     <Box flex="1" minH={0} overflowY={{ base: 'visible', lg: 'auto' }} pr={{ lg: 2 }}>
                       <BudgetSuggestionsList
                         userId={userId}
+                        period={period}
                         suggestions={advice.budget_suggestions}
                         budgets={budgets}
                         categories={categories}

--- a/components/savings/BudgetSuggestionsList.tsx
+++ b/components/savings/BudgetSuggestionsList.tsx
@@ -1,10 +1,12 @@
 'use client'
 
-import { VStack, HStack, Box, Text, Button, Icon, useDisclosure } from '@chakra-ui/react'
+import { VStack, HStack, Box, Text, Button, Icon, IconButton, useDisclosure } from '@chakra-ui/react'
 import { useMemo, useState } from 'react'
 import { useRouter } from 'next/navigation'
-import { FiCheck } from 'react-icons/fi'
+import { FiCheck, FiX } from 'react-icons/fi'
 import { BudgetForm } from '@/components/budgets/BudgetForm'
+import { dismissSuggestion } from '@/lib/actions/savingsAdvice.actions'
+import { toaster } from '@/lib/toaster'
 import { formatCurrency } from '@/lib/utils/currency'
 import type { Category, Currency, SavingsBudgetSuggestion } from '@/types/database.types'
 
@@ -19,13 +21,14 @@ export interface ExistingBudget {
 
 interface Props {
   userId: string
+  period: string
   suggestions: SavingsBudgetSuggestion[]
   budgets: ExistingBudget[]
   categories: Category[]
   currency: Currency
 }
 
-export function BudgetSuggestionsList({ userId, suggestions, budgets, categories, currency }: Props) {
+export function BudgetSuggestionsList({ userId, period, suggestions, budgets, categories, currency }: Props) {
   const router = useRouter()
   const { open, onOpen, onClose } = useDisclosure()
   const [editingBudget, setEditingBudget] = useState<ExistingBudget | null>(null)
@@ -33,6 +36,8 @@ export function BudgetSuggestionsList({ userId, suggestions, budgets, categories
   const [pendingCategoryId, setPendingCategoryId] = useState<string | null>(null)
   // Categories marked applied during this session (instant feedback before refresh).
   const [sessionApplied, setSessionApplied] = useState<Set<string>>(new Set())
+  // Categories dismissed during this session (hidden instantly; persisted on the server).
+  const [dismissed, setDismissed] = useState<Set<string>>(new Set())
 
   const categoryMap = useMemo(() => new Map(categories.map((c) => [c.id, c])), [categories])
   // A category counts as "applied" once it has a live budget.
@@ -65,14 +70,32 @@ export function BudgetSuggestionsList({ userId, suggestions, budgets, categories
     router.refresh()
   }
 
-  if (suggestions.length === 0) {
+  const handleDismiss = async (categoryId: string) => {
+    // Optimistic: hide it right away, restore if the server rejects.
+    setDismissed((prev) => new Set(prev).add(categoryId))
+    const result = await dismissSuggestion(userId, period, 'budget', categoryId)
+    if (!result.success) {
+      setDismissed((prev) => {
+        const next = new Set(prev)
+        next.delete(categoryId)
+        return next
+      })
+      toaster.create({ title: result.error ?? 'Error', type: 'error', duration: 4000 })
+      return
+    }
+    router.refresh()
+  }
+
+  const visibleSuggestions = suggestions.filter((s) => !dismissed.has(s.category_id))
+
+  if (visibleSuggestions.length === 0) {
     return <Text color="#B0B0B0">No hay sugerencias de presupuesto para este periodo.</Text>
   }
 
   return (
     <>
       <VStack gap={3} align="stretch">
-        {suggestions.map((s, i) => {
+        {visibleSuggestions.map((s, i) => {
           const category = categoryMap.get(s.category_id)
           const accent = category?.color ?? '#2d2d35'
           const applied = isApplied(s.category_id)
@@ -110,23 +133,34 @@ export function BudgetSuggestionsList({ userId, suggestions, budgets, categories
                   </HStack>
                 </Box>
 
-                {applied ? (
-                  <Button size="sm" variant="outline" colorPalette="green" disabled flexShrink={0}>
-                    <Icon as={FiCheck} />
-                    Aplicado
-                  </Button>
-                ) : (
-                  <Button
+                <HStack gap={1} flexShrink={0}>
+                  {applied ? (
+                    <Button size="sm" variant="outline" colorPalette="green" disabled>
+                      <Icon as={FiCheck} />
+                      Aplicado
+                    </Button>
+                  ) : (
+                    <Button
+                      size="sm"
+                      bg="#4F46E5"
+                      color="white"
+                      _hover={{ bg: '#4338CA' }}
+                      onClick={() => handleApply(s)}
+                    >
+                      Aplicar y editar
+                    </Button>
+                  )}
+                  <IconButton
+                    aria-label="Descartar sugerencia"
                     size="sm"
-                    bg="#4F46E5"
-                    color="white"
-                    _hover={{ bg: '#4338CA' }}
-                    flexShrink={0}
-                    onClick={() => handleApply(s)}
+                    variant="ghost"
+                    color="#B0B0B0"
+                    _hover={{ color: '#ef4444', bg: '#2d2d35' }}
+                    onClick={() => handleDismiss(s.category_id)}
                   >
-                    Aplicar y editar
-                  </Button>
-                )}
+                    <FiX />
+                  </IconButton>
+                </HStack>
               </HStack>
             </Box>
           )

--- a/lib/actions/savingsAdvice.actions.ts
+++ b/lib/actions/savingsAdvice.actions.ts
@@ -401,6 +401,55 @@ ${JSON.stringify(summary)}`
   }
 }
 
+/**
+ * Removes a single suggestion from the cached advice so it stops appearing.
+ * Persists in place (update, preserving `generated_at`) instead of
+ * delete-then-insert, since this is an edit of an existing analysis — not a
+ * fresh generation. Budget suggestions are keyed by `category_id`, goal
+ * suggestions by `name`.
+ */
+export async function dismissSuggestion(
+  userId: string,
+  period: string,
+  kind: 'budget' | 'goal',
+  key: string
+): Promise<{ success: boolean; error?: string }> {
+  if (!userId) return { success: false, error: 'User ID is required' }
+  if (!key) return { success: false, error: 'Suggestion key is required' }
+
+  try {
+    const { data, error } = await insforgeAdmin.database
+      .from('ai_savings_advice')
+      .select('*')
+      .eq('user_id', userId)
+      .eq('period', period)
+      .maybeSingle()
+
+    if (error) throw error
+    if (!data) return { success: true }
+
+    const row = data as AiSavingsAdvice
+    const patch =
+      kind === 'budget'
+        ? { budget_suggestions: row.budget_suggestions.filter((s) => s.category_id !== key) }
+        : { goal_suggestions: row.goal_suggestions.filter((s) => s.name !== key) }
+
+    const { error: updateError } = await insforgeAdmin.database
+      .from('ai_savings_advice')
+      .update(patch)
+      .eq('user_id', userId)
+      .eq('period', period)
+
+    if (updateError) throw updateError
+
+    revalidatePath('/consejos-ahorro')
+    return { success: true }
+  } catch (error) {
+    console.error('dismissSuggestion error:', error)
+    return { success: false, error: 'No se pudo descartar la sugerencia' }
+  }
+}
+
 /** Reads the cached advice for a user/period (used by the panel page). */
 export async function getSavingsAdvice(
   userId: string,


### PR DESCRIPTION
## Cambios
- `lib/actions/savingsAdvice.actions.ts`: nuevo server action `dismissSuggestion(userId, period, kind, key)` que elimina una sugerencia del jsonb cacheado en `ai_savings_advice` mediante un `update` en sitio (preserva `generated_at`). Sirve para presupuestos (`category_id`) y metas (`name`, lo usará la Tarea 4).
- `components/savings/BudgetSuggestionsList.tsx`: botón 'Descartar' (icono X) por sugerencia, con ocultamiento optimista y reversión + toast ante error.
- `ConsejosAhorroPageClient.tsx`: pasa `period` al listado.

## Testing
- ✅ `pnpm type-check` sin errores
- Probar en `/consejos-ahorro`: descartar una sugerencia la oculta y, tras recargar, no reaparece.

Closes #476
Related to #473