### PR TITLE
Descartar + dedup de metas de ahorro sugeridas por IA

### DIFF
--- a/app/(dashboard)/consejos-ahorro/ConsejosAhorroPageClient.tsx
+++ b/app/(dashboard)/consejos-ahorro/ConsejosAhorroPageClient.tsx
@@ -27,7 +27,7 @@ import { SavingsCoachChat } from '@/components/savings/SavingsCoachChat'
 import { generateSavingsAdvice } from '@/lib/actions/savingsAdvice.actions'
 import { formatCurrency } from '@/lib/utils/currency'
 import { toaster } from '@/lib/toaster'
-import type { AiSavingsAdvice, Category } from '@/types/database.types'
+import type { AiSavingsAdvice, Category, SavingsGoal } from '@/types/database.types'
 import type { SpendingSummary } from '@/lib/actions/savingsAdvice.actions'
 
 interface Props {
@@ -37,6 +37,7 @@ interface Props {
   summary: SpendingSummary
   budgets: ExistingBudget[]
   categories: Category[]
+  goals: SavingsGoal[]
 }
 
 // Fixed height for each scrollable column on desktop.
@@ -49,7 +50,7 @@ function periodLabel(period: string): string {
   return label.charAt(0).toUpperCase() + label.slice(1)
 }
 
-export function ConsejosAhorroPageClient({ userId, period, advice, summary, budgets, categories }: Props) {
+export function ConsejosAhorroPageClient({ userId, period, advice, summary, budgets, categories, goals }: Props) {
   const router = useRouter()
   const [isPending, startTransition] = useTransition()
   const [generating, setGenerating] = useState(false)
@@ -207,7 +208,9 @@ export function ConsejosAhorroPageClient({ userId, period, advice, summary, budg
                 </Heading>
                 <SavingsGoalSuggestions
                   userId={userId}
+                  period={period}
                   suggestions={advice.goal_suggestions ?? []}
+                  goals={goals}
                   capacity={{
                     avgMonthlyIncome: summary.avgMonthlyIncome,
                     avgMonthlyExpense: summary.avgMonthlyExpense,

--- a/app/(dashboard)/consejos-ahorro/page.tsx
+++ b/app/(dashboard)/consejos-ahorro/page.tsx
@@ -5,9 +5,10 @@ import { insforgeAdmin } from '@/lib/insforge-admin'
 import { getSavingsAdvice, buildSpendingSummary } from '@/lib/actions/savingsAdvice.actions'
 import { getBudgets } from '@/lib/actions/budgets.actions'
 import { getCategories } from '@/lib/actions/categories.actions'
+import { getSavingsGoals } from '@/lib/actions/savings.actions'
 import { ConsejosAhorroPageClient } from './ConsejosAhorroPageClient'
 import type { ExistingBudget } from '@/components/savings/BudgetSuggestionsList'
-import type { Category } from '@/types/database.types'
+import type { Category, SavingsGoal } from '@/types/database.types'
 
 export default async function ConsejosAhorroPage() {
   const session = await getServerSession(authOptions)
@@ -27,11 +28,12 @@ export default async function ConsejosAhorroPage() {
 
   const period = new Date().toISOString().slice(0, 7)
 
-  const [adviceRes, summary, budgetsRes, categoriesRes] = await Promise.all([
+  const [adviceRes, summary, budgetsRes, categoriesRes, goalsRes] = await Promise.all([
     getSavingsAdvice(user.id, period),
     buildSpendingSummary(user.id, period),
     getBudgets(user.id),
     getCategories(user.id),
+    getSavingsGoals(user.id),
   ])
 
   const advice = adviceRes.success ? (adviceRes.data ?? null) : null
@@ -44,6 +46,7 @@ export default async function ConsejosAhorroPage() {
     start_date: b.start_date,
   }))
   const categories = (categoriesRes.success ? categoriesRes.data ?? [] : []) as Category[]
+  const goals = (goalsRes.success ? goalsRes.data ?? [] : []) as SavingsGoal[]
 
   return (
     <ConsejosAhorroPageClient
@@ -53,6 +56,7 @@ export default async function ConsejosAhorroPage() {
       summary={summary}
       budgets={budgets}
       categories={categories}
+      goals={goals}
     />
   )
 }

--- a/components/savings/SavingsGoalSuggestions.tsx
+++ b/components/savings/SavingsGoalSuggestions.tsx
@@ -1,11 +1,13 @@
 'use client'
 
-import { VStack, HStack, Box, Text, Button, Icon, useDisclosure } from '@chakra-ui/react'
-import { useState } from 'react'
+import { VStack, HStack, Box, Text, Button, Icon, IconButton, useDisclosure } from '@chakra-ui/react'
+import { useMemo, useState } from 'react'
 import { useRouter } from 'next/navigation'
-import { FiTarget, FiTrendingUp, FiTrendingDown } from 'react-icons/fi'
+import { FiTarget, FiTrendingUp, FiTrendingDown, FiX } from 'react-icons/fi'
 import { SavingsGoalForm } from '@/components/savings/SavingsGoalForm'
 import { Card } from '@/components/ui/Card'
+import { dismissSuggestion } from '@/lib/actions/savingsAdvice.actions'
+import { toaster } from '@/lib/toaster'
 import { formatCurrency } from '@/lib/utils/currency'
 import type { Currency, SavingsGoal, SavingsGoalSuggestion } from '@/types/database.types'
 
@@ -18,32 +20,87 @@ interface Capacity {
 
 interface Props {
   userId: string
+  period: string
   suggestions: SavingsGoalSuggestion[]
+  goals: SavingsGoal[]
   capacity: Capacity
   currency: Currency
 }
 
-export function SavingsGoalSuggestions({ userId, suggestions, capacity, currency }: Props) {
+// Treats amounts as equal within a small relative tolerance, so rounding in
+// the AI-suggested figure doesn't flag an otherwise-identical goal as "differs".
+function amountsEqual(a: number, b: number): boolean {
+  return Math.abs(a - b) <= Math.max(1, Math.round(Math.max(a, b) * 0.005))
+}
+
+const normalizeName = (name: string) => name.trim().toLowerCase()
+
+export function SavingsGoalSuggestions({ userId, period, suggestions, goals, capacity, currency }: Props) {
   const router = useRouter()
   const { open, onOpen, onClose } = useDisclosure()
   const [prefill, setPrefill] = useState<SavingsGoal | null>(null)
+  const [editingGoalId, setEditingGoalId] = useState<string | undefined>(undefined)
+  // Goal names dismissed during this session (hidden instantly; persisted on the server).
+  const [dismissed, setDismissed] = useState<Set<string>>(new Set())
 
   const positive = capacity.monthlySavingsCapacity > 0
 
+  // Existing goal per normalized name, used to dedup suggestions against what exists.
+  const goalByName = useMemo(
+    () => new Map(goals.map((g) => [normalizeName(g.name), g])),
+    [goals]
+  )
+
   const handleCreate = (s: SavingsGoalSuggestion) => {
-    setPrefill({
-      id: '',
-      user_id: userId,
-      name: s.name,
-      target_amount: s.target_amount,
-      current_amount: 0,
-      currency,
-      deadline: s.deadline ?? null,
-      is_completed: false,
-      created_at: '',
-    })
+    const existing = goalByName.get(normalizeName(s.name))
+    if (existing) {
+      // Edit the existing goal, pre-filled with the suggested target.
+      setEditingGoalId(existing.id)
+      setPrefill({ ...existing, target_amount: s.target_amount })
+    } else {
+      setEditingGoalId(undefined)
+      setPrefill({
+        id: '',
+        user_id: userId,
+        name: s.name,
+        target_amount: s.target_amount,
+        current_amount: 0,
+        currency,
+        deadline: s.deadline ?? null,
+        is_completed: false,
+        created_at: '',
+      })
+    }
     onOpen()
   }
+
+  const handleDismiss = async (name: string) => {
+    // Optimistic: hide it right away, restore if the server rejects.
+    setDismissed((prev) => new Set(prev).add(name))
+    const result = await dismissSuggestion(userId, period, 'goal', name)
+    if (!result.success) {
+      setDismissed((prev) => {
+        const next = new Set(prev)
+        next.delete(name)
+        return next
+      })
+      toaster.create({ title: result.error ?? 'Error', type: 'error', duration: 4000 })
+      return
+    }
+    router.refresh()
+  }
+
+  // Show a suggestion only if it adds an action: it's new, or it differs from
+  // the existing goal (so the user can edit it). A suggestion matching an
+  // existing goal with the same target is redundant and gets hidden.
+  const visibleSuggestions = suggestions.filter((s) => {
+    if (dismissed.has(s.name)) return false
+    const existing = goalByName.get(normalizeName(s.name))
+    if (!existing) return true
+    // Different currency → can't safely compare, surface it for editing.
+    if (existing.currency !== currency) return true
+    return !amountsEqual(existing.target_amount, s.target_amount)
+  })
 
   return (
     <>
@@ -69,12 +126,14 @@ export function SavingsGoalSuggestions({ userId, suggestions, capacity, currency
         </Card>
 
         {/* Metas sugeridas */}
-        {suggestions.length === 0 ? (
+        {visibleSuggestions.length === 0 ? (
           <Text color="#B0B0B0" fontSize="sm">
             No hay metas sugeridas para este periodo.
           </Text>
         ) : (
-          suggestions.map((s, i) => (
+          visibleSuggestions.map((s, i) => {
+          const exists = goalByName.has(normalizeName(s.name))
+          return (
             <Box
               key={i}
               borderWidth="1px"
@@ -110,19 +169,31 @@ export function SavingsGoalSuggestions({ userId, suggestions, capacity, currency
                     )}
                   </HStack>
                 </Box>
-                <Button
-                  size="sm"
-                  bg="#4F46E5"
-                  color="white"
-                  _hover={{ bg: '#4338CA' }}
-                  flexShrink={0}
-                  onClick={() => handleCreate(s)}
-                >
-                  Crear meta
-                </Button>
+                <HStack gap={1} flexShrink={0}>
+                  <Button
+                    size="sm"
+                    bg="#4F46E5"
+                    color="white"
+                    _hover={{ bg: '#4338CA' }}
+                    onClick={() => handleCreate(s)}
+                  >
+                    {exists ? 'Editar meta' : 'Crear meta'}
+                  </Button>
+                  <IconButton
+                    aria-label="Descartar sugerencia"
+                    size="sm"
+                    variant="ghost"
+                    color="#B0B0B0"
+                    _hover={{ color: '#ef4444', bg: '#2d2d35' }}
+                    onClick={() => handleDismiss(s.name)}
+                  >
+                    <FiX />
+                  </IconButton>
+                </HStack>
               </HStack>
             </Box>
-          ))
+          )
+          })
         )}
       </VStack>
 
@@ -132,6 +203,7 @@ export function SavingsGoalSuggestions({ userId, suggestions, capacity, currency
         userId={userId}
         onSuccess={() => router.refresh()}
         initialData={prefill ?? undefined}
+        goalId={editingGoalId}
       />
     </>
   )


### PR DESCRIPTION
## Cambios
- `app/(dashboard)/consejos-ahorro/page.tsx`: carga `getSavingsGoals` y pasa las metas existentes al cliente.
- `ConsejosAhorroPageClient.tsx`: pasa `goals` y `period` a `SavingsGoalSuggestions`.
- `components/savings/SavingsGoalSuggestions.tsx`:
  - **Dedup por nombre** (case-insensitive): meta idéntica (mismo objetivo, con tolerancia) → se **oculta**; difiere → **'Editar meta'** (abre la meta existente prellenada con `goalId`); nueva → **'Crear meta'**.
  - Botón **'Descartar'** (X) por sugerencia, reutilizando `dismissSuggestion(kind='goal', key=name)`, con ocultamiento optimista + persistencia.
  - Monedas distintas se muestran para revisión manual.

## Testing
- ✅ `pnpm type-check` sin errores
- Probar en `/consejos-ahorro` (sección Metas de ahorro): meta igual a una existente no aparece; una que difiere abre la existente para editar; descartar persiste tras recargar.

Closes #480
Related to #473