### PR TITLE
chore: release v3.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## [3.8.0] — 2026-06-19
+
+### Added
+
+**Descartar y deduplicar sugerencias de IA en "Consejos de Ahorro"**
+
+- Cada sugerencia de **presupuesto** y de **meta de ahorro** tiene ahora un botón **"Descartar"** que la oculta de forma **persistente** (se elimina del análisis cacheado en `ai_savings_advice`, sin reaparecer hasta la próxima generación mensual).
+- Las **metas de ahorro** sugeridas alcanzan **paridad** con los presupuestos: se deduplican contra las metas existentes por nombre y permiten editar la existente.
+
+### Changed
+
+- **Dedup de sugerencias**: una sugerencia idéntica a un presupuesto/meta ya creado (mismo monto/objetivo) deja de mostrarse; una que difiere se muestra como **"Editar"** abriendo el registro existente prellenado; las nuevas se muestran para crear. Se reemplaza el botón "Aplicado" deshabilitado.
+- **Iconos en los títulos de página**: todas las páginas (Dashboard, Movimientos, Transacciones, Planificación, Metas de Ahorro, Presupuestos, Deudas y Préstamos, Calendario, Chat IA, Etiquetas, Reportes, Configuración) muestran un icono junto al título, siguiendo el patrón de "Consejos de Ahorro".
+
+### Fixed
+
+- La lista **"Mis Recordatorios"** (`movimientos?tab=recordatorios`) se muestra en una **grilla de varias columnas** en desktop, aprovechando el ancho completo (1 columna en móvil).
+
 ## [3.7.0] — 2026-06-17
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expense-manager",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Resumen
Sube a `main` el bump de versión **3.8.0** y la entrada de CHANGELOG de la FASE Arreglos GPM (el código de las features ya está en main vía PR #484).

## Contenido
- `package.json`: 3.7.0 → 3.8.0
- `CHANGELOG.md`: entrada [3.8.0]

Tras el merge se creará el tag `v3.8.0` y el release.

Related to #473