### PR TITLE
Recordatorios de ingreso + diferenciación por tipo + frecuencia en selector

### DIFF
--- a/components/calendar/RemindersCalendar.tsx
+++ b/components/calendar/RemindersCalendar.tsx
@@ -23,7 +23,7 @@ import {
 } from '@chakra-ui/react'
 import { useState } from 'react'
 import { FiPlus, FiX } from 'react-icons/fi'
-import type { ReminderWithCategory, Account, Category } from '@/types/database.types'
+import type { ReminderWithCategory, Account, Category, ReminderType } from '@/types/database.types'
 import { getLocalDateString } from '@/lib/utils/dates'
 import { reminderMatchesDate } from '@/lib/reminders/matches-date'
 import { TransactionForm } from '@/components/transactions/TransactionForm'
@@ -32,12 +32,16 @@ import { ReminderForm } from '@/components/reminders/ReminderForm'
 const WEEKDAYS = ['Dom', 'Lun', 'Mar', 'Mié', 'Jue', 'Vie', 'Sáb']
 const MONTHS = ['Enero', 'Febrero', 'Marzo', 'Abril', 'Mayo', 'Junio', 'Julio', 'Agosto', 'Septiembre', 'Octubre', 'Noviembre', 'Diciembre']
 
-const REMINDER_COLOR = '#6366f1'
+const INCOME_COLOR = '#10b981'
+const EXPENSE_COLOR = '#6366f1'
+
+const reminderColor = (type: ReminderType) => (type === 'income' ? INCOME_COLOR : EXPENSE_COLOR)
 
 interface DayItem {
   label: string
   icon: string
   color: string
+  type: ReminderType
   reminder: ReminderWithCategory
 }
 
@@ -55,7 +59,8 @@ function getItemsForDay(
       items.push({
         label: r.description,
         icon: r.category?.icon ?? '🔔',
-        color: REMINDER_COLOR,
+        color: reminderColor(r.type),
+        type: r.type,
         reminder: r,
       })
     }
@@ -229,8 +234,8 @@ export function RemindersCalendar({ userId, reminders, categories, accounts, onR
                     <Text fontSize="sm" color="white" lineClamp={1} flex={1}>
                       {item.icon} {item.label}
                     </Text>
-                    <Badge size="xs" variant="outline" colorPalette="purple">
-                      Recordatorio
+                    <Badge size="xs" variant="subtle" colorPalette={item.type === 'income' ? 'green' : 'red'}>
+                      {item.type === 'income' ? 'Ingreso' : 'Gasto'}
                     </Badge>
                   </HStack>
                 ))}
@@ -257,8 +262,12 @@ export function RemindersCalendar({ userId, reminders, categories, accounts, onR
           {/* Legend */}
           <HStack gap={4} flexWrap="wrap">
             <HStack gap={1}>
-              <Box w={2} h={2} borderRadius="full" bg={REMINDER_COLOR} />
-              <Text fontSize="xs" color="#B0B0B0">Recordatorio</Text>
+              <Box w={2} h={2} borderRadius="full" bg={EXPENSE_COLOR} />
+              <Text fontSize="xs" color="#B0B0B0">Gasto</Text>
+            </HStack>
+            <HStack gap={1}>
+              <Box w={2} h={2} borderRadius="full" bg={INCOME_COLOR} />
+              <Text fontSize="xs" color="#B0B0B0">Ingreso</Text>
             </HStack>
             <Text fontSize="xs" color="#B0B0B0">· Haz clic en un día para ver detalles o crear un recordatorio</Text>
           </HStack>
@@ -320,8 +329,8 @@ export function RemindersCalendar({ userId, reminders, categories, accounts, onR
                           <Box w={2} h={2} borderRadius="full" bg={item.color} flexShrink={0} mt="6px" />
                           <VStack align="flex-start" gap={0} flex={1}>
                             <Text fontWeight="bold" color="white">{item.icon} {item.label}</Text>
-                            <Badge size="xs" variant="outline" colorPalette="purple">
-                              Recordatorio
+                            <Badge size="xs" variant="subtle" colorPalette={item.type === 'income' ? 'green' : 'red'}>
+                              {item.type === 'income' ? 'Ingreso' : 'Gasto'}
                             </Badge>
                           </VStack>
                         </HStack>
@@ -339,7 +348,7 @@ export function RemindersCalendar({ userId, reminders, categories, accounts, onR
                           }}
                         >
                           <FiPlus />
-                          Registrar pago
+                          {item.type === 'income' ? 'Registrar ingreso' : 'Registrar pago'}
                         </Button>
                       )}
                     </Box>
@@ -384,6 +393,7 @@ export function RemindersCalendar({ userId, reminders, categories, accounts, onR
           }}
           prefillDescription={registerFor.reminder.description}
           prefillCategoryId={registerFor.reminder.category_id ?? undefined}
+          initialType={registerFor.reminder.type}
         />
       )}
 

--- a/components/reminders/PayReminderDialog.tsx
+++ b/components/reminders/PayReminderDialog.tsx
@@ -38,6 +38,7 @@ export function PayReminderDialog({ isOpen, onClose, userId, accounts, reminder,
 
   const selectedAccount = accounts.find((a) => a.id === accountId) ?? null
   const currency = selectedAccount?.currency ?? 'COP'
+  const isIncome = reminder.type === 'income'
   const today = getLocalDateString()
   const todayLabel = new Date(today + 'T12:00:00').toLocaleDateString('es-CO', {
     day: 'numeric', month: 'long', year: 'numeric',
@@ -57,7 +58,7 @@ export function PayReminderDialog({ isOpen, onClose, userId, accounts, reminder,
     const result = await createTransaction(userId, {
       amount,
       currency,
-      type: 'expense',
+      type: reminder.type,
       category_id: reminder.category_id,
       account_id: accountId || null,
       description: reminder.description,
@@ -65,7 +66,7 @@ export function PayReminderDialog({ isOpen, onClose, userId, accounts, reminder,
     })
     setLoading(false)
     if (result.success) {
-      toaster.create({ title: 'Pago registrado', type: 'success', duration: 3000 })
+      toaster.create({ title: isIncome ? 'Ingreso registrado' : 'Pago registrado', type: 'success', duration: 3000 })
       onSuccess()
       onClose()
     } else {
@@ -74,7 +75,7 @@ export function PayReminderDialog({ isOpen, onClose, userId, accounts, reminder,
   }
 
   return (
-    <FormDialog isOpen={isOpen} onClose={onClose} title="Pagar recordatorio">
+    <FormDialog isOpen={isOpen} onClose={onClose} title={isIncome ? 'Registrar ingreso' : 'Pagar recordatorio'}>
       <form onSubmit={handleSubmit}>
         <VStack gap={4} align="stretch">
           <Box borderWidth="1px" borderColor="#2d2d35" borderRadius="md" px={3} py={2} bg="#18181d">
@@ -113,7 +114,7 @@ export function PayReminderDialog({ isOpen, onClose, userId, accounts, reminder,
           />
 
           <PrimaryButton type="submit" width="full" loading={loading} disabled={!accountId}>
-            Registrar pago
+            {isIncome ? 'Registrar ingreso' : 'Registrar pago'}
           </PrimaryButton>
         </VStack>
       </form>

--- a/components/reminders/ReminderForm.tsx
+++ b/components/reminders/ReminderForm.tsx
@@ -7,12 +7,17 @@ import { toaster } from '@/lib/toaster'
 import { FormDialog } from '@/components/ui/FormDialog'
 import { FormInput } from '@/components/ui/FormInput'
 import { DateInput } from '@/components/ui/DateInput'
-import { RadioSelect } from '@/components/ui/RadioSelect'
+import { SelectField } from '@/components/ui/SelectField'
 import { PrimaryButton } from '@/components/ui/PrimaryButton'
 import { CategorySelect } from '@/components/ui/CategorySelect'
 import { AccountSelect } from '@/components/ui/AccountSelect'
-import type { Account, Category, Reminder } from '@/types/database.types'
+import type { Account, Category, Reminder, ReminderType } from '@/types/database.types'
 import { getLocalDateString } from '@/lib/utils/dates'
+
+const TYPE_OPTIONS = [
+  { value: 'expense', label: 'Gasto' },
+  { value: 'income', label: 'Ingreso' },
+]
 
 const FREQUENCY_OPTIONS = [
   { value: 'once', label: 'Una vez' },
@@ -55,6 +60,7 @@ interface Props {
 
 const defaultForm = {
   description: '',
+  type: 'expense' as ReminderType,
   category_id: '',
   account_id: '',
   frequency: 'monthly' as 'once' | 'weekly' | 'monthly' | 'yearly',
@@ -72,6 +78,7 @@ export function ReminderForm({ isOpen, onClose, userId, categories, accounts = [
     if (editingReminder) {
       setFormData({
         description: editingReminder.description,
+        type: editingReminder.type ?? 'expense',
         category_id: editingReminder.category_id ?? '',
         account_id: editingReminder.account_id ?? '',
         frequency: editingReminder.frequency,
@@ -101,6 +108,7 @@ export function ReminderForm({ isOpen, onClose, userId, categories, accounts = [
 
     const payload = {
       description: formData.description,
+      type: formData.type,
       category_id: formData.category_id || null,
       account_id: formData.account_id || null,
       frequency: formData.frequency,
@@ -141,6 +149,14 @@ export function ReminderForm({ isOpen, onClose, userId, categories, accounts = [
             required
           />
 
+          <SelectField
+            label="Tipo"
+            value={formData.type}
+            onChange={(v) => setFormData({ ...formData, type: v as ReminderType })}
+            options={TYPE_OPTIONS}
+            required
+          />
+
           <Box w="full">
             <CategorySelect
               value={formData.category_id}
@@ -160,7 +176,7 @@ export function ReminderForm({ isOpen, onClose, userId, categories, accounts = [
             />
           )}
 
-          <RadioSelect
+          <SelectField
             label="Frecuencia"
             value={formData.frequency}
             onChange={(v) => setFormData({ ...formData, frequency: v as typeof formData.frequency })}

--- a/components/reminders/RemindersList.tsx
+++ b/components/reminders/RemindersList.tsx
@@ -1,8 +1,8 @@
 'use client'
 
-import { VStack, HStack, Box, Text, Badge, IconButton, SimpleGrid } from '@chakra-ui/react'
+import { VStack, HStack, Box, Text, Badge, IconButton, SimpleGrid, Icon } from '@chakra-ui/react'
 import { useState } from 'react'
-import { FiEdit2, FiTrash2 } from 'react-icons/fi'
+import { FiEdit2, FiTrash2, FiArrowUpRight, FiArrowDownLeft } from 'react-icons/fi'
 import { deleteReminder } from '@/lib/actions/reminders.actions'
 import { toaster } from '@/lib/toaster'
 import { ConfirmDialog } from '@/components/ui/ConfirmDialog'
@@ -88,6 +88,14 @@ export function RemindersList({ userId, reminders, categories, accounts = [], on
                     {r.category?.icon ?? '🔔'} {r.description}
                   </Text>
                   <HStack gap={2} flexWrap="wrap">
+                    <Badge
+                      size="sm"
+                      variant="subtle"
+                      colorPalette={r.type === 'income' ? 'green' : 'red'}
+                    >
+                      <Icon as={r.type === 'income' ? FiArrowDownLeft : FiArrowUpRight} mr={1} />
+                      {r.type === 'income' ? 'Ingreso' : 'Gasto'}
+                    </Badge>
                     <Badge size="sm" variant="outline" colorPalette="purple">
                       {FREQUENCY_LABELS[r.frequency]}
                     </Badge>

--- a/components/transactions/TransactionForm.tsx
+++ b/components/transactions/TransactionForm.tsx
@@ -37,6 +37,7 @@ interface Props {
   lockedDate?: boolean
   prefillDescription?: string
   prefillCategoryId?: string
+  initialType?: 'income' | 'expense'
 }
 
 const defaultForm = {
@@ -50,9 +51,9 @@ const defaultForm = {
   notes: '',
 }
 
-export function TransactionForm({ isOpen, onClose, userId, categories, accounts = [], onSuccess, initialDate, lockedDate, prefillDescription, prefillCategoryId }: Props) {
+export function TransactionForm({ isOpen, onClose, userId, categories, accounts = [], onSuccess, initialDate, lockedDate, prefillDescription, prefillCategoryId, initialType }: Props) {
   const [loading, setLoading] = useState(false)
-  const [formData, setFormData] = useState({ ...defaultForm, date: initialDate ?? getLocalDateString() })
+  const [formData, setFormData] = useState({ ...defaultForm, type: initialType ?? defaultForm.type, date: initialDate ?? getLocalDateString() })
   const [localCategories, setLocalCategories] = useState<Category[]>(categories)
   const [quickCategoryOpen, setQuickCategoryOpen] = useState(false)
 
@@ -60,13 +61,14 @@ export function TransactionForm({ isOpen, onClose, userId, categories, accounts 
     if (isOpen) {
       setFormData({
         ...defaultForm,
+        type: initialType ?? defaultForm.type,
         date: initialDate ?? getLocalDateString(),
         description: prefillDescription ?? '',
         category_id: prefillCategoryId ?? '',
       })
       setLocalCategories(categories)
     }
-  }, [isOpen, initialDate, categories, prefillDescription, prefillCategoryId])
+  }, [isOpen, initialDate, categories, prefillDescription, prefillCategoryId, initialType])
 
   const handleAccountChange = (accountId: string) => {
     const account = accounts.find((a) => a.id === accountId)

--- a/components/ui/SelectField.tsx
+++ b/components/ui/SelectField.tsx
@@ -1,0 +1,37 @@
+'use client'
+
+import { FieldRoot, FieldLabel, NativeSelectRoot, NativeSelectField } from '@chakra-ui/react'
+
+interface Option {
+  value: string
+  label: string
+}
+
+interface Props {
+  label: string
+  value: string
+  onChange: (value: string) => void
+  options: Option[]
+  required?: boolean
+}
+
+/**
+ * Labeled dropdown built on Chakra's NativeSelect. Reusable across forms
+ * (reminder type/frequency, account type, …).
+ */
+export function SelectField({ label, value, onChange, options, required }: Props) {
+  return (
+    <FieldRoot required={required} w="full">
+      <FieldLabel>{label}</FieldLabel>
+      <NativeSelectRoot>
+        <NativeSelectField value={value} onChange={(e) => onChange(e.target.value)}>
+          {options.map((opt) => (
+            <option key={opt.value} value={opt.value}>
+              {opt.label}
+            </option>
+          ))}
+        </NativeSelectField>
+      </NativeSelectRoot>
+    </FieldRoot>
+  )
+}

--- a/lib/validations/reminder.ts
+++ b/lib/validations/reminder.ts
@@ -2,6 +2,7 @@ import { z } from 'zod'
 
 export const reminderSchema = z.object({
   description: z.string().min(1, 'La descripción es requerida'),
+  type: z.enum(['income', 'expense']).default('expense'),
   category_id: z.string().uuid().nullable().optional(),
   account_id: z.string().uuid().nullable().optional(),
   frequency: z.enum(['once', 'weekly', 'monthly', 'yearly']),

--- a/types/database.types.ts
+++ b/types/database.types.ts
@@ -178,10 +178,13 @@ export interface LoanPayment {
 
 export type ReminderFrequency = 'once' | 'weekly' | 'monthly' | 'yearly'
 
+export type ReminderType = 'income' | 'expense'
+
 export interface Reminder {
   id: string
   user_id: string
   description: string
+  type: ReminderType
   category_id: string | null
   account_id: string | null
   frequency: ReminderFrequency


### PR DESCRIPTION
## Cambios
- **Recordatorios de ingreso**: nueva columna/campo `type` (`income` | `expense`) en tipos y validación (default `expense`).
- **Nuevo `SelectField`** (dropdown reutilizable). El **tipo** y la **frecuencia** del recordatorio ahora son dropdowns.
- **Diferenciación visual** por tipo:
  - Listado: badge "Ingreso" (verde) / "Gasto" (rojo) con icono.
  - Calendario: color del punto por tipo, leyenda con ambos, badges y textos de registro ("Registrar ingreso"/"Registrar pago").
- `PayReminderDialog` y el registro desde el calendario crean la transacción con el tipo correcto (`TransactionForm` recibe `initialType`).

## Testing
- ✅ `pnpm type-check` sin errores
- 🔍 Tras aplicar la migración: crear recordatorio de ingreso y de gasto, verificar listado y calendario

Closes #491