### PR TITLE
Iconos en todos los títulos de página

### DIFF
--- a/app/(dashboard)/budgets/BudgetsPageClient.tsx
+++ b/app/(dashboard)/budgets/BudgetsPageClient.tsx
@@ -1,8 +1,9 @@
 'use client'
 
-import { VStack, Heading, Button, HStack, Box } from '@chakra-ui/react'
+import { VStack, Heading, Button, HStack, Box, Icon } from '@chakra-ui/react'
 import { useState, useCallback } from 'react'
 import { useRouter } from 'next/navigation'
+import { FiPieChart } from 'react-icons/fi'
 import { BudgetForm } from '@/components/budgets/BudgetForm'
 import { BudgetList } from '@/components/budgets/BudgetList'
 import type { Category } from '@/types/database.types'
@@ -45,7 +46,10 @@ export function BudgetsPageClient({ userId, categories, initialBudgets }: Props)
   return (
     <VStack gap={6} align="stretch">
       <HStack justify="space-between">
-        <Heading size="lg">Presupuestos</Heading>
+        <HStack gap={2}>
+          <Icon as={FiPieChart} color="#6366f1" boxSize={6} />
+          <Heading size="lg">Presupuestos</Heading>
+        </HStack>
         <Button
           bg="#4F46E5"
           color="white"

--- a/app/(dashboard)/chat/page.tsx
+++ b/app/(dashboard)/chat/page.tsx
@@ -4,7 +4,8 @@ import { redirect } from 'next/navigation'
 import { insforgeAdmin } from '@/lib/insforge-admin'
 import { getCategories } from '@/lib/actions/categories.actions'
 import { ChatInterface } from '@/components/chat/ChatInterface'
-import { Box, Heading, Text, VStack } from '@chakra-ui/react'
+import { Box, Heading, Text, VStack, HStack, Icon } from '@chakra-ui/react'
+import { FiMessageCircle } from 'react-icons/fi'
 
 export default async function ChatPage() {
   const session = await getServerSession(authOptions)
@@ -29,7 +30,10 @@ export default async function ChatPage() {
   return (
     <VStack gap={0} h="full" align="stretch">
       <Box pb={4}>
-        <Heading size="lg" color="white">Chat IA</Heading>
+        <HStack gap={2}>
+          <Icon as={FiMessageCircle} color="#6366f1" boxSize={6} />
+          <Heading size="lg" color="white">Chat IA</Heading>
+        </HStack>
         <Text color="#B0B0B0" fontSize="sm" mt={1}>
           Registra gastos e ingresos escribiendo en lenguaje natural
         </Text>

--- a/app/(dashboard)/loans/LoansPageClient.tsx
+++ b/app/(dashboard)/loans/LoansPageClient.tsx
@@ -1,9 +1,9 @@
 'use client'
 
-import { Box, Heading, Button, HStack, Text, useDisclosure } from '@chakra-ui/react'
+import { Box, Heading, Button, HStack, Text, useDisclosure, Icon } from '@chakra-ui/react'
 import { useState, useCallback } from 'react'
 import { useRouter } from 'next/navigation'
-import { FiPlus } from 'react-icons/fi'
+import { FiPlus, FiCreditCard } from 'react-icons/fi'
 import { Card } from '@/components/ui/Card'
 import { LoanForm } from '@/components/loans/LoanForm'
 import { LoanPaymentForm } from '@/components/loans/LoanPaymentForm'
@@ -78,7 +78,10 @@ export function LoansPageClient({ userId, initialLoans, accounts }: Props) {
   return (
     <Box>
       <HStack justify="space-between" mb={{ base: 4, md: 6 }}>
-        <Heading size={{ base: 'md', md: 'lg' }} color="white">Deudas y Préstamos</Heading>
+        <HStack gap={2}>
+          <Icon as={FiCreditCard} color="#6366f1" boxSize={6} />
+          <Heading size={{ base: 'md', md: 'lg' }} color="white">Deudas y Préstamos</Heading>
+        </HStack>
         <Button
           bg="#4F46E5"
           color="white"

--- a/app/(dashboard)/movimientos/MovimientosPageClient.tsx
+++ b/app/(dashboard)/movimientos/MovimientosPageClient.tsx
@@ -1,9 +1,9 @@
 'use client'
 
 import { useTransition, useState, useEffect } from 'react'
-import { Box, Heading, Tabs, Spinner, Icon } from '@chakra-ui/react'
+import { Box, Heading, HStack, Tabs, Spinner, Icon } from '@chakra-ui/react'
 import { useRouter } from 'next/navigation'
-import { FiList, FiCreditCard, FiBell } from 'react-icons/fi'
+import { FiList, FiCreditCard, FiBell, FiActivity } from 'react-icons/fi'
 import { TransactionsPageClient } from '../transactions/TransactionsPageClient'
 import { LoansPageClient } from '../loans/LoansPageClient'
 import { RecordatoriosTab } from '@/components/reminders/RecordatoriosTab'
@@ -70,9 +70,12 @@ export function MovimientosPageClient({
 
   return (
     <Box>
-      <Heading size="lg" mb={6} color="white">
-        Movimientos
-      </Heading>
+      <HStack gap={2} mb={6}>
+        <Icon as={FiActivity} color="#6366f1" boxSize={6} />
+        <Heading size="lg" color="white">
+          Movimientos
+        </Heading>
+      </HStack>
 
       <Tabs.Root
         value={activeTab}

--- a/app/(dashboard)/planificacion/PlanificacionPageClient.tsx
+++ b/app/(dashboard)/planificacion/PlanificacionPageClient.tsx
@@ -1,9 +1,9 @@
 'use client'
 
 import { useTransition, useState, useEffect } from 'react'
-import { Box, Heading, Tabs, Spinner } from '@chakra-ui/react'
+import { Box, Heading, HStack, Tabs, Spinner, Icon } from '@chakra-ui/react'
 import { useRouter } from 'next/navigation'
-import { FiTarget, FiPieChart } from 'react-icons/fi'
+import { FiTarget, FiPieChart, FiClipboard } from 'react-icons/fi'
 import { SavingsGoalsPageContent } from '@/components/savings/SavingsGoalsPageContent'
 import { BudgetsPageClient } from '../budgets/BudgetsPageClient'
 import type { Account, SavingsGoal, Category } from '@/types/database.types'
@@ -47,9 +47,12 @@ export function PlanificacionPageClient({
 
   return (
     <Box>
-      <Heading size="lg" mb={6} color="white">
-        Planificación
-      </Heading>
+      <HStack gap={2} mb={6}>
+        <Icon as={FiClipboard} color="#6366f1" boxSize={6} />
+        <Heading size="lg" color="white">
+          Planificación
+        </Heading>
+      </HStack>
 
       <Tabs.Root
         value={activeTab}

--- a/app/(dashboard)/settings/SettingsPageClient.tsx
+++ b/app/(dashboard)/settings/SettingsPageClient.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useTransition, useState, useEffect } from 'react'
-import { Box, Heading, VStack, Text, Separator, Tabs, Spinner, Icon } from '@chakra-ui/react'
+import { Box, Heading, HStack, VStack, Text, Separator, Tabs, Spinner, Icon } from '@chakra-ui/react'
 import { useRouter } from 'next/navigation'
 import { FiSliders, FiBriefcase, FiTag } from 'react-icons/fi'
 import { CurrencySelector } from '@/components/settings/CurrencySelector'
@@ -64,9 +64,12 @@ export function SettingsPageClient({
 
   return (
     <Box>
-      <Heading size="lg" mb={8} color="white">
-        Configuración
-      </Heading>
+      <HStack gap={2} mb={8}>
+        <Icon as={FiSliders} color="#6366f1" boxSize={6} />
+        <Heading size="lg" color="white">
+          Configuración
+        </Heading>
+      </HStack>
 
       <Tabs.Root
         value={activeTab}

--- a/app/(dashboard)/transactions/TransactionsPageClient.tsx
+++ b/app/(dashboard)/transactions/TransactionsPageClient.tsx
@@ -7,10 +7,11 @@ import {
   HStack,
   useDisclosure,
   Text,
+  Icon,
 } from '@chakra-ui/react'
 import { useState, useEffect, useMemo, useCallback } from 'react'
 import { useRouter } from 'next/navigation'
-import { FiPlus, FiDownload, FiUpload } from 'react-icons/fi'
+import { FiPlus, FiDownload, FiUpload, FiList } from 'react-icons/fi'
 import { Card } from '@/components/ui/Card'
 import { TransactionForm } from '@/components/transactions/TransactionForm'
 import { TransactionEditForm } from '@/components/transactions/TransactionEditForm'
@@ -95,7 +96,10 @@ export function TransactionsPageClient({ userId, categories, initialTransactions
   return (
     <Box>
       <HStack justify="space-between" mb={{ base: 4, md: 6 }} gap={2} align="center" flexWrap="wrap">
-        <Heading size={{ base: 'md', md: 'lg' }} color="white">Transacciones</Heading>
+        <HStack gap={2}>
+          <Icon as={FiList} color="#6366f1" boxSize={6} />
+          <Heading size={{ base: 'md', md: 'lg' }} color="white">Transacciones</Heading>
+        </HStack>
         <HStack gap={2} justify="flex-end" flexWrap="wrap">
           <GmailSyncButton userId={userId} categories={categories} accounts={accounts} />
           <Button variant="outline" onClick={onExportOpen} size={{ base: 'sm', md: 'md' }} aria-label="Exportar">

--- a/components/ReportsContent.tsx
+++ b/components/ReportsContent.tsx
@@ -1,7 +1,8 @@
 'use client'
 
 import { useState } from 'react'
-import { Box, Heading, SimpleGrid } from '@chakra-ui/react'
+import { Box, Heading, SimpleGrid, HStack, Icon } from '@chakra-ui/react'
+import { FiBarChart2 } from 'react-icons/fi'
 import { ExpensesByCategoryChart } from '@/components/charts/ExpensesByCategoryChart'
 import { MonthlyComparisonChart } from '@/components/charts/MonthlyComparisonChart'
 import { AccumulatedBalanceChart } from '@/components/charts/AccumulatedBalanceChart'
@@ -26,9 +27,12 @@ export function ReportsContent({ userId, preferredCurrency }: Props) {
 
   return (
     <Box p={4}>
-      <Heading mb={8} size="lg">
-        Reportes
-      </Heading>
+      <HStack gap={2} mb={8}>
+        <Icon as={FiBarChart2} color="#6366f1" boxSize={6} />
+        <Heading size="lg">
+          Reportes
+        </Heading>
+      </HStack>
 
       <ReportFilters userId={userId} onFilterChange={setFilters} />
 

--- a/components/calendar/CalendarPageContent.tsx
+++ b/components/calendar/CalendarPageContent.tsx
@@ -1,8 +1,9 @@
 'use client'
 
-import { VStack, HStack, Heading, Box, Text, Button } from '@chakra-ui/react'
+import { VStack, HStack, Heading, Box, Text, Button, Icon } from '@chakra-ui/react'
 import { useState } from 'react'
 import { useRouter } from 'next/navigation'
+import { FiCalendar } from 'react-icons/fi'
 import { TransactionCalendar } from '@/components/calendar/TransactionCalendar'
 import { RemindersCalendar } from '@/components/calendar/RemindersCalendar'
 import { RemindersList } from '@/components/reminders/RemindersList'
@@ -24,7 +25,10 @@ export function CalendarPageContent({ userId, initialTransactions, categories, a
 
   return (
     <VStack alignItems="flex-start" gap={6} w="full">
-      <Heading size="lg">Calendario</Heading>
+      <HStack gap={2}>
+        <Icon as={FiCalendar} color="#6366f1" boxSize={6} />
+        <Heading size="lg">Calendario</Heading>
+      </HStack>
 
       {/* Tab bar */}
       <HStack gap={0} borderWidth="1px" borderRadius="lg" borderColor="#2d2d35" overflow="hidden" w="fit-content">

--- a/components/dashboard/DashboardContent.tsx
+++ b/components/dashboard/DashboardContent.tsx
@@ -2,7 +2,8 @@
 
 import { useState } from 'react'
 import dynamic from 'next/dynamic'
-import { Box, Heading, VStack, HStack, Spinner } from '@chakra-ui/react'
+import { Box, Heading, VStack, HStack, Spinner, Icon } from '@chakra-ui/react'
+import { FiHome } from 'react-icons/fi'
 import { FinancialCards } from './FinancialCards'
 import { RecentTransactions } from './RecentTransactions'
 import { AccountsOverview } from './AccountsOverview'
@@ -37,7 +38,10 @@ export function DashboardContent({
   return (
     <Box>
       <HStack justify="space-between" align="center" mb={{ base: 4, md: 8 }}>
-        <Heading size={{ base: 'lg', md: 'xl' }}>Dashboard</Heading>
+        <HStack gap={2}>
+          <Icon as={FiHome} color="#6366f1" boxSize={6} />
+          <Heading size={{ base: 'lg', md: 'xl' }}>Dashboard</Heading>
+        </HStack>
         <MonthSelector value={selectedMonth} onChange={setSelectedMonth} />
       </HStack>
 

--- a/components/savings/SavingsGoalsPageContent.tsx
+++ b/components/savings/SavingsGoalsPageContent.tsx
@@ -1,9 +1,9 @@
 'use client'
 
-import { VStack, Heading, Button, HStack } from '@chakra-ui/react'
+import { VStack, Heading, Button, HStack, Icon } from '@chakra-ui/react'
 import { useState } from 'react'
 import { useRouter } from 'next/navigation'
-import { FiPlus } from 'react-icons/fi'
+import { FiPlus, FiTarget } from 'react-icons/fi'
 import { SavingsGoalForm } from '@/components/savings/SavingsGoalForm'
 import { SavingsGoalsGrid } from '@/components/savings/SavingsGoalsGrid'
 import type { Account, SavingsGoal } from '@/types/database.types'
@@ -27,7 +27,10 @@ export function SavingsGoalsPageContent({ userId, initialGoals, accounts = [] }:
   return (
     <VStack alignItems="flex-start" gap={{ base: 4, md: 6 }}>
       <HStack justifyContent="space-between" width="100%">
-        <Heading size={{ base: 'md', md: 'lg' }}>Metas de Ahorro</Heading>
+        <HStack gap={2}>
+          <Icon as={FiTarget} color="#6366f1" boxSize={6} />
+          <Heading size={{ base: 'md', md: 'lg' }}>Metas de Ahorro</Heading>
+        </HStack>
         <Button bg="#4F46E5" color="white" _hover={{ bg: '#4338CA' }} onClick={() => setIsFormOpen(true)} size={{ base: 'sm', md: 'md' }}>
           <FiPlus />
           Nueva Meta

--- a/components/tags/TagsPageContent.tsx
+++ b/components/tags/TagsPageContent.tsx
@@ -1,7 +1,8 @@
 'use client'
 
-import { VStack, Heading, Box, Text } from '@chakra-ui/react'
+import { VStack, Heading, Box, Text, Icon } from '@chakra-ui/react'
 import { useState } from 'react'
+import { FiTag } from 'react-icons/fi'
 import { deleteTag } from '@/lib/actions/tags.actions'
 import { TagBadge } from '@/components/tags/TagBadge'
 import { Button, HStack } from '@chakra-ui/react'
@@ -41,7 +42,10 @@ export function TagsPageContent({ userId, initialTags }: Props) {
   return (
     <>
       <VStack alignItems="flex-start" gap={6}>
-        <Heading size="lg">Gestión de Etiquetas</Heading>
+        <HStack gap={2}>
+          <Icon as={FiTag} color="#6366f1" boxSize={6} />
+          <Heading size="lg">Gestión de Etiquetas</Heading>
+        </HStack>
 
         {initialTags.length === 0 ? (
           <Text color="fg.muted">No hay etiquetas. Créalas al editar transacciones.</Text>


### PR DESCRIPTION
## Cambios
Se añade un icono junto al título de cada página, replicando el patrón de 'Consejos de Ahorro' (`Icon color=#6366f1 boxSize=6` dentro de un `HStack`):

| Página | Icono |
|---|---|
| Dashboard | FiHome |
| Movimientos | FiActivity |
| Transacciones | FiList |
| Planificación | FiClipboard |
| Metas de Ahorro | FiTarget |
| Presupuestos | FiPieChart |
| Deudas y Préstamos | FiCreditCard |
| Calendario | FiCalendar |
| Chat IA | FiMessageCircle |
| Etiquetas | FiTag |
| Reportes | FiBarChart2 |
| Configuración | FiSliders |

## Testing
- ✅ `pnpm type-check` sin errores
- Navegar cada página y confirmar el icono junto al título, sin romper los botones de acción del header.

Closes #482
Related to #473