### PR TITLE
Mostrar "Crafted with… by Sanghel González" en el header cuando el sidebar está contraído

### DIFF
--- a/components/dashboard/DashboardShell.tsx
+++ b/components/dashboard/DashboardShell.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { Flex, Box } from '@chakra-ui/react'
 import { Header } from './Header'
 import { Sidebar } from './Sidebar'
@@ -9,12 +9,26 @@ import { MobileNav } from './MobileNav'
 
 export function DashboardShell({ children }: { children: React.ReactNode }) {
   const [isMobileNavOpen, setIsMobileNavOpen] = useState(false)
+  const [isCollapsed, setIsCollapsed] = useState(false)
+
+  useEffect(() => {
+    const saved = localStorage.getItem('sidebar-collapsed')
+    if (saved === 'true') setIsCollapsed(true)
+  }, [])
+
+  const toggleSidebar = () => {
+    setIsCollapsed((prev) => {
+      const next = !prev
+      localStorage.setItem('sidebar-collapsed', String(next))
+      return next
+    })
+  }
 
   return (
     <Flex direction="row" h="100dvh" bg="#0f0f13">
-      <Sidebar />
+      <Sidebar isCollapsed={isCollapsed} toggle={toggleSidebar} />
       <Flex direction="column" flex="1" minW={0} overflow="hidden" bg="#0f0f13">
-        <Header />
+        <Header isCollapsed={isCollapsed} />
         <Box
           as="main"
           flex="1"

--- a/components/dashboard/Header.tsx
+++ b/components/dashboard/Header.tsx
@@ -20,8 +20,13 @@ import Image from 'next/image'
 import { useRouter } from 'next/navigation'
 import { FiLogOut, FiSettings } from 'react-icons/fi'
 import logo from '@/public/brand/gh_push_money_logo.png'
+import { CraftedByFooter } from './CraftedByFooter'
 
-export function Header() {
+interface Props {
+  isCollapsed: boolean
+}
+
+export function Header({ isCollapsed }: Props) {
   const { data: session } = useSession()
   const router = useRouter()
 
@@ -36,19 +41,29 @@ export function Header() {
       flexShrink={0}
       style={{ paddingTop: 'max(12px, env(safe-area-inset-top))' }}
     >
-      <Flex justify={{ base: 'space-between', md: 'flex-end' }} align="center">
-        {/* Logo only on mobile — on desktop it lives in the sidebar */}
-        <Flex align="center" gap={2} display={{ base: 'flex', md: 'none' }}>
-          <Image src={logo} alt="GitPush Money" width={30} height={30} />
-          <HStack gap={2} align="center" justify="center">
-            <Text fontSize="18px" fontWeight="bold" color="brand.300">
-              GitPush
-            </Text>
-            <Text fontSize="18px" fontWeight="bold" color="brand.200">
-              Money
-            </Text>
-          </HStack>
-        </Flex>
+      <Flex justify="space-between" align="center" gap={3}>
+        {/* Left slot */}
+        <Box minW={0}>
+          {/* Logo only on mobile — on desktop it lives in the sidebar */}
+          <Flex align="center" gap={2} display={{ base: 'flex', md: 'none' }}>
+            <Image src={logo} alt="GitPush Money" width={30} height={30} />
+            <HStack gap={2} align="center" justify="center">
+              <Text fontSize="18px" fontWeight="bold" color="brand.300">
+                GitPush
+              </Text>
+              <Text fontSize="18px" fontWeight="bold" color="brand.200">
+                Money
+              </Text>
+            </HStack>
+          </Flex>
+
+          {/* When the sidebar is collapsed, the crafted-by footer moves here (desktop only) */}
+          {isCollapsed && (
+            <Box display={{ base: 'none', md: 'block' }}>
+              <CraftedByFooter />
+            </Box>
+          )}
+        </Box>
 
         {session?.user && (
           <MenuRoot>

--- a/components/dashboard/Sidebar.tsx
+++ b/components/dashboard/Sidebar.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import { useState, useEffect } from 'react'
 import { Box, VStack, HStack, Text, Button, Icon, Spinner } from '@chakra-ui/react'
 import { usePathname } from 'next/navigation'
 import Image from 'next/image'
@@ -30,23 +29,14 @@ const navItems: { href: string; label: string; icon: IconType }[] = [
   { href: '/settings', label: 'Configuración', icon: FiSettings },
 ]
 
-export function Sidebar() {
+interface Props {
+  isCollapsed: boolean
+  toggle: () => void
+}
+
+export function Sidebar({ isCollapsed, toggle }: Props) {
   const pathname = usePathname()
   const { navigate, loadingPath } = useNavigation()
-  const [isCollapsed, setIsCollapsed] = useState(false)
-
-  useEffect(() => {
-    const saved = localStorage.getItem('sidebar-collapsed')
-    if (saved === 'true') setIsCollapsed(true)
-  }, [])
-
-  const toggle = () => {
-    setIsCollapsed((prev) => {
-      const next = !prev
-      localStorage.setItem('sidebar-collapsed', String(next))
-      return next
-    })
-  }
 
   return (
     <Box


### PR DESCRIPTION
## Cambios
- El estado de colapso del sidebar (`isCollapsed` + `toggle`) se subió a `DashboardShell` y se comparte con `Sidebar` y `Header` (init desde `localStorage`).
- Cuando el sidebar está **contraído** (desktop), el footer "Crafted with ❤ and Next.js by Sanghel González" se muestra en el **header**.
- En mobile el footer no aparece en el header.

## Testing
- ✅ `pnpm type-check` sin errores
- 🔍 Revisar: contraer/expandir el sidebar mueve el footer entre sidebar y header

Closes #495