### PR TITLE
Refactor layout: logo en sidebar, sidebar por encima del header

### DIFF
--- a/components/dashboard/DashboardShell.tsx
+++ b/components/dashboard/DashboardShell.tsx
@@ -11,10 +11,10 @@ export function DashboardShell({ children }: { children: React.ReactNode }) {
   const [isMobileNavOpen, setIsMobileNavOpen] = useState(false)
 
   return (
-    <Flex direction="column" h="100dvh" bg="#0f0f13">
-      <Header />
-      <Flex flex="1" overflow="hidden" bg="#0f0f13">
-        <Sidebar />
+    <Flex direction="row" h="100dvh" bg="#0f0f13">
+      <Sidebar />
+      <Flex direction="column" flex="1" minW={0} overflow="hidden" bg="#0f0f13">
+        <Header />
         <Box
           as="main"
           flex="1"

--- a/components/dashboard/Header.tsx
+++ b/components/dashboard/Header.tsx
@@ -36,8 +36,9 @@ export function Header() {
       flexShrink={0}
       style={{ paddingTop: 'max(12px, env(safe-area-inset-top))' }}
     >
-      <Flex justify="space-between" align="center">
-        <Flex align="center" gap={2}>
+      <Flex justify={{ base: 'space-between', md: 'flex-end' }} align="center">
+        {/* Logo only on mobile — on desktop it lives in the sidebar */}
+        <Flex align="center" gap={2} display={{ base: 'flex', md: 'none' }}>
           <Image src={logo} alt="GitPush Money" width={30} height={30} />
           <HStack gap={2} align="center" justify="center">
             <Text fontSize="18px" fontWeight="bold" color="brand.300">

--- a/components/dashboard/Sidebar.tsx
+++ b/components/dashboard/Sidebar.tsx
@@ -1,9 +1,11 @@
 'use client'
 
 import { useState, useEffect } from 'react'
-import { Box, VStack, Button, Icon, Spinner } from '@chakra-ui/react'
+import { Box, VStack, HStack, Text, Button, Icon, Spinner } from '@chakra-ui/react'
 import { usePathname } from 'next/navigation'
+import Image from 'next/image'
 import { CraftedByFooter } from './CraftedByFooter'
+import logo from '@/public/brand/gh_push_money_logo.png'
 import {
   FiHome,
   FiBarChart2,
@@ -86,6 +88,30 @@ export function Sidebar() {
         aria-label={isCollapsed ? 'Expandir sidebar' : 'Colapsar sidebar'}
       >
         <Icon as={isCollapsed ? FiChevronsRight : FiChevronsLeft} boxSize="2.5" />
+      </Box>
+
+      {/* Brand / logo */}
+      <Box
+        px={isCollapsed ? 0 : 3}
+        py={4}
+        borderBottomWidth="1px"
+        borderColor="#2d2d35"
+        flexShrink={0}
+        style={{ paddingTop: 'max(16px, env(safe-area-inset-top))' }}
+      >
+        <HStack gap={2} justify={isCollapsed ? 'center' : 'flex-start'} align="center">
+          <Image src={logo} alt="GitPush Money" width={30} height={30} style={{ flexShrink: 0 }} />
+          {!isCollapsed && (
+            <HStack gap={1} align="center">
+              <Text fontSize="18px" fontWeight="bold" color="brand.300">
+                GitPush
+              </Text>
+              <Text fontSize="18px" fontWeight="bold" color="brand.200">
+                Money
+              </Text>
+            </HStack>
+          )}
+        </HStack>
       </Box>
 
       {/* Scrollable nav content */}


### PR DESCRIPTION
## Cambios
- `DashboardShell` reestructurado de `column[Header, row[Sidebar, Main]]` a `row[Sidebar, column[Header, Main]]`: el sidebar ahora ocupa toda la altura a la izquierda y el header solo cubre el área de contenido.
- El logo + texto "GitPush Money" se movió al tope del sidebar.
  - **Expandido:** logo + texto.
  - **Contraído:** solo el logo, centrado.
- El `Header` ya no muestra el logo en desktop; se mantiene **solo en mobile** (donde el sidebar está oculto).

## Testing
- ✅ `pnpm type-check` sin errores
- 🔍 Revisar visualmente: desktop expandido/contraído y mobile

Closes #489